### PR TITLE
fix(auth): bump aiohttp dependency to latest major

### DIFF
--- a/auth/requirements.txt
+++ b/auth/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp >= 1.0.0, < 2.0.0
+aiohttp >= 2.0.0, < 3.0.0
 cryptography >= 2.0.0, < 3.0.0
 gcloud-aio-core >= 0.7.0, < 1.0.0
 pyjwt >= 1.5.3, < 2.0.0

--- a/auth/setup.py
+++ b/auth/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as f:
 
 setuptools.setup(
     name='gcloud-aio-auth',
-    version='0.6.0',
+    version='0.6.1',
     description='Auth Helpers for Asyncio Google Cloud Library',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Extracted from #13 -- we will need aiohttp v2 for cloudtasks v2beta2, and anyway v1 has been long-deprecated.