### PR TITLE
enforce single session per every poll() and process()

### DIFF
--- a/taskqueue/gcloud/aio/taskqueue/taskmanager.py
+++ b/taskqueue/gcloud/aio/taskqueue/taskmanager.py
@@ -1,7 +1,6 @@
 """
 An asynchronous task manager for Google Appengine Task Queues
 """
-import aiohttp
 import asyncio
 import concurrent.futures
 import datetime
@@ -9,6 +8,7 @@ import logging
 import multiprocessing
 import time
 import traceback
+import aiohttp
 
 import requests
 from gcloud.aio.taskqueue.error import FailFastError
@@ -116,6 +116,7 @@ class TaskManager:
 
         self.running = False
 
+    @classmethod
     def get_session(self):
         connector = aiohttp.TCPConnector(
             enable_cleanup_closed=True,

--- a/taskqueue/gcloud/aio/taskqueue/taskmanager.py
+++ b/taskqueue/gcloud/aio/taskqueue/taskmanager.py
@@ -8,8 +8,8 @@ import logging
 import multiprocessing
 import time
 import traceback
-import aiohttp
 
+import aiohttp
 import requests
 from gcloud.aio.taskqueue.error import FailFastError
 from gcloud.aio.taskqueue.taskqueue import API_ROOT
@@ -116,16 +116,12 @@ class TaskManager:
 
         self.running = False
 
-    @classmethod
-    def get_session(self):
-        connector = aiohttp.TCPConnector(
-            enable_cleanup_closed=True,
-            force_close=True,
-            limit_per_host=1)
-        return aiohttp.ClientSession(
-            connector=connector,
-            conn_timeout=10,
-            read_timeout=10)
+    @staticmethod
+    def get_session():
+        connector = aiohttp.TCPConnector(enable_cleanup_closed=True,
+                                         force_close=True, limit_per_host=1)
+        return aiohttp.ClientSession(connector=connector, conn_timeout=10,
+                                     read_timeout=10)
 
     async def fail(self, task, payload, exception):
         if not self.deadletter_insert_function:
@@ -152,8 +148,7 @@ class TaskManager:
                     async with self.get_session() as session:
                         task_lease = await self.tq.lease(
                             lease_seconds=self.lease_seconds,
-                            num_tasks=self.batch_size,
-                            session=session)
+                            num_tasks=self.batch_size, session=session)
                 except concurrent.futures.CancelledError:
                     return
                 except concurrent.futures.TimeoutError:


### PR DESCRIPTION
this helps mitigate 'Broken Pipe' errors with long-running sessions against GCloud services which are less prone to supporting long-lived connects