### PR TITLE
fix(taskqueue): fix retry handler for taskqueue requests

### DIFF
--- a/pubsub/tests/integration/smoke_test.py
+++ b/pubsub/tests/integration/smoke_test.py
@@ -12,7 +12,7 @@ async def test_pubsub_lifecycle():
     project = os.environ['GCLOUD_PROJECT']
 
     topic_name = 'test-topic-{}'.format(uuid.uuid4().hex)
-    subscription_name = 'test-subscription-'.format(uuid.uuid4().hex)
+    subscription_name = 'test-subscription-{}'.format(uuid.uuid4().hex)
 
     subscriber = pubsub.Client(project)
 

--- a/taskqueue/gcloud/aio/taskqueue/taskqueue.py
+++ b/taskqueue/gcloud/aio/taskqueue/taskqueue.py
@@ -38,6 +38,7 @@ class TaskQueue:
 
     @backoff.on_exception(backoff.expo, Exception, max_tries=3)
     async def _request(self, meth, url, json=None, params=None, session=None):
+        # pylint: disable=too-many-arguments
         if not self.session:
             self.session = aiohttp.ClientSession(conn_timeout=10,
                                                  read_timeout=10)
@@ -92,7 +93,7 @@ class TaskQueue:
             'responseView': 'FULL' if full else 'BASIC',
         }
 
-        return await self._request('GET', params=params, session=session)
+        return await self._request('GET', url, params=params, session=session)
 
     # https://cloud.google.com/cloud-tasks/docs/reference/rest/v2beta2/projects.locations.queues.tasks/create
     async def insert(self, payload, tag=None, session=None):

--- a/taskqueue/gcloud/aio/taskqueue/taskqueue.py
+++ b/taskqueue/gcloud/aio/taskqueue/taskqueue.py
@@ -5,8 +5,8 @@ import asyncio
 import logging
 
 import aiohttp
+import backoff
 from gcloud.aio.auth import Token
-from gcloud.aio.taskqueue.utils import retry
 
 
 API_ROOT = 'https://cloudtasks.googleapis.com/v2beta2'
@@ -36,6 +36,24 @@ class TaskQueue:
             'Content-Type': 'application/json',
         }
 
+    @backoff.on_exception(backoff.expo, Exception, max_tries=3)
+    async def _request(self, meth, url, json=None, params=None, session=None):
+        if not self.session:
+            self.session = aiohttp.ClientSession(conn_timeout=10,
+                                                 read_timeout=10)
+        s = session or self.session
+        headers = await self.headers()
+
+        if json:
+            resp = await s.request(meth, url, headers=headers, json=json)
+        elif params:
+            resp = await s.request(meth, url, headers=headers, params=params)
+        else:
+            resp = await s.request(meth, url, headers=headers)
+
+        resp.raise_for_status()
+        return await resp.json()
+
     # https://cloud.google.com/cloud-tasks/docs/reference/rest/v2beta2/projects.locations.queues.tasks/acknowledge
     async def ack(self, task, session=None):
         url = f'{API_ROOT}/{task["name"]}:acknowledge'
@@ -43,14 +61,7 @@ class TaskQueue:
             'scheduleTime': task['scheduleTime'],
         }
 
-        if not self.session:
-            self.session = aiohttp.ClientSession(conn_timeout=10,
-                                                 read_timeout=10)
-        s = session or self.session
-        resp = await retry(s.post(url, headers=await self.headers(),
-                                  json=body))
-        resp.raise_for_status()
-        return await resp.json()
+        return await self._request('POST', url, json=body, session=session)
 
     # https://cloud.google.com/cloud-tasks/docs/reference/rest/v2beta2/projects.locations.queues.tasks/cancelLease
     async def cancel(self, task, session=None):
@@ -60,26 +71,13 @@ class TaskQueue:
             'responseView': 'BASIC',
         }
 
-        if not self.session:
-            self.session = aiohttp.ClientSession(conn_timeout=10,
-                                                 read_timeout=10)
-        s = session or self.session
-        resp = await retry(s.post(url, headers=await self.headers(),
-                                  json=body))
-        resp.raise_for_status()
-        return await resp.json()
+        return await self._request('POST', url, json=body, session=session)
 
     # https://cloud.google.com/cloud-tasks/docs/reference/rest/v2beta2/projects.locations.queues.tasks/delete
     async def delete(self, tname, session=None):
         url = f'{API_ROOT}/{tname}'
 
-        if not self.session:
-            self.session = aiohttp.ClientSession(conn_timeout=10,
-                                                 read_timeout=10)
-        s = session or self.session
-        resp = await retry(s.delete(url, headers=await self.headers()))
-        resp.raise_for_status()
-        return await resp.json()
+        return await self._request('DELETE', url, session=session)
 
     async def drain(self):
         resp = await self.lease(num_tasks=1000)
@@ -94,14 +92,7 @@ class TaskQueue:
             'responseView': 'FULL' if full else 'BASIC',
         }
 
-        if not self.session:
-            self.session = aiohttp.ClientSession(conn_timeout=10,
-                                                 read_timeout=10)
-        s = session or self.session
-        resp = await retry(s.get(url, headers=await self.headers(),
-                                 params=params))
-        resp.raise_for_status()
-        return await resp.json()
+        return await self._request('GET', params=params, session=session)
 
     # https://cloud.google.com/cloud-tasks/docs/reference/rest/v2beta2/projects.locations.queues.tasks/create
     async def insert(self, payload, tag=None, session=None):
@@ -116,14 +107,7 @@ class TaskQueue:
             'responseView': 'FULL',
         }
 
-        if not self.session:
-            self.session = aiohttp.ClientSession(conn_timeout=10,
-                                                 read_timeout=10)
-        s = session or self.session
-        resp = await retry(s.post(url, headers=await self.headers(),
-                                  json=body))
-        resp.raise_for_status()
-        return await resp.json()
+        return await self._request('POST', url, json=body, session=session)
 
     # https://cloud.google.com/cloud-tasks/docs/reference/rest/v2beta2/projects.locations.queues.tasks/lease
     async def lease(self, num_tasks=1, lease_seconds=60, task_filter=None,
@@ -137,14 +121,7 @@ class TaskQueue:
         if task_filter:
             body['filter'] = task_filter
 
-        if not self.session:
-            self.session = aiohttp.ClientSession(conn_timeout=10,
-                                                 read_timeout=10)
-        s = session or self.session
-        resp = await retry(s.post(url, headers=await self.headers(),
-                                  json=body))
-        resp.raise_for_status()
-        return await resp.json()
+        return await self._request('POST', url, json=body, session=session)
 
     # https://cloud.google.com/cloud-tasks/docs/reference/rest/v2beta2/projects.locations.queues.tasks/list
     async def list(self, full=False, page_size=1000, page_token='',
@@ -156,14 +133,7 @@ class TaskQueue:
             'pageToken': page_token,
         }
 
-        if not self.session:
-            self.session = aiohttp.ClientSession(conn_timeout=10,
-                                                 read_timeout=10)
-        s = session or self.session
-        resp = await retry(s.get(url, headers=await self.headers(),
-                                 params=params))
-        resp.raise_for_status()
-        return await resp.json()
+        return await self._request('GET', url, params=params, session=session)
 
     # https://cloud.google.com/cloud-tasks/docs/reference/rest/v2beta2/projects.locations.queues.tasks/renewLease
     async def renew(self, task, lease_seconds=60, session=None):
@@ -174,11 +144,4 @@ class TaskQueue:
             'responseView': 'FULL',
         }
 
-        if not self.session:
-            self.session = aiohttp.ClientSession(conn_timeout=10,
-                                                 read_timeout=10)
-        s = session or self.session
-        resp = await retry(s.post(url, headers=await self.headers(),
-                                  json=body))
-        resp.raise_for_status()
-        return await resp.json()
+        return await self._request('POST', url, json=body, session=session)

--- a/taskqueue/gcloud/aio/taskqueue/taskqueue.py
+++ b/taskqueue/gcloud/aio/taskqueue/taskqueue.py
@@ -37,7 +37,7 @@ class TaskQueue:
         }
 
     @backoff.on_exception(backoff.expo, Exception, max_tries=3)
-    async def _request(self, meth, url, session=None, **kwargs):
+    async def _request(self, method, url, session=None, **kwargs):
         # pylint: disable=too-many-arguments
         if not self.session:
             self.session = aiohttp.ClientSession(conn_timeout=10,
@@ -45,7 +45,7 @@ class TaskQueue:
         s = session or self.session
         headers = await self.headers()
 
-        resp = await s.request(meth, url, headers=headers, **kwargs)
+        resp = await s.request(method, url, headers=headers, **kwargs)
         resp.raise_for_status()
         return await resp.json()
 

--- a/taskqueue/gcloud/aio/taskqueue/taskqueue.py
+++ b/taskqueue/gcloud/aio/taskqueue/taskqueue.py
@@ -37,7 +37,7 @@ class TaskQueue:
         }
 
     @backoff.on_exception(backoff.expo, Exception, max_tries=3)
-    async def _request(self, meth, url, json=None, params=None, session=None):
+    async def _request(self, meth, url, session=None, **kwargs):
         # pylint: disable=too-many-arguments
         if not self.session:
             self.session = aiohttp.ClientSession(conn_timeout=10,
@@ -45,13 +45,7 @@ class TaskQueue:
         s = session or self.session
         headers = await self.headers()
 
-        if json:
-            resp = await s.request(meth, url, headers=headers, json=json)
-        elif params:
-            resp = await s.request(meth, url, headers=headers, params=params)
-        else:
-            resp = await s.request(meth, url, headers=headers)
-
+        resp = await s.request(meth, url, headers=headers, **kwargs)
         resp.raise_for_status()
         return await resp.json()
 

--- a/taskqueue/gcloud/aio/taskqueue/utils.py
+++ b/taskqueue/gcloud/aio/taskqueue/utils.py
@@ -1,4 +1,3 @@
-import asyncio
 import base64
 import logging
 import random

--- a/taskqueue/gcloud/aio/taskqueue/utils.py
+++ b/taskqueue/gcloud/aio/taskqueue/utils.py
@@ -90,22 +90,3 @@ async def raise_for_status(resp):
         raise aiohttp.client_exceptions.ClientResponseError(
             resp.request_info, resp.history, code=resp.status,
             headers=resp.headers, message=resp.reason)
-
-
-async def retry(coro, exceptions=None, retries=3):
-    attempt = 0
-    while True:
-        attempt += 1
-
-        try:
-            return await coro
-        except Exception as e:  # pylint: disable=broad-except
-            if exceptions is not None and e not in exceptions:
-                raise
-
-            if attempt >= retries:
-                raise
-
-            log.warning('retrying with attempt %d of %d', attempt, retries,
-                        exc_info=e)
-            await asyncio.sleep(0.5)

--- a/taskqueue/requirements.txt
+++ b/taskqueue/requirements.txt
@@ -1,3 +1,4 @@
 aiohttp >= 2.0.0, < 4.0.0
+backoff >= 1.0.0, < 2.0.0
 gcloud-aio-auth >= 1.0.0, < 2.0.0
 requests >= 2.0.0, < 3.0.0

--- a/taskqueue/setup.py
+++ b/taskqueue/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as f:
 
 setuptools.setup(
     name='gcloud-aio-taskqueue',
-    version='1.4.2',
+    version='1.4.3',
     description='Asyncio Python Client for Google Cloud Task Queue',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
The previous retry loop `await`ed the same coroutine multiple
times, which led to swallowing every exception with:
> RuntimeError: cannot reuse already awaited coroutine

This patchset uses `backoff` rather than rolling our own --
it should now capture the real exception in the worst case
and _actually retry failed requests_ in the standard case.