### PR TITLE
fix(encoding): fix URI path encoding for GCP REST API

### DIFF
--- a/storage/gcloud/aio/storage/bucket.py
+++ b/storage/gcloud/aio/storage/bucket.py
@@ -16,7 +16,6 @@ class Bucket:
         self.name = name
 
     async def get_blob(self, blob_name, session=None):
-        blob_name = blob_name.replace('/', '%2F')
         content = await self.storage.download(self.name, blob_name,
                                               session=session)
 

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -59,8 +59,6 @@ class Storage:
         session = session or self.session
         resp = await session.delete(url, headers=headers, params=params or {},
                                     timeout=60)
-        log.warning(url)
-        log.warning(await resp.json())
         resp.raise_for_status()
         return await resp.text()
 

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -1,5 +1,5 @@
 import logging
-import urllib
+from urllib.parse import quote
 
 import aiohttp
 from gcloud.aio.auth import Token
@@ -29,7 +29,7 @@ class Storage:
     async def download(self, bucket, object_name, params=None, session=None):
         token = await self.token.get()
         # https://cloud.google.com/storage/docs/json_api/#encoding
-        encoded_object_name = urllib.parse.quote(object_name, safe='')
+        encoded_object_name = quote(object_name, safe='')
         url = f'{STORAGE_API_ROOT}/{bucket}/o/{encoded_object_name}'
         headers = {
             'Authorization': f'Bearer {token}',
@@ -47,7 +47,7 @@ class Storage:
     async def delete(self, bucket, object_name, params=None, session=None):
         token = await self.token.get()
         # https://cloud.google.com/storage/docs/json_api/#encoding
-        encoded_object_name = urllib.parse.quote(object_name, safe='')
+        encoded_object_name = quote(object_name, safe='')
         url = f'{STORAGE_API_ROOT}/{bucket}/o/{encoded_object_name}'
         headers = {
             'Authorization': f'Bearer {token}',

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -1,4 +1,5 @@
 import logging
+import urllib
 
 import aiohttp
 from gcloud.aio.auth import Token
@@ -27,7 +28,9 @@ class Storage:
 
     async def download(self, bucket, object_name, params=None, session=None):
         token = await self.token.get()
-        url = f'{STORAGE_API_ROOT}/{bucket}/o/{object_name}'
+        # https://cloud.google.com/storage/docs/json_api/#encoding
+        encoded_object_name = urllib.parse.quote(object_name, safe='')
+        url = f'{STORAGE_API_ROOT}/{bucket}/o/{encoded_object_name}'
         headers = {
             'Authorization': f'Bearer {token}',
         }
@@ -43,7 +46,9 @@ class Storage:
 
     async def delete(self, bucket, object_name, params=None, session=None):
         token = await self.token.get()
-        url = f'{STORAGE_API_ROOT}/{bucket}/o/{object_name}'
+        # https://cloud.google.com/storage/docs/json_api/#encoding
+        encoded_object_name = urllib.parse.quote(object_name, safe='')
+        url = f'{STORAGE_API_ROOT}/{bucket}/o/{encoded_object_name}'
         headers = {
             'Authorization': f'Bearer {token}',
         }
@@ -54,6 +59,8 @@ class Storage:
         session = session or self.session
         resp = await session.delete(url, headers=headers, params=params or {},
                                     timeout=60)
+        log.warning(url)
+        log.warning(await resp.json())
         resp.raise_for_status()
         return await resp.text()
 
@@ -111,7 +118,6 @@ class Storage:
         return await resp.json()
 
     async def download_as_string(self, bucket, object_name, session=None):
-        object_name = object_name.replace('/', '%2F')
         return await self.download(bucket, object_name,
                                    params={'alt': 'media'}, session=session)
 

--- a/storage/tests/integration/smoke_test.py
+++ b/storage/tests/integration/smoke_test.py
@@ -17,7 +17,7 @@ CREDS = os.environ['GOOGLE_APPLICATION_CREDENTIALS']
 ])
 async def test_object_life_cycle(uploaded_data, expected_data):
     bucket_name = 'talkiq-integration-test'
-    object_name = uuid.uuid4().hex
+    object_name = f'{uuid.uuid4().hex}/{uuid.uuid4().hex}.txt'
 
     async with aiohttp.ClientSession() as session:
         storage = Storage(PROJECT, CREDS, session=session)


### PR DESCRIPTION
Added support for properly encoding Storage object names with special paths to follow https://cloud.google.com/storage/docs/json_api/#encoding