### PR TITLE
feat(auth): enable auth with default application credentials

### DIFF
--- a/auth/requirements.test.txt
+++ b/auth/requirements.test.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+
+pytest
+pytest-asyncio

--- a/auth/requirements.test.txt
+++ b/auth/requirements.test.txt
@@ -1,4 +1,0 @@
--r requirements.txt
-
-pytest
-pytest-asyncio

--- a/auth/tests/integration/smoke_test.py
+++ b/auth/tests/integration/smoke_test.py
@@ -11,7 +11,7 @@ async def test_token_is_created(creds, project):
         token = Token(project, creds, session=session, scopes=scopes)
         result = await token.get()
 
-    assert result is not None and result is not False
+    assert result
     assert token.access_token is not None
     assert token.access_token_duration is not None
     assert token.access_token_acquired_at is not None
@@ -24,7 +24,7 @@ async def test_token_does_not_require_session(creds, project):
     token = Token(project, creds, scopes=scopes)
     result = await token.get()
 
-    assert result is not None and result is not False
+    assert result
     assert token.access_token is not None
     assert token.access_token_duration is not None
     assert token.access_token_acquired_at is not None

--- a/auth/tests/integration/smoke_test.py
+++ b/auth/tests/integration/smoke_test.py
@@ -11,7 +11,10 @@ async def test_token_is_created(creds, project):
         token = Token(project, creds, session=session, scopes=scopes)
         result = await token.get()
 
-    assert result is not None
+    assert result is not None and result is not False
+    assert token.access_token is not None
+    assert token.access_token_duration is not None
+    assert token.access_token_acquired_at is not None
 
 
 @pytest.mark.asyncio
@@ -21,4 +24,7 @@ async def test_token_does_not_require_session(creds, project):
     token = Token(project, creds, scopes=scopes)
     result = await token.get()
 
-    assert result is not None
+    assert result is not None and result is not False
+    assert token.access_token is not None
+    assert token.access_token_duration is not None
+    assert token.access_token_acquired_at is not None


### PR DESCRIPTION
![gif](https://media.giphy.com/media/3o7TKT64zUTc0hHB96/giphy.gif)

Users can now authenticate through gcloud-aio-auth using default application credentials (`adc.json`)
Added a few cases to the auth tests.
Compatibility has been tested with: `gcloud-aio-bigquery`, `gcloud-aio-datastore`, and `gcloud-aio-taskqueue`