### PR TITLE
Update gcloud-datastore to use local development emulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.pyc
 */.coverage
 */build/*
+*.idea


### PR DESCRIPTION
Check for the DATASTORE_EMULATOR_HOST env variable and if it exists assume working in dev mode. Then update the API_ROOT to point to the emulator as well as not requiring Authorization header or the need to obtain an auth Token.