### PR TITLE
fix(datastore): allow non-transactional datastore usage w/o ID

### DIFF
--- a/datastore/tests/integration/smoke_test.py
+++ b/datastore/tests/integration/smoke_test.py
@@ -60,7 +60,7 @@ async def test_transaction(creds: str, kind: str, project: str) -> None:
             ds.make_mutation(Operation.UPDATE, key,
                              properties={'animal': 'aardvark'}),
         ]
-        await ds.commit(transaction, mutations=mutations, session=s)
+        await ds.commit(mutations, transaction=transaction, session=s)
 
         actual = await ds.lookup([key], session=s)
         assert actual['found'][0].entity.properties == {'animal': 'aardvark'}
@@ -99,7 +99,7 @@ async def test_query(creds: str, kind: str, project: str) -> None:
                              Key(project, [PathElement(kind)]),
                              properties={'value': 42}),
         ]
-        await ds.commit(transaction, mutations=mutations, session=s)
+        await ds.commit(mutations, transaction=transaction, session=s)
 
         after = await ds.runQuery(query, session=s)
         assert len(after.entity_results) == num_results + 3


### PR DESCRIPTION
When invoking a non-transactional commit, the `transaction` key can (and
should) be omitted. This change allows users to commit in
non-transactional mode without providing a transaction key (or arbitrary
string) by ensuring that key is optional.

This is a breaking change, since the `commit` API changed.