### PR TITLE
[WIP] feat(datastore) add non-GQL queries

### DIFF
--- a/datastore/gcloud/aio/datastore/__init__.py
+++ b/datastore/gcloud/aio/datastore/__init__.py
@@ -1,21 +1,30 @@
 from pkg_resources import get_distribution
 __version__ = get_distribution('gcloud-aio-datastore').version
 
+from gcloud.aio.datastore.constants import CompositeFilterOperator
 from gcloud.aio.datastore.constants import Consistency
 from gcloud.aio.datastore.constants import Mode
 from gcloud.aio.datastore.constants import MoreResultsType
 from gcloud.aio.datastore.constants import Operation
+from gcloud.aio.datastore.constants import PropertyFilterOperator
 from gcloud.aio.datastore.constants import ResultType
 from gcloud.aio.datastore.datastore import Datastore
 from gcloud.aio.datastore.datastore import SCOPES
 from gcloud.aio.datastore.entity import Entity
 from gcloud.aio.datastore.entity import EntityResult
+from gcloud.aio.datastore.filter import CompositeFilter
+from gcloud.aio.datastore.filter import Filter
+from gcloud.aio.datastore.filter import PropertyFilter
 from gcloud.aio.datastore.key import Key
 from gcloud.aio.datastore.key import PathElement
 from gcloud.aio.datastore.query import GQLQuery
+from gcloud.aio.datastore.query import Query
 from gcloud.aio.datastore.query import QueryResultBatch
+from gcloud.aio.datastore.value import Value
 
 
-__all__ = ['__version__', 'Consistency', 'Datastore', 'Entity', 'EntityResult',
+__all__ = ['__version__', 'CompositeFilter', 'CompositeFilterOperator',
+           'Consistency', 'Datastore', 'Entity', 'EntityResult', 'Filter',
            'GQLQuery', 'Key', 'Mode', 'MoreResultsType', 'Operation',
-           'PathElement', 'QueryResultBatch', 'ResultType', 'SCOPES']
+           'PathElement', 'PropertyFilter', 'PropertyFilterOperator', 'Query',
+           'QueryResultBatch', 'ResultType', 'SCOPES', 'Value']

--- a/datastore/gcloud/aio/datastore/constants.py
+++ b/datastore/gcloud/aio/datastore/constants.py
@@ -2,6 +2,11 @@ import enum
 from datetime import datetime as dt
 
 
+class CompositeFilterOperator(enum.Enum):
+    OPERATOR_UNSPECIFIED = 'OPERATOR_UNSPECIFIED'
+    AND = 'AND'
+
+
 class Consistency(enum.Enum):
     EVENTUAL = 'EVENTUAL'
     STRONG = 'STRONG'
@@ -27,6 +32,16 @@ class Operation(enum.Enum):
     INSERT = 'insert'
     UPDATE = 'update'
     UPSERT = 'upsert'
+
+
+class PropertyFilterOperator(enum.Enum):
+    OPERATOR_UNSPECIFIED = 'OPERATOR_UNSPECIFIED'
+    LESS_THAN = 'LESS_THAN'
+    LESS_THAN_OR_EQUAL = 'LESS_THAN_OR_EQUAL'
+    GREATER_THAN = 'GREATER_THAN'
+    GREATER_THAN_OR_EQUAL = 'GREATER_THAN_OR_EQUAL'
+    EQUAL = 'EQUAL'
+    HAS_ANCESTOR = 'HAS_ANCESTOR'
 
 
 class ResultType(enum.Enum):

--- a/datastore/gcloud/aio/datastore/datastore.py
+++ b/datastore/gcloud/aio/datastore/datastore.py
@@ -13,7 +13,7 @@ from gcloud.aio.datastore.constants import Mode
 from gcloud.aio.datastore.constants import Operation
 from gcloud.aio.datastore.entity import EntityResult
 from gcloud.aio.datastore.key import Key
-from gcloud.aio.datastore.query import GQLQuery
+from gcloud.aio.datastore.query import _BaseQuery
 from gcloud.aio.datastore.query import QueryResultBatch
 from gcloud.aio.datastore.utils import make_value
 try:
@@ -283,8 +283,7 @@ class Datastore:
         resp.raise_for_status()
 
     # https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects/runQuery
-    # TODO: support non-GQL queries
-    async def runQuery(self, query: GQLQuery, transaction: str = None,
+    async def runQuery(self, query: _BaseQuery, transaction: str = None,
                        consistency: Consistency = Consistency.EVENTUAL,
                        session: aiohttp.ClientSession = None,
                        timeout: int = 10) -> QueryResultBatch:
@@ -300,7 +299,7 @@ class Datastore:
                 'projectId': project,
                 'namespaceId': self.namespace,
             },
-            'gqlQuery': query.to_repr(),
+            query.json_key:  query.to_repr(),
             'readOptions': options,
         }).encode('utf-8')
 

--- a/datastore/gcloud/aio/datastore/filter.py
+++ b/datastore/gcloud/aio/datastore/filter.py
@@ -1,0 +1,111 @@
+from typing import Any
+from typing import Dict
+from typing import List
+
+from gcloud.aio.datastore.constants import CompositeFilterOperator
+from gcloud.aio.datastore.constants import PropertyFilterOperator
+from gcloud.aio.datastore.value import Value
+
+
+class _BaseFilter:
+    json_key = ''
+
+    def __repr__(self) -> str:
+        return str(self.to_repr())
+
+    @classmethod
+    def from_repr(cls, data: Dict[str, Any]) -> '_BaseFilter':
+        raise NotImplementedError
+
+    def to_repr(self) -> Dict[str, Any]:
+        raise NotImplementedError
+
+
+# https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects/runQuery#Filter
+class Filter:
+    def __init__(self, inner_filter: _BaseFilter):
+        self.inner_filter = inner_filter
+
+    def __repr__(self) -> str:
+        return str(self.to_repr())
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Filter):
+            return False
+        return self.inner_filter == other.inner_filter
+
+    @classmethod
+    def from_repr(cls, data: Dict[str, Any]) -> 'Filter':
+        (inner_filter_name, inner_filter_data), = data.items()
+        if inner_filter_name == 'compositeFilter':
+            inner_filter = CompositeFilter.from_repr(inner_filter_data)
+        elif inner_filter_name == 'propertyFilter':
+            inner_filter = PropertyFilter.from_repr(inner_filter_data)
+        else:
+            raise ValueError(f'Invalid filter name: {inner_filter_name}')
+        return cls(inner_filter=inner_filter)
+
+    def to_repr(self) -> Dict[str, Any]:
+        return {
+            self.inner_filter.__class__.json_key: self.inner_filter.to_repr()
+        }
+
+
+class CompositeFilter(_BaseFilter):
+    json_key = 'compositeFilter'
+
+    def __init__(
+            self, operator: CompositeFilterOperator, filters: List[Filter]):
+        self.operator = operator
+        self.filters = filters
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, CompositeFilter):
+            return False
+        return bool(
+            self.operator == other.operator
+            and self.filters == other.filters)
+
+    @classmethod
+    def from_repr(cls, data: Dict[str, Any]) -> 'CompositeFilter':
+        operator = CompositeFilterOperator(data['op'])
+        filters = [Filter.from_repr(f) for f in data['filters']]
+        return cls(operator=operator, filters=filters)
+
+    def to_repr(self) -> Dict[str, Any]:
+        return {
+            'op': self.operator.value,
+            'filters': [f.to_repr() for f in self.filters]
+        }
+
+
+class PropertyFilter(_BaseFilter):
+    json_key = 'propertyFilter'
+
+    def __init__(
+            self, prop: str, operator: PropertyFilterOperator, value: Value):
+        self.prop = prop
+        self.operator = operator
+        self.value = value
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, PropertyFilter):
+            return False
+        return bool(
+            self.prop == other.prop
+            and self.operator == other.operator
+            and self.value == other.value)
+
+    @classmethod
+    def from_repr(cls, data: Dict[str, Any]) -> 'PropertyFilter':
+        prop = data['property']['name']
+        operator = PropertyFilterOperator(data['op'])
+        value = Value.from_repr(data['value'])
+        return cls(prop, operator, value)
+
+    def to_repr(self) -> Dict[str, Any]:
+        return {
+            'property': {'name': self.prop},
+            'op': self.operator.value,
+            'value': self.value.to_repr()
+        }

--- a/datastore/gcloud/aio/datastore/query.py
+++ b/datastore/gcloud/aio/datastore/query.py
@@ -5,11 +5,60 @@ from typing import List
 from gcloud.aio.datastore.constants import MoreResultsType
 from gcloud.aio.datastore.constants import ResultType
 from gcloud.aio.datastore.entity import EntityResult
+from gcloud.aio.datastore.filter import Filter
 from gcloud.aio.datastore.utils import make_value
 from gcloud.aio.datastore.utils import parse_value
 
 
-class GQLQuery:
+class _BaseQuery:
+    json_key = ''
+
+    def __repr__(self) -> str:
+        return str(self.to_repr())
+
+    @classmethod
+    def from_repr(cls, data: Dict[str, Any]) -> '_BaseQuery':
+        raise NotImplementedError
+
+    def to_repr(self) -> Dict[str, Any]:
+        raise NotImplementedError
+
+
+# https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects/runQuery#Query
+class Query(_BaseQuery):
+    json_key = 'query'
+
+    def __init__(self, kind: str, query_filter: Filter = None):
+        if not kind:
+            raise NotImplementedError('Kindless queries are not supported')
+        self.kind = kind
+        self.query_filter = query_filter
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Query):
+            return False
+        return bool(
+            self.kind == other.kind
+            and self.query_filter == other.query_filter)
+
+    @classmethod
+    def from_repr(cls, data: Dict[str, Any]) -> 'Query':
+        kind = data['kind']
+        query_filter = Filter.from_repr(data['filter'])
+        return cls(kind=kind, query_filter=query_filter)
+
+    def to_repr(self) -> Dict[str, Any]:
+        data = {
+            'kind': [{'name': self.kind}]
+        }
+        if self.query_filter:
+            data['filter'] = self.query_filter.to_repr()
+        return data
+
+
+class GQLQuery(_BaseQuery):
+    json_key = 'gqlQuery'
+
     def __init__(self, query_string: str, allow_literals: bool = True,
                  named_bindings: Dict[str, Any] = None,
                  positional_bindings: List[Any] = None) -> None:
@@ -28,12 +77,9 @@ class GQLQuery:
             and self.named_bindings == other.named_bindings
             and self.positional_bindings == other.positional_bindings)
 
-    def __repr__(self) -> str:
-        return str(self.to_repr())
-
     @classmethod
     def from_repr(cls, data: Dict[str, Any]) -> 'GQLQuery':
-        allow_literals = data['allowLiteralls']
+        allow_literals = data['allowLiterals']
         query_string = data['queryString']
         named_bindings = {k: parse_value(v['value'])
                           for k, v in data.get('namedBindings', {}).items()}

--- a/datastore/gcloud/aio/datastore/value.py
+++ b/datastore/gcloud/aio/datastore/value.py
@@ -1,0 +1,63 @@
+from typing import Any
+from typing import Dict
+
+
+_JSON_KEYS = {
+    type(None): 'nullValue',
+    bool: 'booleanValue',
+    int: 'integerValue',
+    float: 'doubleValue',
+    # TODO timestampValue
+    # TODO keyValue
+    str: 'stringValue',
+    # TODO blobValue
+    # TODO geoPointValue
+    # TODO entityValue
+    # TODO arrayValue
+}
+
+_VALUE_TYPES = {v: k for k, v in _JSON_KEYS.items()}
+
+
+# https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects/runQuery#value
+class Value:
+    def __init__(self, value: Any, exclude_from_indexes: bool = False):
+        self.value = value
+        self.excludeFromIndexes = exclude_from_indexes
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Value):
+            return False
+        return bool(
+            self.excludeFromIndexes == other.excludeFromIndexes
+            and self.value == other.value)
+
+    def __repr__(self) -> str:
+        return str(self.to_repr())
+
+    @classmethod
+    def from_repr(cls, data: Dict[str, Any]) -> 'Value':
+        for json_key, value_type in _VALUE_TYPES.items():
+            if json_key in data:
+                if json_key == 'nullValue':
+                    value = None
+                else:
+                    value = value_type(data[json_key])
+                break
+        else:
+            raise NotImplementedError(
+                f"Dict '{str(data)}' does not contain a supported value key")
+        exclude_from_indexes = bool(data['excludeFromIndexes'])
+
+        return cls(value=value, exclude_from_indexes=exclude_from_indexes)
+
+    def to_repr(self) -> Dict[str, Any]:
+        value_type = type(self.value)
+        if value_type not in _JSON_KEYS:
+            raise NotImplementedError(
+                f"Type '{value_type}' is not supported by the Value type")
+
+        return {
+            'excludeFromIndexes': self.excludeFromIndexes,
+            _JSON_KEYS[value_type]: self.value or 'NULL_VALUE'
+        }

--- a/datastore/tests/integration/smoke_test.py
+++ b/datastore/tests/integration/smoke_test.py
@@ -78,6 +78,12 @@ async def test_rollback(creds: str, project: str) -> None:
 @pytest.mark.asyncio  # type: ignore
 @pytest.mark.xfail(strict=False)  # type: ignore
 async def test_query(creds: str, kind: str, project: str) -> None:
+    assert False  # TODO
+
+
+@pytest.mark.asyncio  # type: ignore
+@pytest.mark.xfail(strict=False)  # type: ignore
+async def test_gql_query(creds: str, kind: str, project: str) -> None:
     async with aiohttp.ClientSession(conn_timeout=10, read_timeout=10) as s:
         ds = Datastore(project=project, service_file=creds, session=s)
 

--- a/datastore/tests/unit/filter_test.py
+++ b/datastore/tests/unit/filter_test.py
@@ -1,0 +1,165 @@
+from typing import Any
+from typing import Dict
+from typing import List
+
+import pytest
+from gcloud.aio.datastore import CompositeFilter
+from gcloud.aio.datastore import CompositeFilterOperator
+from gcloud.aio.datastore import Filter
+from gcloud.aio.datastore import PropertyFilter
+from gcloud.aio.datastore import PropertyFilterOperator
+from gcloud.aio.datastore import Value
+
+
+class TestFilter:
+
+    def test_property_filter_from_repr(self):
+        original_filter = self._create_property_filter()
+        data = {
+            'property': {
+                'name': original_filter.prop
+            },
+            'op': original_filter.operator,
+            'value': original_filter.value.to_repr()
+        }
+
+        output_filter = PropertyFilter.from_repr(data)
+
+        assert output_filter == original_filter
+
+    def test_property_filter_to_repr(self):
+        property_filter = self._create_property_filter()
+        query_filter = Filter(inner_filter=property_filter)
+
+        r = query_filter.to_repr()
+
+        self._assert_is_correct_prop_dict_for_property_filter(r['propertyFilter'], property_filter)
+
+    def test_composite_filter_from_repr(self):
+        property_filters = self._create_property_filters(count=2)
+        original_filter = CompositeFilter(
+            operator=CompositeFilterOperator.AND,
+            filters=[
+                Filter(property_filters[0]),
+                Filter(property_filters[1])
+            ])
+        data = {
+            'op': original_filter.operator,
+            'filters': [
+                {
+                    'propertyFilter': {
+                        'property': {
+                            'name': original_filter.filters[0].inner_filter.prop
+                        },
+                        'op': original_filter.filters[0].inner_filter.operator,
+                        'value': original_filter.filters[0].inner_filter.value.to_repr()
+                    }
+                },
+                {
+                    'propertyFilter': {
+                        'property': {
+                            'name': original_filter.filters[1].inner_filter.prop
+                        },
+                        'op': original_filter.filters[1].inner_filter.operator,
+                        'value': original_filter.filters[1].inner_filter.value.to_repr()
+                    }
+                },
+            ]
+        }
+
+        output_filter = CompositeFilter.from_repr(data)
+
+        assert output_filter == original_filter
+
+    def test_composite_filter_to_repr(self):
+        property_filters = self._create_property_filters(count=2)
+        composite_filter = CompositeFilter(
+            operator=CompositeFilterOperator.AND,
+            filters=[
+                Filter(property_filters[0]),
+                Filter(property_filters[1])
+            ])
+        query_filter = Filter(composite_filter)
+
+        r = query_filter.to_repr()
+
+        composite_filter_dict = r['compositeFilter']
+        assert composite_filter_dict['op'] == 'AND'
+        self._assert_is_correct_prop_dict_for_property_filter(
+            composite_filter_dict['filters'][0]['propertyFilter'], property_filters[0])
+        self._assert_is_correct_prop_dict_for_property_filter(
+            composite_filter_dict['filters'][1]['propertyFilter'], property_filters[1])
+
+    def test_filter_from_repr(self):
+        composite_filter = self._create_composite_filter()
+        original_filter = Filter(inner_filter=composite_filter)
+
+        data = {
+            'compositeFilter': original_filter.inner_filter.to_repr()
+        }
+
+        output_filter = Filter.from_repr(data)
+
+        assert output_filter == original_filter
+
+    def test_filter_from_repr_unexpected_filter_name(self):
+        unexpected_filter_name = 'unexpectedFilterName'
+        data = {
+            unexpected_filter_name: 'DoesNotMatter'
+        }
+
+        with pytest.raises(ValueError) as ex_info:
+            Filter.from_repr(data)
+
+        assert unexpected_filter_name in ex_info.value.args[0]
+
+    def test_filter_to_repr(self):
+        composite_filter = self._create_composite_filter()
+        test_filter = Filter(inner_filter=composite_filter)
+
+        r = test_filter.to_repr()
+
+        assert r['compositeFilter'] == test_filter.inner_filter.to_repr()
+
+    def test_repr_returns_to_repr_as_string(self):
+        query_filter = self._create_filter()
+
+        assert repr(query_filter) == str(query_filter.to_repr())
+
+    @staticmethod
+    def _create_property_filter() -> PropertyFilter:
+        return TestFilter._create_property_filters(count=1)[0]
+
+    @staticmethod
+    def _create_property_filters(count: int) -> List[PropertyFilter]:
+        if count > 2:
+            raise NotImplementedError('You may need to implement a way to generate any number of property filters :)')
+        return [
+            PropertyFilter(prop='prop1', operator=PropertyFilterOperator.LESS_THAN, value=Value('value1')),
+            PropertyFilter(prop='prop2', operator=PropertyFilterOperator.GREATER_THAN, value=Value(1234))
+        ][0:count]
+
+    @staticmethod
+    def _create_composite_filter() -> CompositeFilter:
+        property_filters = TestFilter._create_property_filters(count=2)
+        return CompositeFilter(
+            operator=CompositeFilterOperator.AND,
+            filters=[
+                Filter(property_filters[0]),
+                Filter(property_filters[1])
+            ])
+
+    @staticmethod
+    def _create_filter() -> Filter:
+        composite_filter = TestFilter._create_composite_filter()
+        return Filter(inner_filter=composite_filter)
+
+    @staticmethod
+    def _create_value() -> Value:
+        return Value('value')
+
+    @staticmethod
+    def _assert_is_correct_prop_dict_for_property_filter(prop_dict: Dict[str, Any], property_filter: PropertyFilter):
+        assert prop_dict['property']['name'] == property_filter.prop
+        assert prop_dict['op'] == property_filter.operator.value
+        assert prop_dict['value'] == property_filter.value.to_repr()

--- a/datastore/tests/unit/query_test.py
+++ b/datastore/tests/unit/query_test.py
@@ -1,0 +1,59 @@
+import pytest
+from gcloud.aio.datastore import Filter
+from gcloud.aio.datastore import PropertyFilter
+from gcloud.aio.datastore import PropertyFilterOperator
+from gcloud.aio.datastore import Query
+from gcloud.aio.datastore import Value
+
+
+class TestQuery:
+
+    def test_create_query_without_kind_throws_not_implemented_error(self):
+        with pytest.raises(NotImplementedError) as ex_info:
+            Query(kind='')
+        assert 'Kindless queries are not supported' in ex_info.value.args[0]
+
+    def test_from_repr(self):
+        original_query = self._create_query()
+        data = {
+            'kind': original_query.kind,
+            'filter': original_query.query_filter.to_repr()
+        }
+
+        output_query = Query.from_repr(data)
+
+        assert output_query == original_query
+
+    def test_to_repr_simple_query(self):
+        kind = 'foo'
+        query = Query(kind)
+
+        r = query.to_repr()
+
+        assert len(r['kind']) == 1
+        assert r['kind'][0]['name'] == kind
+
+    def test_to_repr_query_with_filter(self):
+        property_filter = self._create_filter()
+        query = Query('foo', property_filter)
+
+        r = query.to_repr()
+
+        assert r['filter'] == property_filter.to_repr()
+
+    def test_repr_returns_to_repr_as_string(self):
+        query = self._create_query()
+
+        assert repr(query) == str(query.to_repr())
+
+    def _create_query(self):
+        query_filter = self._create_filter()
+        return Query('query_kind', query_filter)
+
+    @staticmethod
+    def _create_filter():
+        inner_filter = PropertyFilter(
+            prop='property_name',
+            operator=PropertyFilterOperator.EQUAL,
+            value=Value(123))
+        return Filter(inner_filter)

--- a/datastore/tests/unit/value_test.py
+++ b/datastore/tests/unit/value_test.py
@@ -1,0 +1,90 @@
+import pytest
+from gcloud.aio.datastore import Value
+
+
+class TestValue:
+
+    @pytest.mark.parametrize('json_key,json_value', [
+        ('booleanValue', True),
+        ('integerValue', 8483),
+        ('doubleValue', 34.48),
+        ('stringValue', 'foobar')
+    ])
+    def test_from_repr(self, json_key, json_value):
+        data = {
+            'excludeFromIndexes': False,
+            json_key: json_value
+        }
+
+        value = Value.from_repr(data)
+
+        assert value.excludeFromIndexes is False
+        assert value.value == json_value
+
+    def test_from_repr_with_null_value(self):
+        data = {
+            'excludeFromIndexes': False,
+            'nullValue': 'NULL_VALUE'
+        }
+
+        value = Value.from_repr(data)
+
+        assert value.excludeFromIndexes is False
+        assert value.value is None
+
+    def test_from_repr_could_not_find_supported_value_key(self):
+        data = {
+            'excludeFromIndexes': False,
+        }
+
+        with pytest.raises(NotImplementedError) as ex_info:
+            Value.from_repr(data)
+
+        assert str(data) in ex_info.value.args[0]
+
+    @pytest.mark.parametrize('v,expected_json_key', [
+        (True, 'booleanValue'),
+        (8483, 'integerValue'),
+        (34.48, 'doubleValue'),
+        ('foobar', 'stringValue')
+    ])
+    def test_to_repr(self, v, expected_json_key):
+        value = Value(v)
+
+        r = value.to_repr()
+
+        assert len(r) == 2  # Value + excludeFromIndexes
+        assert r['excludeFromIndexes'] is False
+        assert r[expected_json_key] == v
+
+    def test_to_repr_with_null_value(self):
+        value = Value(None)
+
+        r = value.to_repr()
+
+        assert r['nullValue'] == 'NULL_VALUE'
+
+    def test_to_repr_exclude_from_indexes(self):
+        value = Value(123, exclude_from_indexes=True)
+
+        r = value.to_repr()
+
+        assert r['excludeFromIndexes']
+
+    def test_to_repr_non_supported_type(self):
+        class NonSupportedType:
+            pass
+        value = Value(NonSupportedType())
+
+        with pytest.raises(NotImplementedError) as ex_info:
+            value.to_repr()
+
+        assert NonSupportedType.__name__ in ex_info.value.args[0]
+
+    def test_repr_returns_to_repr_as_string(self):
+        value = self._create_value()
+
+        assert repr(value) == str(value.to_repr())
+
+    def _create_value(self):
+        return Value(value='foobar', exclude_from_indexes=False)


### PR DESCRIPTION
[WIP] I still need to figure out how to run the integration tests - I wouldn't merge this before test_query in `smoke_test.py` is implemented (and the docs are updated). But the code is there so I think there is value in giving time to review while I work out the integration tests and the pre-commit hook (pylint did find some issues that I fixed, but it currently raises an Attribute error for some reason)

I added classes for Query, Filter, and Value. This adds support for non-GQL queries.