### PR TITLE
feat(datastore) add non-GQL queries

### DIFF
--- a/datastore/README.rst
+++ b/datastore/README.rst
@@ -19,9 +19,14 @@ started:
 .. code-block:: python
 
     from gcloud.aio.datastore import Datastore
+    from gcloud.aio.datastore import Filter
+    from gcloud.aio.datastore import GQLQuery
     from gcloud.aio.datastore import Key
     from gcloud.aio.datastore import PathElement
-    from gcloud.aio.datastore import GQLQuery
+    from gcloud.aio.datastore import PropertyFilter
+    from gcloud.aio.datastore import PropertyFilterOperator
+    from gcloud.aio.datastore import Query
+    from gcloud.aio.datastore import Value
 
     ds = Datastore('my-gcloud-project', '/path/to/creds.json')
     key1 = Key('my-gcloud-project', [PathElement('Kind', 'entityname')])

--- a/datastore/README.rst
+++ b/datastore/README.rst
@@ -55,9 +55,13 @@ started:
     await ds.reserveIds(allocated_keys)
 
     # query support
-    query = GQLQuery('SELECT * FROM the_meaning_of_life WHERE answer = @answer',
-                     named_bindings={'answer': 42})
+    property_filter = PropertyFilter(prop='answer', operator=PropertyFilterOperator.EQUAL, value=Value(42))
+    query = Query(kind='the_meaning_of_life', query_filter=Filter(property_filter))
     results = await ds.runQuery(query, session=s)
+
+    gql_query = GQLQuery('SELECT * FROM the_meaning_of_life WHERE answer = @answer',
+                        named_bindings={'answer': 42})
+    results = await ds.runQuery(gql_query, session=s)
 
 Custom Subclasses
 ~~~~~~~~~~~~~~~~~

--- a/datastore/gcloud/aio/datastore/__init__.py
+++ b/datastore/gcloud/aio/datastore/__init__.py
@@ -1,21 +1,30 @@
 from pkg_resources import get_distribution
 __version__ = get_distribution('gcloud-aio-datastore').version
 
+from gcloud.aio.datastore.constants import CompositeFilterOperator
 from gcloud.aio.datastore.constants import Consistency
 from gcloud.aio.datastore.constants import Mode
 from gcloud.aio.datastore.constants import MoreResultsType
 from gcloud.aio.datastore.constants import Operation
+from gcloud.aio.datastore.constants import PropertyFilterOperator
 from gcloud.aio.datastore.constants import ResultType
 from gcloud.aio.datastore.datastore import Datastore
 from gcloud.aio.datastore.datastore import SCOPES
 from gcloud.aio.datastore.entity import Entity
 from gcloud.aio.datastore.entity import EntityResult
+from gcloud.aio.datastore.filter import CompositeFilter
+from gcloud.aio.datastore.filter import Filter
+from gcloud.aio.datastore.filter import PropertyFilter
 from gcloud.aio.datastore.key import Key
 from gcloud.aio.datastore.key import PathElement
 from gcloud.aio.datastore.query import GQLQuery
+from gcloud.aio.datastore.query import Query
 from gcloud.aio.datastore.query import QueryResultBatch
+from gcloud.aio.datastore.value import Value
 
 
-__all__ = ['__version__', 'Consistency', 'Datastore', 'Entity', 'EntityResult',
+__all__ = ['__version__', 'CompositeFilter', 'CompositeFilterOperator',
+           'Consistency', 'Datastore', 'Entity', 'EntityResult', 'Filter',
            'GQLQuery', 'Key', 'Mode', 'MoreResultsType', 'Operation',
-           'PathElement', 'QueryResultBatch', 'ResultType', 'SCOPES']
+           'PathElement', 'PropertyFilter', 'PropertyFilterOperator', 'Query',
+           'QueryResultBatch', 'ResultType', 'SCOPES', 'Value']

--- a/datastore/gcloud/aio/datastore/constants.py
+++ b/datastore/gcloud/aio/datastore/constants.py
@@ -2,6 +2,11 @@ import enum
 from datetime import datetime as dt
 
 
+class CompositeFilterOperator(enum.Enum):
+    UNSPECIFIED = 'OPERATOR_UNSPECIFIED'
+    AND = 'AND'
+
+
 class Consistency(enum.Enum):
     EVENTUAL = 'EVENTUAL'
     STRONG = 'STRONG'
@@ -29,6 +34,16 @@ class Operation(enum.Enum):
     UPSERT = 'upsert'
 
 
+class PropertyFilterOperator(enum.Enum):
+    UNSPECIFIED = 'OPERATOR_UNSPECIFIED'
+    LESS_THAN = 'LESS_THAN'
+    LESS_THAN_OR_EQUAL = 'LESS_THAN_OR_EQUAL'
+    GREATER_THAN = 'GREATER_THAN'
+    GREATER_THAN_OR_EQUAL = 'GREATER_THAN_OR_EQUAL'
+    EQUAL = 'EQUAL'
+    HAS_ANCESTOR = 'HAS_ANCESTOR'
+
+
 class ResultType(enum.Enum):
     FULL = 'FULL'
     KEY_ONLY = 'KEY_ONLY'
@@ -53,7 +68,7 @@ TYPES = {
     float: TypeName.DOUBLE,
     int: TypeName.INTEGER,
     str: TypeName.STRING,
-    type(False): TypeName.BOOLEAN,
+    bool: TypeName.BOOLEAN,
     type(None): TypeName.NULL,
 }
 

--- a/datastore/gcloud/aio/datastore/datastore.py
+++ b/datastore/gcloud/aio/datastore/datastore.py
@@ -13,7 +13,7 @@ from gcloud.aio.datastore.constants import Mode
 from gcloud.aio.datastore.constants import Operation
 from gcloud.aio.datastore.entity import EntityResult
 from gcloud.aio.datastore.key import Key
-from gcloud.aio.datastore.query import GQLQuery
+from gcloud.aio.datastore.query import BaseQuery
 from gcloud.aio.datastore.query import QueryResultBatch
 from gcloud.aio.datastore.utils import make_value
 try:
@@ -283,8 +283,7 @@ class Datastore:
         resp.raise_for_status()
 
     # https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects/runQuery
-    # TODO: support non-GQL queries
-    async def runQuery(self, query: GQLQuery, transaction: str = None,
+    async def runQuery(self, query: BaseQuery, transaction: str = None,
                        consistency: Consistency = Consistency.EVENTUAL,
                        session: aiohttp.ClientSession = None,
                        timeout: int = 10) -> QueryResultBatch:
@@ -300,7 +299,7 @@ class Datastore:
                 'projectId': project,
                 'namespaceId': self.namespace,
             },
-            'gqlQuery': query.to_repr(),
+            query.json_key:  query.to_repr(),
             'readOptions': options,
         }).encode('utf-8')
 

--- a/datastore/gcloud/aio/datastore/filter.py
+++ b/datastore/gcloud/aio/datastore/filter.py
@@ -13,8 +13,8 @@ class BaseFilter:
     # pylint: disable=unused-argument
     def __new__(cls, *args, **kwargs):
         if cls is BaseFilter:
-            raise TypeError('BaseFilter may not be instantiated')
-        return object.__new__(cls)
+            raise NotImplementedError('BaseFilter may not be instantiated')
+        return super().__new__(cls)
 
     def __repr__(self) -> str:
         return str(self.to_repr())
@@ -29,7 +29,7 @@ class BaseFilter:
 
 # https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects/runQuery#Filter
 class Filter:
-    def __init__(self, inner_filter: BaseFilter):
+    def __init__(self, inner_filter: BaseFilter) -> None:
         self.inner_filter = inner_filter
 
     def __repr__(self) -> str:
@@ -51,15 +51,15 @@ class Filter:
 
     def to_repr(self) -> Dict[str, Any]:
         return {
-            self.inner_filter.json_key: self.inner_filter.to_repr()
+            self.inner_filter.json_key: self.inner_filter.to_repr(),
         }
 
 
 class CompositeFilter(BaseFilter):
     json_key = 'compositeFilter'
 
-    def __init__(
-            self, operator: CompositeFilterOperator, filters: List[Filter]):
+    def __init__(self, operator: CompositeFilterOperator,
+                 filters: List[Filter]) -> None:
         self.operator = operator
         self.filters = filters
 
@@ -86,8 +86,8 @@ class CompositeFilter(BaseFilter):
 class PropertyFilter(BaseFilter):
     json_key = 'propertyFilter'
 
-    def __init__(
-            self, prop: str, operator: PropertyFilterOperator, value: Value):
+    def __init__(self, prop: str, operator: PropertyFilterOperator,
+                 value: Value) -> None:
         self.prop = prop
         self.operator = operator
         self.value = value

--- a/datastore/gcloud/aio/datastore/filter.py
+++ b/datastore/gcloud/aio/datastore/filter.py
@@ -1,0 +1,115 @@
+from typing import Any
+from typing import Dict
+from typing import List
+
+from gcloud.aio.datastore.constants import CompositeFilterOperator
+from gcloud.aio.datastore.constants import PropertyFilterOperator
+from gcloud.aio.datastore.value import Value
+
+
+class BaseFilter:
+    json_key: str
+
+    # pylint: disable=unused-argument
+    def __new__(cls, *args, **kwargs):
+        if cls is BaseFilter:
+            raise TypeError('BaseFilter may not be instantiated')
+        return object.__new__(cls)
+
+    def __repr__(self) -> str:
+        return str(self.to_repr())
+
+    @classmethod
+    def from_repr(cls, data: Dict[str, Any]) -> 'BaseFilter':
+        raise NotImplementedError
+
+    def to_repr(self) -> Dict[str, Any]:
+        raise NotImplementedError
+
+
+# https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects/runQuery#Filter
+class Filter:
+    def __init__(self, inner_filter: BaseFilter):
+        self.inner_filter = inner_filter
+
+    def __repr__(self) -> str:
+        return str(self.to_repr())
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Filter):
+            return False
+        return self.inner_filter == other.inner_filter
+
+    @classmethod
+    def from_repr(cls, data: Dict[str, Any]) -> 'Filter':
+        if 'compositeFilter' in data:
+            return cls(CompositeFilter.from_repr(data['compositeFilter']))
+        if 'propertyFilter' in data:
+            return cls(PropertyFilter.from_repr(data['propertyFilter']))
+
+        raise ValueError(f'invalid filter name: {data.keys()}')
+
+    def to_repr(self) -> Dict[str, Any]:
+        return {
+            self.inner_filter.json_key: self.inner_filter.to_repr()
+        }
+
+
+class CompositeFilter(BaseFilter):
+    json_key = 'compositeFilter'
+
+    def __init__(
+            self, operator: CompositeFilterOperator, filters: List[Filter]):
+        self.operator = operator
+        self.filters = filters
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, CompositeFilter):
+            return False
+        return bool(
+            self.operator == other.operator
+            and self.filters == other.filters)
+
+    @classmethod
+    def from_repr(cls, data: Dict[str, Any]) -> 'CompositeFilter':
+        operator = CompositeFilterOperator(data['op'])
+        filters = [Filter.from_repr(f) for f in data['filters']]
+        return cls(operator=operator, filters=filters)
+
+    def to_repr(self) -> Dict[str, Any]:
+        return {
+            'op': self.operator.value,
+            'filters': [f.to_repr() for f in self.filters],
+        }
+
+
+class PropertyFilter(BaseFilter):
+    json_key = 'propertyFilter'
+
+    def __init__(
+            self, prop: str, operator: PropertyFilterOperator, value: Value):
+        self.prop = prop
+        self.operator = operator
+        self.value = value
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, PropertyFilter):
+            return False
+        return bool(
+            self.prop == other.prop
+            and self.operator == other.operator
+            and self.value == other.value)
+
+    @classmethod
+    def from_repr(cls, data: Dict[str, Any]) -> 'PropertyFilter':
+        prop = data['property']['name']
+        operator = PropertyFilterOperator(data['op'])
+        value = Value.from_repr(data['value'])
+        return cls(prop, operator, value)
+
+    def to_repr(self) -> Dict[str, Any]:
+        return {
+            'property': {'name': self.prop},
+            'op': self.operator.value,
+            'value': self.value.to_repr(),
+        }

--- a/datastore/gcloud/aio/datastore/filter.py
+++ b/datastore/gcloud/aio/datastore/filter.py
@@ -10,12 +10,6 @@ from gcloud.aio.datastore.value import Value
 class BaseFilter:
     json_key: str
 
-    # pylint: disable=unused-argument
-    def __new__(cls, *args, **kwargs):
-        if cls is BaseFilter:
-            raise NotImplementedError('BaseFilter may not be instantiated')
-        return super().__new__(cls)
-
     def __repr__(self) -> str:
         return str(self.to_repr())
 

--- a/datastore/gcloud/aio/datastore/query.py
+++ b/datastore/gcloud/aio/datastore/query.py
@@ -13,12 +13,6 @@ from gcloud.aio.datastore.utils import parse_value
 class BaseQuery:
     json_key: str
 
-    # pylint: disable=unused-argument
-    def __new__(cls, *args, **kwargs):
-        if cls is BaseQuery:
-            raise TypeError('BaseQuery may not be instantiated')
-        return object.__new__(cls)
-
     def __repr__(self) -> str:
         return str(self.to_repr())
 

--- a/datastore/gcloud/aio/datastore/query.py
+++ b/datastore/gcloud/aio/datastore/query.py
@@ -11,7 +11,7 @@ from gcloud.aio.datastore.utils import parse_value
 
 
 class BaseQuery:
-    json_key = ''
+    json_key: str
 
     # pylint: disable=unused-argument
     def __new__(cls, *args, **kwargs):
@@ -34,7 +34,7 @@ class BaseQuery:
 class Query(BaseQuery):
     json_key = 'query'
 
-    def __init__(self, kind: str = '', query_filter: Filter = None):
+    def __init__(self, kind: str = '', query_filter: Filter = None) -> None:
         self.kind = kind
         self.query_filter = query_filter
 

--- a/datastore/gcloud/aio/datastore/value.py
+++ b/datastore/gcloud/aio/datastore/value.py
@@ -7,7 +7,7 @@ from gcloud.aio.datastore.constants import TYPES
 
 # https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects/runQuery#value
 class Value:
-    def __init__(self, value: Any, exclude_from_indexes: bool = False):
+    def __init__(self, value: Any, exclude_from_indexes: bool = False) -> None:
         self.value = value
         self.excludeFromIndexes = exclude_from_indexes
 

--- a/datastore/gcloud/aio/datastore/value.py
+++ b/datastore/gcloud/aio/datastore/value.py
@@ -1,0 +1,55 @@
+from datetime import datetime
+from typing import Any
+from typing import Dict
+
+from gcloud.aio.datastore.constants import TYPES
+
+
+# https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects/runQuery#value
+class Value:
+    def __init__(self, value: Any, exclude_from_indexes: bool = False):
+        self.value = value
+        self.excludeFromIndexes = exclude_from_indexes
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Value):
+            return False
+        return bool(
+            self.excludeFromIndexes == other.excludeFromIndexes
+            and self.value == other.value)
+
+    def __repr__(self) -> str:
+        return str(self.to_repr())
+
+    @classmethod
+    def from_repr(cls, data: Dict[str, Any]) -> 'Value':
+        for value_type, type_name in TYPES.items():
+            json_key = type_name.value
+            if json_key in data:
+                if json_key == 'nullValue':
+                    value = None
+                elif value_type == datetime:  # No parsing needed
+                    value = data[json_key]
+                else:
+                    value = value_type(data[json_key])
+                break
+        else:
+            supported_types = [type_name.value for type_name in TYPES.values()]
+            raise NotImplementedError(
+                f'{data.keys()} does not contain a supported value type'
+                f' (any of: {supported_types})')
+
+        exclude_from_indexes = bool(data['excludeFromIndexes'])
+
+        return cls(value=value, exclude_from_indexes=exclude_from_indexes)
+
+    def to_repr(self) -> Dict[str, Any]:
+        value_type = type(self.value)
+        if value_type not in TYPES:
+            raise NotImplementedError(
+                f"Type '{value_type}' is not supported by the Value type")
+
+        return {
+            'excludeFromIndexes': self.excludeFromIndexes,
+            TYPES[value_type].value: self.value or 'NULL_VALUE',
+        }

--- a/datastore/tests/unit/filter_test.py
+++ b/datastore/tests/unit/filter_test.py
@@ -1,0 +1,173 @@
+from typing import Any
+from typing import Dict
+from typing import List
+
+import pytest
+from gcloud.aio.datastore import CompositeFilter
+from gcloud.aio.datastore import CompositeFilterOperator
+from gcloud.aio.datastore import Filter
+from gcloud.aio.datastore import PropertyFilter
+from gcloud.aio.datastore import PropertyFilterOperator
+from gcloud.aio.datastore import Value
+
+
+class TestFilter:
+
+    @staticmethod
+    def test_property_filter_from_repr(property_filters):
+        original_filter = property_filters[0]
+        data = {
+            'property': {
+                'name': original_filter.prop
+            },
+            'op': original_filter.operator,
+            'value': original_filter.value.to_repr()
+        }
+
+        output_filter = PropertyFilter.from_repr(data)
+
+        assert output_filter == original_filter
+
+    def test_property_filter_to_repr(self, property_filters):
+        property_filter = property_filters[0]
+        query_filter = Filter(inner_filter=property_filter)
+
+        r = query_filter.to_repr()
+
+        self._assert_is_correct_prop_dict_for_property_filter(
+            r['propertyFilter'], property_filter)
+
+    @staticmethod
+    def test_composite_filter_from_repr(property_filters):
+        original_filter = CompositeFilter(
+            operator=CompositeFilterOperator.AND,
+            filters=[
+                Filter(property_filters[0]),
+                Filter(property_filters[1])
+            ])
+        data = {
+            'op': original_filter.operator,
+            'filters': [
+                {
+                    'propertyFilter': {
+                        'property': {
+                            'name': original_filter.filters[0].inner_filter.prop
+                        },
+                        'op': original_filter.filters[0].inner_filter.operator,
+                        'value': property_filters[0].value.to_repr()
+                    }
+                },
+                {
+                    'propertyFilter': {
+                        'property': {
+                            'name': original_filter.filters[1].inner_filter.prop
+                        },
+                        'op': original_filter.filters[1].inner_filter.operator,
+                        'value': property_filters[1].value.to_repr()
+                    }
+                },
+            ]
+        }
+
+        output_filter = CompositeFilter.from_repr(data)
+
+        assert output_filter == original_filter
+
+    def test_composite_filter_to_repr(self, property_filters):
+        composite_filter = CompositeFilter(
+            operator=CompositeFilterOperator.AND,
+            filters=[
+                Filter(property_filters[0]),
+                Filter(property_filters[1])
+            ])
+        query_filter = Filter(composite_filter)
+
+        r = query_filter.to_repr()
+
+        composite_filter_dict = r['compositeFilter']
+        assert composite_filter_dict['op'] == 'AND'
+        self._assert_is_correct_prop_dict_for_property_filter(
+            composite_filter_dict['filters'][0]['propertyFilter'],
+            property_filters[0])
+        self._assert_is_correct_prop_dict_for_property_filter(
+            composite_filter_dict['filters'][1]['propertyFilter'],
+            property_filters[1])
+
+    @staticmethod
+    def test_filter_from_repr(composite_filter):
+        original_filter = Filter(inner_filter=composite_filter)
+
+        data = {
+            'compositeFilter': original_filter.inner_filter.to_repr()
+        }
+
+        output_filter = Filter.from_repr(data)
+
+        assert output_filter == original_filter
+
+    @staticmethod
+    def test_filter_from_repr_unexpected_filter_name():
+        unexpected_filter_name = 'unexpectedFilterName'
+        data = {
+            unexpected_filter_name: 'DoesNotMatter'
+        }
+
+        with pytest.raises(ValueError) as ex_info:
+            Filter.from_repr(data)
+
+        assert unexpected_filter_name in ex_info.value.args[0]
+
+    @staticmethod
+    def test_filter_to_repr(composite_filter):
+        test_filter = Filter(inner_filter=composite_filter)
+
+        r = test_filter.to_repr()
+
+        assert r['compositeFilter'] == test_filter.inner_filter.to_repr()
+
+    @staticmethod
+    def test_repr_returns_to_repr_as_string(query_filter):
+        assert repr(query_filter) == str(query_filter.to_repr())
+
+    @staticmethod
+    @pytest.fixture()
+    def property_filters() -> List[PropertyFilter]:
+        return [
+            PropertyFilter(
+                prop='prop1',
+                operator=PropertyFilterOperator.LESS_THAN,
+                value=Value('value1')
+            ),
+            PropertyFilter(
+                prop='prop2',
+                operator=PropertyFilterOperator.GREATER_THAN,
+                value=Value(1234)
+            )
+        ]
+
+    @staticmethod
+    @pytest.fixture()
+    def composite_filter(property_filters) -> CompositeFilter:
+        return CompositeFilter(
+            operator=CompositeFilterOperator.AND,
+            filters=[
+                Filter(property_filters[0]),
+                Filter(property_filters[1])
+            ])
+
+    @staticmethod
+    @pytest.fixture()
+    def query_filter(composite_filter) -> Filter:
+        return Filter(inner_filter=composite_filter)
+
+    @staticmethod
+    @pytest.fixture()
+    def value() -> Value:
+        return Value('value')
+
+    @staticmethod
+    def _assert_is_correct_prop_dict_for_property_filter(
+            prop_dict: Dict[str, Any], property_filter: PropertyFilter):
+        assert prop_dict['property']['name'] == property_filter.prop
+        assert prop_dict['op'] == property_filter.operator.value
+        assert prop_dict['value'] == property_filter.value.to_repr()

--- a/datastore/tests/unit/query_test.py
+++ b/datastore/tests/unit/query_test.py
@@ -1,0 +1,78 @@
+import pytest
+from gcloud.aio.datastore import Filter
+from gcloud.aio.datastore import PropertyFilter
+from gcloud.aio.datastore import PropertyFilterOperator
+from gcloud.aio.datastore import Query
+from gcloud.aio.datastore import Value
+
+
+class TestQuery:
+
+    @staticmethod
+    def test_from_repr(query):
+        original_query = query
+        data = {
+            'kind': original_query.kind,
+            'filter': original_query.query_filter.to_repr()
+        }
+
+        output_query = Query.from_repr(data)
+
+        assert output_query == original_query
+
+    @staticmethod
+    def test_from_repr_query_without_kind(query_filter):
+        original_query = Query(kind='', query_filter=query_filter)
+        data = {
+            'kind': [],
+            'filter': original_query.query_filter.to_repr()
+        }
+
+        output_query = Query.from_repr(data)
+
+        assert output_query == original_query
+
+    @staticmethod
+    def test_to_repr_simple_query():
+        kind = 'foo'
+        query = Query(kind)
+
+        r = query.to_repr()
+
+        assert len(r['kind']) == 1
+        assert r['kind'][0]['name'] == kind
+
+    @staticmethod
+    def test_to_repr_query_without_kind():
+        query = Query()
+
+        r = query.to_repr()
+
+        assert not r['kind']
+
+    @staticmethod
+    def test_to_repr_query_with_filter(query_filter):
+        property_filter = query_filter
+        query = Query('foo', property_filter)
+
+        r = query.to_repr()
+
+        assert r['filter'] == property_filter.to_repr()
+
+    @staticmethod
+    def test_repr_returns_to_repr_as_string(query):
+        assert repr(query) == str(query.to_repr())
+
+    @staticmethod
+    @pytest.fixture()
+    def query(query_filter) -> Query:
+        return Query('query_kind', query_filter)
+
+    @staticmethod
+    @pytest.fixture()
+    def query_filter() -> Filter:
+        inner_filter = PropertyFilter(
+            prop='property_name',
+            operator=PropertyFilterOperator.EQUAL,
+            value=Value(123))
+        return Filter(inner_filter)

--- a/datastore/tests/unit/value_test.py
+++ b/datastore/tests/unit/value_test.py
@@ -1,0 +1,104 @@
+from datetime import datetime
+
+import pytest
+from gcloud.aio.datastore import Value
+
+
+class TestValue:
+
+    @staticmethod
+    @pytest.mark.parametrize('json_key,json_value', [
+        ('blobValue', bytes('foobar', 'utf-8')),
+        ('booleanValue', True),
+        ('doubleValue', 34.48),
+        ('integerValue', 8483),
+        ('stringValue', 'foobar'),
+        ('timestampValue', datetime(year=1998, month=7, day=12)),
+    ])
+    def test_from_repr(json_key, json_value):
+        data = {
+            'excludeFromIndexes': False,
+            json_key: json_value
+        }
+
+        value = Value.from_repr(data)
+
+        assert value.excludeFromIndexes is False
+        assert value.value == json_value
+
+    @staticmethod
+    def test_from_repr_with_null_value():
+        data = {
+            'excludeFromIndexes': False,
+            'nullValue': 'NULL_VALUE'
+        }
+
+        value = Value.from_repr(data)
+
+        assert value.excludeFromIndexes is False
+        assert value.value is None
+
+    @staticmethod
+    def test_from_repr_could_not_find_supported_value_key():
+        data = {
+            'excludeFromIndexes': False,
+        }
+
+        with pytest.raises(NotImplementedError) as ex_info:
+            Value.from_repr(data)
+
+        assert 'excludeFromIndexes' in ex_info.value.args[0]
+
+    @staticmethod
+    @pytest.mark.parametrize('v,expected_json_key', [
+        (bytes('foobar', 'utf-8'), 'blobValue'),
+        (True, 'booleanValue'),
+        (34.48, 'doubleValue'),
+        (8483, 'integerValue'),
+        ('foobar', 'stringValue'),
+        (datetime(year=2018, month=7, day=15), 'timestampValue'),
+    ])
+    def test_to_repr(v, expected_json_key):
+        value = Value(v)
+
+        r = value.to_repr()
+
+        assert len(r) == 2  # Value + excludeFromIndexes
+        assert r['excludeFromIndexes'] is False
+        assert r[expected_json_key] == v
+
+    @staticmethod
+    def test_to_repr_with_null_value():
+        value = Value(None)
+
+        r = value.to_repr()
+
+        assert r['nullValue'] == 'NULL_VALUE'
+
+    @staticmethod
+    def test_to_repr_exclude_from_indexes():
+        value = Value(123, exclude_from_indexes=True)
+
+        r = value.to_repr()
+
+        assert r['excludeFromIndexes']
+
+    @staticmethod
+    def test_to_repr_non_supported_type():
+        class NonSupportedType:
+            pass
+        value = Value(NonSupportedType())
+
+        with pytest.raises(NotImplementedError) as ex_info:
+            value.to_repr()
+
+        assert NonSupportedType.__name__ in ex_info.value.args[0]
+
+    @staticmethod
+    def test_repr_returns_to_repr_as_string(value):
+        assert repr(value) == str(value.to_repr())
+
+    @staticmethod
+    @pytest.fixture()
+    def value() -> Value:
+        return Value(value='foobar', exclude_from_indexes=False)


### PR DESCRIPTION
Add support for non-GQL queries

I realized after rebasing that it would have been better to add commits to the previous code review and squash at the end, just before merging. Sorry about that. It's not obvious but I addressed your comments from #69 and added a smoke test and a documentation example for the queries.