### PR TITLE
fix(datastore): Value.to_repr fix for False-like values

### DIFF
--- a/datastore/gcloud/aio/datastore/value.py
+++ b/datastore/gcloud/aio/datastore/value.py
@@ -61,7 +61,7 @@ class Value:
         elif value_type == TypeName.TIMESTAMP:
             value = self.value.strftime('%Y-%m-%dT%H:%M:%S.%f000Z')
         else:
-            value = self.value or 'NULL_VALUE'
+            value = 'NULL_VALUE' if self.value is None else self.value
         return {
             'excludeFromIndexes': self.excludeFromIndexes,
             value_type.value: value,

--- a/datastore/tests/unit/value_test.py
+++ b/datastore/tests/unit/value_test.py
@@ -14,6 +14,11 @@ class TestValue:
         ('doubleValue', 34.48),
         ('integerValue', 8483),
         ('stringValue', 'foobar'),
+        ('blobValue', b''),
+        ('booleanValue', False),
+        ('doubleValue', 0.0),
+        ('integerValue', 0),
+        ('stringValue', ''),
     ])
     def test_from_repr(json_key, json_value):
         data = {
@@ -80,6 +85,11 @@ class TestValue:
         (34.48, 'doubleValue'),
         (8483, 'integerValue'),
         ('foobar', 'stringValue'),
+        (b'', 'blobValue'),
+        (False, 'booleanValue'),
+        (0.0, 'doubleValue'),
+        (0, 'integerValue'),
+        ('', 'stringValue'),
     ])
     def test_to_repr(v, expected_json_key):
         value = Value(v)


### PR DESCRIPTION
Evaluate value to 'NULL_VALUE' only when it's None, all other
false-like values will be evaluated as is.