### PR TITLE
fix(pubsub): fix kwargs expansion syntax in create_subscription

### DIFF
--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -36,7 +36,7 @@ class SubscriberClient:
             self._subscriber.create_subscription(
                 subscription,
                 topic,
-                *kwargs
+                **kwargs
             )
         except exceptions.AlreadyExists:
             pass

--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as f:
 
 setuptools.setup(
     name='gcloud-aio-pubsub',
-    version='1.0.0',
+    version='1.0.1',
     description='Asyncio Python Client for Google Cloud Pub/Sub',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
### In this PR:
- fix `kwargs` expansion (must use `**kwargs` not `*kwargs`)
- bump pubsub release to `1.0.1`

I believe due to broken tests this will require a manual merge by @TheKevJames 