### PR TITLE
Allow service data to be passed directly to a token or an API

### DIFF
--- a/auth/gcloud/aio/auth/iam.py
+++ b/auth/gcloud/aio/auth/iam.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -18,10 +19,12 @@ SCOPES = ['https://www.googleapis.com/auth/iam']
 
 class IamClient:
     def __init__(self, service_file: Optional[str] = None,
+                 service_data: Optional[Dict[str, Any]] = None,
                  session: Optional[aiohttp.ClientSession] = None,
                  token: Optional[Token] = None) -> None:
         self.session = session
         self.token = token or Token(service_file=service_file,
+                                    service_data=service_data,
                                     session=session, scopes=SCOPES)
 
         if self.token.token_type != Type.SERVICE_ACCOUNT:

--- a/auth/gcloud/aio/auth/token.py
+++ b/auth/gcloud/aio/auth/token.py
@@ -63,18 +63,25 @@ def get_service_data(service: Optional[str]) -> Dict[str, Any]:
 class Token:
     # pylint: disable=too-many-instance-attributes
     def __init__(self, service_file: Optional[str] = None,
+                 service_data: Optional[Dict[str, Any]] = None,
                  session: aiohttp.ClientSession = None,
                  scopes: List[str] = None) -> None:
-        self.service_data = get_service_data(service_file)
-        if self.service_data:
+        if service_data is not None:
+            self.service_data = service_data
             self.token_type = Type(self.service_data['type'])
             self.token_uri = self.service_data.get(
                 'token_uri', 'https://oauth2.googleapis.com/token')
-        else:
-            # At this point, all we can do is assume we're running somewhere
-            # with default credentials, eg. GCE.
-            self.token_type = Type.GCE_METADATA
-            self.token_uri = GCE_ENDPOINT_TOKEN
+        elif service_file is not None:
+            self.service_data = get_service_data(service_file)
+            if self.service_data:
+                self.token_type = Type(self.service_data['type'])
+                self.token_uri = self.service_data.get(
+                    'token_uri', 'https://oauth2.googleapis.com/token')
+            else:
+                # At this point, all we can do is assume we're running
+                # somewhere with default credentials, eg. GCE.
+                self.token_type = Type.GCE_METADATA
+                self.token_uri = GCE_ENDPOINT_TOKEN
 
         self.session = session
         self.scopes = ' '.join(scopes or [])

--- a/auth/gcloud/aio/auth/token.py
+++ b/auth/gcloud/aio/auth/token.py
@@ -71,7 +71,7 @@ class Token:
             self.token_type = Type(self.service_data['type'])
             self.token_uri = self.service_data.get(
                 'token_uri', 'https://oauth2.googleapis.com/token')
-        elif service_file is not None:
+        else:
             self.service_data = get_service_data(service_file)
             if self.service_data:
                 self.token_type = Type(self.service_data['type'])

--- a/bigquery/gcloud/aio/bigquery/bigquery.py
+++ b/bigquery/gcloud/aio/bigquery/bigquery.py
@@ -22,6 +22,7 @@ class Table:
     def __init__(self, dataset_name: str, table_name: str,
                  project: Optional[str] = None,
                  service_file: Optional[str] = None,
+                 service_data: Optional[Dict[str, Any]] = None,
                  session: Optional[aiohttp.ClientSession] = None,
                  token: Optional[Token] = None) -> None:
         self._project = project
@@ -30,7 +31,7 @@ class Table:
 
         self.session = session
         self.token = token or Token(service_file=service_file, session=session,
-                                    scopes=SCOPES)
+                                    service_data=service_data, scopes=SCOPES)
 
     async def project(self) -> str:
         if self._project:

--- a/datastore/gcloud/aio/datastore/datastore.py
+++ b/datastore/gcloud/aio/datastore/datastore.py
@@ -46,7 +46,9 @@ class Datastore:
     value_kind = Value
 
     def __init__(self, project: Optional[str] = None,
-                 service_file: Optional[str] = None, namespace: str = '',
+                 service_file: Optional[str] = None,
+                 service_data: Optional[Dict[str, Any]] = None,
+                 namespace: str = '',
                  session: Optional[aiohttp.ClientSession] = None,
                  token: Optional[Token] = None) -> None:
         self.namespace = namespace
@@ -59,6 +61,7 @@ class Datastore:
         else:
             self._project = project
             self.token = token or Token(service_file=service_file,
+                                        service_data=service_data,
                                         session=session, scopes=SCOPES)
 
     async def project(self) -> str:

--- a/kms/gcloud/aio/kms/kms.py
+++ b/kms/gcloud/aio/kms/kms.py
@@ -1,6 +1,7 @@
 """
 An asynchronous client for Google Cloud KMS
 """
+from typing import Any
 from typing import Dict
 from typing import Optional
 
@@ -17,7 +18,9 @@ SCOPES = [
 
 class KMS:
     def __init__(self, keyproject: str, keyring: str, keyname: str,
-                 service_file: Optional[str] = None, location: str = LOCATION,
+                 service_file: Optional[str] = None,
+                 service_data: Optional[Dict[str, Any]] = None,
+                 location: str = LOCATION,
                  session: Optional[aiohttp.ClientSession] = None,
                  token: Optional[Token] = None) -> None:
         self.api_root = (f'{API_ROOT}/projects/{keyproject}/'
@@ -26,6 +29,7 @@ class KMS:
 
         self.session = session
         self.token = token or Token(service_file=service_file, scopes=SCOPES,
+                                    service_data=service_data,
                                     session=self.session)
 
     async def headers(self) -> Dict[str, str]:

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -7,6 +7,7 @@ import os
 from typing import Any
 from typing import Optional
 from typing import Tuple
+from typing import Dict
 from urllib.parse import quote
 
 import aiohttp
@@ -37,10 +38,12 @@ class UploadType(enum.Enum):
 
 class Storage:
     def __init__(self, *, service_file: Optional[str] = None,
+                 service_data: Optional[Dict[str, Any]] = None,
                  token: Optional[Token] = None,
                  session: Optional[aiohttp.ClientSession] = None) -> None:
         self.session = session
         self.token = token or Token(service_file=service_file,
+                                    service_data=service_data,
                                     session=self.session, scopes=SCOPES)
 
     def get_bucket(self, bucket_name: str) -> Bucket:

--- a/taskqueue/gcloud/aio/taskqueue/queue.py
+++ b/taskqueue/gcloud/aio/taskqueue/queue.py
@@ -22,14 +22,17 @@ log = logging.getLogger(__name__)
 
 class PushQueue:
     def __init__(self, project: str, taskqueue: str,
-                 service_file: Optional[str] = None, location: str = LOCATION,
+                 service_file: Optional[str] = None,
+                 service_data: Optional[Dict[str, Any]] = None,
+                 location: str = LOCATION,
                  session: Optional[aiohttp.ClientSession] = None,
                  token: Optional[Token] = None) -> None:
         self.base_api_root = f'{API_ROOT}/v2beta3'
         self.api_root = (f'{self.base_api_root}/projects/{project}/'
                          f'locations/{location}/queues/{taskqueue}')
         self.session = session
-        self.token = token or Token(service_file=service_file, scopes=SCOPES,
+        self.token = token or Token(service_file=service_file,
+                                    service_data=service_data, scopes=SCOPES,
                                     session=self.session)
 
     async def headers(self) -> Dict[str, str]:


### PR DESCRIPTION
This PR adds the ability to call `Token` or any API with `service_data` instead of just `service_file`. It is useful when one already has the service data in memory as a dictionary and not in a file.

Fixes #92.