### PR TITLE
Allow service_file to be an io.IOBase instance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
         args: [--allow-multiple-documents]
     -   id: debug-statements
     -   id: detect-private-key
+        exclude: auth/tests/unit/token_test.py
     -   id: double-quote-string-fixer
     -   id: end-of-file-fixer
     -   id: file-contents-sorter

--- a/auth/README.rst
+++ b/auth/README.rst
@@ -32,7 +32,9 @@ Additionally, the ``Token`` constructor accepts the following optional
 arguments:
 
 * ``service_file``: path to a `service account`_, authorized user file, or any
-  other application credentials. If omitted, will attempt to find one on your
+  other application credentials. Alternatively, you can pass a file-like
+  object, like an ``io.StringIO`` instance, in case your credentials are not
+  stored in a file but in memory. If omitted, will attempt to find one on your
   path or fallback to generating a token from GCE metadata.
 * ``session``: an ``aiohttp.ClientSession`` instance to be used for all
   requests. If omitted, a default session will be created.

--- a/auth/gcloud/aio/auth/iam.py
+++ b/auth/gcloud/aio/auth/iam.py
@@ -1,3 +1,4 @@
+import io
 import json
 from typing import Dict
 from typing import List
@@ -17,7 +18,7 @@ SCOPES = ['https://www.googleapis.com/auth/iam']
 
 
 class IamClient:
-    def __init__(self, service_file: Optional[str] = None,
+    def __init__(self, service_file: Optional[Union[str, io.IOBase]] = None,
                  session: Optional[aiohttp.ClientSession] = None,
                  token: Optional[Token] = None) -> None:
         self.session = session

--- a/auth/gcloud/aio/auth/token.py
+++ b/auth/gcloud/aio/auth/token.py
@@ -11,8 +11,8 @@ import time
 from typing import Any
 from typing import Dict
 from typing import List
-from typing import Union
 from typing import Optional
+from typing import Union
 from urllib.parse import quote_plus
 from urllib.parse import urlencode
 

--- a/auth/gcloud/aio/auth/token.py
+++ b/auth/gcloud/aio/auth/token.py
@@ -4,12 +4,14 @@ Google Cloud auth via service account file
 import asyncio
 import datetime
 import enum
+import io
 import json
 import os
 import time
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Union
 from typing import Optional
 from urllib.parse import quote_plus
 from urllib.parse import urlencode
@@ -34,7 +36,7 @@ class Type(enum.Enum):
     SERVICE_ACCOUNT = 'service_account'
 
 
-def get_service_data(service: Optional[str]) -> Dict[str, Any]:
+def get_service_data(service: Optional[Union[str, io.IOBase]]) -> Dict[str, Any]:
     service = service or os.environ.get('GOOGLE_APPLICATION_CREDENTIALS')
     if not service:
         cloudsdk_config = os.environ.get('CLOUDSDK_CONFIG')
@@ -56,13 +58,16 @@ def get_service_data(service: Optional[str]) -> Dict[str, Any]:
             raise
 
         return {}
+    except TypeError:
+        data: Dict[str, Any] = json.loads(service.read())
+        return data
     except Exception:  # pylint: disable=broad-except
         return {}
 
 
 class Token:
     # pylint: disable=too-many-instance-attributes
-    def __init__(self, service_file: Optional[str] = None,
+    def __init__(self, service_file: Optional[Union[str, io.IOBase]] = None,
                  session: aiohttp.ClientSession = None,
                  scopes: List[str] = None) -> None:
         self.service_data = get_service_data(service_file)

--- a/auth/gcloud/aio/auth/token.py
+++ b/auth/gcloud/aio/auth/token.py
@@ -50,8 +50,12 @@ def get_service_data(
         set_explicitly = True
 
     try:
-        with open(service, 'r') as f:
-            data: Dict[str, Any] = json.loads(f.read())
+        try:
+            with open(service, 'r') as f:
+                data: Dict[str, Any] = json.loads(f.read())
+                return data
+        except TypeError:
+            data: Dict[str, Any] = json.loads(service.read())
             return data
     except FileNotFoundError:
         if set_explicitly:
@@ -59,9 +63,6 @@ def get_service_data(
             raise
 
         return {}
-    except TypeError:
-        data: Dict[str, Any] = json.loads(service.read())
-        return data
     except Exception:  # pylint: disable=broad-except
         return {}
 

--- a/auth/gcloud/aio/auth/token.py
+++ b/auth/gcloud/aio/auth/token.py
@@ -36,7 +36,8 @@ class Type(enum.Enum):
     SERVICE_ACCOUNT = 'service_account'
 
 
-def get_service_data(service: Optional[Union[str, io.IOBase]]) -> Dict[str, Any]:
+def get_service_data(
+        service: Optional[Union[str, io.IOBase]]) -> Dict[str, Any]:
     service = service or os.environ.get('GOOGLE_APPLICATION_CREDENTIALS')
     if not service:
         cloudsdk_config = os.environ.get('CLOUDSDK_CONFIG')

--- a/auth/noxfile.py
+++ b/auth/noxfile.py
@@ -5,7 +5,7 @@ import nox
 
 @nox.session(python=['3.6', '3.7'], reuse_venv=True)
 def unit_tests(session):
-    session.install('pytest', 'pytest-cov')
+    session.install('pytest', 'pytest-asyncio', 'pytest-cov')
     session.install('-e', '.')
 
     session.run('py.test', '--quiet', '--cov=gcloud.aio.auth',

--- a/auth/tests/unit/token_test.py
+++ b/auth/tests/unit/token_test.py
@@ -12,17 +12,18 @@ def test_importable():
 
 @pytest.mark.asyncio
 async def test_service_as_io():
+    # pylint: disable=line-too-long
     service_data = {
-      'type': 'service_account',
-      'project_id': 'random-project-123',
-      'private_key_id': '399asdfsdf92923k32423a9f9sdf',
-      'private_key': '-----BEGIN PRIVATE KEY-----\nABCDF012923949394239492349234923==\n-----END PRIVATE KEY-----\n',
-      'client_email': 'gcloud-aio-test@random-project-123.iam.gserviceaccount.com',
-      'client_id': '2384283429349234293',
-      'auth_uri': 'https://accounts.google.com/o/oauth2/auth',
-      'token_uri': 'https://oauth2.googleapis.com/token',
-      'auth_provider_x509_cert_url': 'https://www.googleapis.com/oauth2/v1/certs',
-      'client_x509_cert_url': 'https://www.googleapis.com/robot/v1/metadata/x509/gcloud-aio%40random-project-123.iam.gserviceaccount.com'
+        'type': 'service_account',
+        'project_id': 'random-project-123',
+        'private_key_id': '399asdfsdf92923k32423a9f9sdf',
+        'private_key': '-----BEGIN PRIVATE KEY-----\nABCDF012923949394239492349234923==\n-----END PRIVATE KEY-----\n',
+        'client_email': 'gcloud-aio-test@random-project-123.iam.gserviceaccount.com',
+        'client_id': '2384283429349234293',
+        'auth_uri': 'https://accounts.google.com/o/oauth2/auth',
+        'token_uri': 'https://oauth2.googleapis.com/token',
+        'auth_provider_x509_cert_url': 'https://www.googleapis.com/oauth2/v1/certs',
+        'client_x509_cert_url': 'https://www.googleapis.com/robot/v1/metadata/x509/gcloud-aio%40random-project-123.iam.gserviceaccount.com'
     }
     service_file = io.StringIO(json.dumps(service_data))
     t = token.Token(service_file=service_file,

--- a/auth/tests/unit/token_test.py
+++ b/auth/tests/unit/token_test.py
@@ -1,5 +1,33 @@
-import gcloud.aio.auth.token as token  # pylint: disable=unused-import
+import io
+import json
+
+import gcloud.aio.auth.token as token
+
+import pytest
 
 
 def test_importable():
     assert True
+
+
+@pytest.mark.asyncio
+async def test_service_as_io():
+    service_data = {
+      'type': 'service_account',
+      'project_id': 'random-project-123',
+      'private_key_id': '399asdfsdf92923k32423a9f9sdf',
+      'private_key': '-----BEGIN PRIVATE KEY-----\nABCDF012923949394239492349234923==\n-----END PRIVATE KEY-----\n',
+      'client_email': 'gcloud-aio-test@random-project-123.iam.gserviceaccount.com',
+      'client_id': '2384283429349234293',
+      'auth_uri': 'https://accounts.google.com/o/oauth2/auth',
+      'token_uri': 'https://oauth2.googleapis.com/token',
+      'auth_provider_x509_cert_url': 'https://www.googleapis.com/oauth2/v1/certs',
+      'client_x509_cert_url': 'https://www.googleapis.com/robot/v1/metadata/x509/gcloud-aio%40random-project-123.iam.gserviceaccount.com'
+    }
+    service_file = io.StringIO(json.dumps(service_data))
+    t = token.Token(service_file=service_file,
+                    scopes=['https://google.com/random-scope'])
+
+    assert t.token_type == token.Type.SERVICE_ACCOUNT
+    assert t.token_uri == 'https://oauth2.googleapis.com/token'
+    assert await t.get_project() == 'random-project-123'

--- a/auth/tests/unit/token_test.py
+++ b/auth/tests/unit/token_test.py
@@ -2,7 +2,6 @@ import io
 import json
 
 import gcloud.aio.auth.token as token
-
 import pytest
 
 

--- a/bigquery/gcloud/aio/bigquery/bigquery.py
+++ b/bigquery/gcloud/aio/bigquery/bigquery.py
@@ -1,8 +1,10 @@
+import io
 import uuid
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Union
 
 import aiohttp
 from gcloud.aio.auth import Token  # pylint: disable=no-name-in-module
@@ -21,7 +23,7 @@ SCOPES = [
 class Table:
     def __init__(self, dataset_name: str, table_name: str,
                  project: Optional[str] = None,
-                 service_file: Optional[str] = None,
+                 service_file: Optional[Union[str, io.IOBase]] = None,
                  session: Optional[aiohttp.ClientSession] = None,
                  token: Optional[Token] = None) -> None:
         self._project = project

--- a/datastore/gcloud/aio/datastore/datastore.py
+++ b/datastore/gcloud/aio/datastore/datastore.py
@@ -1,3 +1,4 @@
+import io
 import logging
 import os
 from typing import Any
@@ -46,7 +47,8 @@ class Datastore:
     value_kind = Value
 
     def __init__(self, project: Optional[str] = None,
-                 service_file: Optional[str] = None, namespace: str = '',
+                 service_file: Optional[Union[str, io.IOBase]] = None,
+                 namespace: str = '',
                  session: Optional[aiohttp.ClientSession] = None,
                  token: Optional[Token] = None) -> None:
         self.namespace = namespace

--- a/kms/gcloud/aio/kms/kms.py
+++ b/kms/gcloud/aio/kms/kms.py
@@ -1,8 +1,10 @@
 """
 An asynchronous client for Google Cloud KMS
 """
+import io
 from typing import Dict
 from typing import Optional
+from typing import Union
 
 import aiohttp
 from gcloud.aio.auth import Token  # pylint: disable=no-name-in-module
@@ -17,7 +19,8 @@ SCOPES = [
 
 class KMS:
     def __init__(self, keyproject: str, keyring: str, keyname: str,
-                 service_file: Optional[str] = None, location: str = LOCATION,
+                 service_file: Optional[Union[str, io.IOBase]] = None,
+                 location: str = LOCATION,
                  session: Optional[aiohttp.ClientSession] = None,
                  token: Optional[Token] = None) -> None:
         self.api_root = (f'{API_ROOT}/projects/{keyproject}/'

--- a/storage/gcloud/aio/storage/blob.py
+++ b/storage/gcloud/aio/storage/blob.py
@@ -2,8 +2,10 @@ import binascii
 import collections
 import datetime
 import hashlib
+import io
 from typing import Any
 from typing import Optional
+from typing import Union
 from urllib.parse import quote
 
 import aiohttp
@@ -44,7 +46,8 @@ class Blob:
             query_params: Optional[dict] = None, http_method: str = 'GET',
             iam_client: Optional[IamClient] = None,
             service_account_email: Optional[str] = None,
-            service_file: Optional[str] = None, token: Optional[Token] = None,
+            service_file: Optional[Union[str, io.IOBase]] = None,
+            token: Optional[Token] = None,
             session: Optional[aiohttp.ClientSession] = None) -> str:
         """
         Create a temporary access URL for Storage Blob accessible by anyone

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -7,6 +7,7 @@ import os
 from typing import Any
 from typing import Optional
 from typing import Tuple
+from typing import Union
 from urllib.parse import quote
 
 import aiohttp
@@ -36,7 +37,7 @@ class UploadType(enum.Enum):
 
 
 class Storage:
-    def __init__(self, *, service_file: Optional[str] = None,
+    def __init__(self, *, service_file: Optional[Union[str, io.IOBase]] = None,
                  token: Optional[Token] = None,
                  session: Optional[aiohttp.ClientSession] = None) -> None:
         self.session = session

--- a/taskqueue/gcloud/aio/taskqueue/queue.py
+++ b/taskqueue/gcloud/aio/taskqueue/queue.py
@@ -1,10 +1,12 @@
 """
 An asynchronous push queue for Google Appengine Task Queues
 """
+import io
 import logging
 from typing import Any
 from typing import Dict
 from typing import Optional
+from typing import Union
 
 import aiohttp
 import backoff
@@ -22,7 +24,8 @@ log = logging.getLogger(__name__)
 
 class PushQueue:
     def __init__(self, project: str, taskqueue: str,
-                 service_file: Optional[str] = None, location: str = LOCATION,
+                 service_file: Optional[Union[str, io.IOBase]] = None,
+                 location: str = LOCATION,
                  session: Optional[aiohttp.ClientSession] = None,
                  token: Optional[Token] = None) -> None:
         self.base_api_root = f'{API_ROOT}/v2beta3'


### PR DESCRIPTION
This PR allows `service_file` to be any `io.IOBase` instance, like `io.StringIO`. In general, it allows any object with a `read()` method, but I think it's best to keep the type declaration stricter. A file-like object should inherit from `io.IOBase` anyway. The README was updated to reflect this change.

Fixes #92 