### PR TITLE
Implement custom insertid for bigquery table

### DIFF
--- a/bigquery/gcloud/aio/bigquery/bigquery.py
+++ b/bigquery/gcloud/aio/bigquery/bigquery.py
@@ -1,6 +1,7 @@
 import io
 import uuid
 from typing import Any
+from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -45,15 +46,20 @@ class Table:
         raise Exception('could not determine project, please set it manually')
 
     @staticmethod
+    def _mk_unique_insert_id(row: Dict[str, Any]) -> str:
+        return uuid.uuid4().hex
+
+    @staticmethod
     def _make_insert_body(rows: List[Dict[str, Any]],
-                          skip_invalid: bool = False,
-                          ignore_unknown: bool = True) -> Dict[str, Any]:
+                          skip_invalid: bool,
+                          ignore_unknown: bool,
+                          insert_id_fn: Callable[[Dict[str, Any]], str]) -> Dict[str, Any]:
         return {
             'kind': 'bigquery#tableDataInsertAllRequest',
             'skipInvalidRows': skip_invalid,
             'ignoreUnknownValues': ignore_unknown,
             'rows': [{
-                'insertId': uuid.uuid4().hex,
+                'insertId': insert_id_fn(row),
                 'json': row
             } for row in rows],
         }
@@ -67,9 +73,13 @@ class Table:
     async def insert(self, rows: List[Dict[str, Any]],
                      skip_invalid: bool = False, ignore_unknown: bool = True,
                      session: Optional[aiohttp.ClientSession] = None,
-                     timeout: int = 60) -> Dict[str, Any]:
+                     timeout: int = 60,
+                     insert_id_fn: Callable[[Dict[str, Any]], str] = _mk_unique_insert_id) -> Dict[str, Any]:
         """
         Streams data into BigQuery
+
+        By default, each row is assigned a unique insertId, this can be customized this by 
+        supplying a insert_id_fn, taking a row an returning an insert id.
 
         The response payload will include an `insertErrors` key if a subset of
         the rows failed to get inserted.
@@ -82,7 +92,8 @@ class Table:
                f'tables/{self.table_name}/insertAll')
 
         body = self._make_insert_body(rows, skip_invalid=skip_invalid,
-                                      ignore_unknown=ignore_unknown)
+                                      ignore_unknown=ignore_unknown,
+                                      insert_id_fn=insert_id_fn)
         payload = json.dumps(body).encode('utf-8')
 
         headers = await self.headers()

--- a/bigquery/tests/unit/bigquery_test.py
+++ b/bigquery/tests/unit/bigquery_test.py
@@ -3,3 +3,25 @@ import gcloud.aio.bigquery as bigquery  # pylint: disable=unused-import
 
 def test_importable():
     assert True
+
+
+def test_make_insert_body():
+    body = bigquery.Table._make_insert_body(
+        [
+            {'foo': 'herp', 'bar': 42},
+            {'foo': 'derp', 'bar': 13},
+        ],
+        skip_invalid=False,
+        ignore_unknown=False,
+        insert_id_fn=lambda b: b['bar']
+    )
+
+    assert body == {
+            'kind': 'bigquery#tableDataInsertAllRequest',
+            'skipInvalidRows': False,
+            'ignoreUnknownValues': False,
+            'rows': [
+                {'insertId': 42, 'json': {'foo': 'herp', 'bar': 42}},
+                {'insertId': 13, 'json': {'foo': 'derp', 'bar': 13}},
+            ],
+        }


### PR DESCRIPTION
Bigquery uses insertid to prevent duplicate insertions. The previous implementation generated a uuid for each row, effectively disabling this feature,  as uuids are guaranteed to be different each time. My changes allow the end-user to specify a key derivation function, so duplicate insertions can be prevented properly, without imposing a specific structure to the inserted data.