### PR TITLE
datastore export to storage fails with 'done' keyerror.

### DIFF
--- a/datastore/gcloud/aio/datastore/datastore_operation.py
+++ b/datastore/gcloud/aio/datastore/datastore_operation.py
@@ -17,7 +17,7 @@ class DatastoreOperation:
 
     @classmethod
     def from_repr(cls, data: Dict[str, Any]) -> 'DatastoreOperation':
-        return cls(data['name'], data['done'], data.get('metadata'),
+        return cls(data['name'], data.get('done', False), data.get('metadata'),
                    data.get('error'), data.get('response'))
 
     def to_repr(self) -> Dict[str, Any]:


### PR DESCRIPTION
Google documents export API responds with Operation object which should have 'done' key
but it's missing when export is still in process.