### PR TITLE
feat(storage): implement copy operation

### DIFF
--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -87,6 +87,12 @@ class Storage:
         url = (f"{API_ROOT}/{bucket}/o/{quote(object_name, safe='')}/rewriteTo"
                f"/b/{destination_bucket}/o/{quote(new_name, safe='')}")
 
+        # We may optionally supply metadata* to apply to the rewritten
+        # object, which explains why `rewriteTo` is a POST endpoint; however,
+        # we don't expose that here so we have to send an empty body. Therefore
+        # the `Content-Length` and `Content-Type` indicate an empty body.
+        #
+        # * https://cloud.google.com/storage/docs/json_api/v1/objects#resource
         headers = headers or {}
         headers.update({
             'Authorization': f'Bearer {token}',

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -71,10 +71,8 @@ class Storage:
         # multiple calls to fully copy an object.
         #
         # https://cloud.google.com/storage/docs/json_api/v1/objects/rewrite
-        encoded_object_name = quote(object_name, safe='')
-        encoded_new_name = quote(new_name, safe='')
-        url = (f'{API_ROOT}/{bucket}/o/{encoded_object_name}/rewriteTo'
-               f'/b/{destination_bucket}/o/{encoded_new_name}')
+        url = (f"{API_ROOT}/{bucket}/o/{quote(object_name, safe='')}/rewriteTo"
+               f"/b/{destination_bucket}/o/{quote(new_name, safe='')}")
 
         headers = headers or {}
         headers.update({

--- a/storage/tests/integration/smoke_test.py
+++ b/storage/tests/integration/smoke_test.py
@@ -23,7 +23,7 @@ else:
 async def test_object_life_cycle(bucket_name, creds, uploaded_data,
                                  expected_data, file_extension):
     object_name = f'{uuid.uuid4().hex}/{uuid.uuid4().hex}.{file_extension}'
-    copied_object_name = f'copyof_{copied_object_name}'
+    copied_object_name = f'copyof_{object_name}'
 
     async with Session() as session:
         storage = Storage(service_file=creds, session=session)

--- a/storage/tests/integration/smoke_test.py
+++ b/storage/tests/integration/smoke_test.py
@@ -23,6 +23,7 @@ else:
 async def test_object_life_cycle(bucket_name, creds, uploaded_data,
                                  expected_data, file_extension):
     object_name = f'{uuid.uuid4().hex}/{uuid.uuid4().hex}.{file_extension}'
+    copied_object_name = f'copyof_{copied_object_name}'
 
     async with Session() as session:
         storage = Storage(service_file=creds, session=session)
@@ -36,7 +37,17 @@ async def test_object_life_cycle(bucket_name, creds, uploaded_data,
         direct_result = await storage.download(bucket_name, object_name)
         assert direct_result == expected_data
 
+        await storage.copy(bucket_name, object_name, bucket_name,
+                           new_name=copied_object_name)
+
+        direct_result = await storage.download(bucket_name, copied_object_name)
+        assert direct_result == expected_data
+
         await storage.delete(bucket_name, object_name)
+        await storage.delete(bucket_name, copied_object_name)
 
         with pytest.raises(ResponseError):
             await storage.download(bucket_name, object_name)
+
+        with pytest.raises(ResponseError):
+            await storage.download(bucket_name, copied_object_name)


### PR DESCRIPTION
According to the GCP Storage API documentation, the copy operation can be achieved either by using the `copyTo` endpoint or the `rewriteTo` endpoint. Google recommends using `rewriteTo`, since `copyTo` simply uses a single call to the behaviour of `rewriteTo` whereas multiple may be needed for large files or other multi-part copy causes.

`rewriteTo` exposes a `done` field in the response payload; if this is false then the value of the `rewriteToken` field must be used in subsequent calls until the copy operation is completed.

https://cloud.google.com/storage/docs/json_api/v1/objects/rewrite

Testing:

- Added an extra flow to the smoke test to (1) copy the originally uploaded object, (2) verify that its contents are expected, (3) delete it on cleanup, and (4) ensure the deletion was successful