### PR TITLE
fix(datastore): allow microsecond resolution timestamp values

### DIFF
--- a/datastore/gcloud/aio/datastore/value.py
+++ b/datastore/gcloud/aio/datastore/value.py
@@ -35,8 +35,8 @@ class Value:  # pylint:disable=useless-object-inheritance
                 if json_key == 'nullValue':
                     value = None
                 elif value_type == datetime:
-                    value = datetime.strptime(data[json_key],
-                                              '%Y-%m-%dT%H:%M:%S.%f000Z')
+                    value = datetime.strptime(data[json_key][:-4],
+                                              '%Y-%m-%dT%H:%M:%S.%f')
                 elif hasattr(value_type, 'from_repr'):
                     value = value_type.from_repr(data[json_key])
                 else:

--- a/datastore/gcloud/aio/datastore/value.py
+++ b/datastore/gcloud/aio/datastore/value.py
@@ -35,7 +35,7 @@ class Value:  # pylint:disable=useless-object-inheritance
                 if json_key == 'nullValue':
                     value = None
                 elif value_type == datetime:
-                    value = datetime.strptime(data[json_key][:-4],
+                    value = datetime.strptime(data[json_key][:26],
                                               '%Y-%m-%dT%H:%M:%S.%f')
                 elif hasattr(value_type, 'from_repr'):
                     value = value_type.from_repr(data[json_key])

--- a/datastore/gcloud/aio/datastore/value.py
+++ b/datastore/gcloud/aio/datastore/value.py
@@ -35,7 +35,7 @@ class Value:  # pylint:disable=useless-object-inheritance
                 if json_key == 'nullValue':
                     value = None
                 elif value_type == datetime:
-                    value = datetime.strptime(data[json_key][:26],
+                    value = datetime.strptime(data[json_key][:-1][:26],
                                               '%Y-%m-%dT%H:%M:%S.%f')
                 elif hasattr(value_type, 'from_repr'):
                     value = value_type.from_repr(data[json_key])

--- a/datastore/tests/unit/value_test.py
+++ b/datastore/tests/unit/value_test.py
@@ -2,10 +2,8 @@ import sys
 from datetime import datetime
 
 import pytest
-from gcloud.aio.datastore import Key
-from gcloud.aio.datastore import LatLng
-from gcloud.aio.datastore import PathElement
-from gcloud.aio.datastore import Value
+
+from gcloud.aio.datastore import Key, LatLng, PathElement, Value
 
 
 class TestValue:
@@ -56,30 +54,25 @@ class TestValue:
         assert value.value is None
 
     @staticmethod
-    def test_from_repr_with_datetime_value():
+    @pytest.mark.parametrize('v,expected', [
+        ('1998-07-12T11:22:33.456789000Z',
+         datetime(year=1998, month=7, day=12, hour=11,
+                  minute=22, second=33, microsecond=456789)),
+        ('1998-07-12T11:22:33.456789Z',
+         datetime(year=1998, month=7, day=12, hour=11,
+                  minute=22, second=33, microsecond=456789)),
+        ('1998-07-12T11:22:33.456Z',
+         datetime(year=1998, month=7, day=12, hour=11,
+                  minute=22, second=33, microsecond=456000))
+    ])
+    def test_from_repr_with_datetime_value(v, expected):
         data = {
             'excludeFromIndexes': False,
-            'timestampValue': '1998-07-12T11:22:33.456789000Z'
+            'timestampValue': v
         }
 
         value = Value.from_repr(data)
-
-        expected_value = datetime(year=1998, month=7, day=12, hour=11,
-                                  minute=22, second=33, microsecond=456789)
-        assert value.value == expected_value
-
-    @staticmethod
-    def test_from_repr_with_legacy_datetime_value():
-        data = {
-            'excludeFromIndexes': False,
-            'timestampValue': '1998-07-12T11:22:33.456789Z'
-        }
-
-        value = Value.from_repr(data)
-
-        expected_value = datetime(year=1998, month=7, day=12, hour=11,
-                                  minute=22, second=33, microsecond=456789)
-        assert value.value == expected_value
+        assert value.value == expected
 
     @staticmethod
     def test_from_repr_with_key_value(key):
@@ -209,6 +202,7 @@ class TestValue:
     def test_to_repr_non_supported_type():
         class NonSupportedType:
             pass
+
         value = Value(NonSupportedType())
 
         with pytest.raises(Exception) as ex_info:

--- a/datastore/tests/unit/value_test.py
+++ b/datastore/tests/unit/value_test.py
@@ -69,6 +69,19 @@ class TestValue:
         assert value.value == expected_value
 
     @staticmethod
+    def test_from_repr_with_legacy_datetime_value():
+        data = {
+            'excludeFromIndexes': False,
+            'timestampValue': '1998-07-12T11:22:33.456789Z'
+        }
+
+        value = Value.from_repr(data)
+
+        expected_value = datetime(year=1998, month=7, day=12, hour=11,
+                                  minute=22, second=33, microsecond=456789)
+        assert value.value == expected_value
+
+    @staticmethod
     def test_from_repr_with_key_value(key):
         data = {
             'excludeFromIndexes': False,

--- a/datastore/tests/unit/value_test.py
+++ b/datastore/tests/unit/value_test.py
@@ -3,7 +3,10 @@ from datetime import datetime
 
 import pytest
 
-from gcloud.aio.datastore import Key, LatLng, PathElement, Value
+from gcloud.aio.datastore import Key
+from gcloud.aio.datastore import LatLng
+from gcloud.aio.datastore import PathElement
+from gcloud.aio.datastore import Value
 
 
 class TestValue:

--- a/datastore/tests/unit/value_test.py
+++ b/datastore/tests/unit/value_test.py
@@ -2,7 +2,6 @@ import sys
 from datetime import datetime
 
 import pytest
-
 from gcloud.aio.datastore import Key
 from gcloud.aio.datastore import LatLng
 from gcloud.aio.datastore import PathElement


### PR DESCRIPTION
Slice the date string to drop the nanoseconds and trailing 'Z'.