### PR TITLE
fix(datastore): use base64 representation for blobs (fixes #150)

### DIFF
--- a/datastore/gcloud/aio/datastore/value.py
+++ b/datastore/gcloud/aio/datastore/value.py
@@ -1,3 +1,4 @@
+import base64
 from datetime import datetime
 from typing import Any
 from typing import Dict
@@ -34,6 +35,8 @@ class Value:  # pylint:disable=useless-object-inheritance
             if json_key in data:
                 if json_key == 'nullValue':
                     value = None
+                elif json_key == 'blobValue':
+                    value = base64.b64decode(data[json_key])
                 elif value_type == datetime:
                     value = datetime.strptime(data[json_key][:-1][:26],
                                               '%Y-%m-%dT%H:%M:%S.%f')
@@ -62,6 +65,8 @@ class Value:  # pylint:disable=useless-object-inheritance
             value = self.value.to_repr()
         elif value_type == TypeName.TIMESTAMP:
             value = self.value.strftime('%Y-%m-%dT%H:%M:%S.%f000Z')
+        elif value_type == TypeName.BLOB:
+            value = base64.b64encode(self.value).decode('utf8')
         else:
             value = 'NULL_VALUE' if self.value is None else self.value
         return {

--- a/datastore/tests/unit/value_test.py
+++ b/datastore/tests/unit/value_test.py
@@ -1,4 +1,3 @@
-import sys
 from datetime import datetime
 
 import pytest

--- a/datastore/tests/unit/value_test.py
+++ b/datastore/tests/unit/value_test.py
@@ -1,3 +1,4 @@
+import sys
 from datetime import datetime
 
 import pytest
@@ -64,6 +65,9 @@ class TestValue:
         assert value.value == expected
 
     @staticmethod
+    @pytest.mark.skipif(sys.version_info[0] < 3,
+                        reason='skipping because python2 has same '
+                               'type for str and bytes')
     def test_from_repr_with_blob_value():
         data = {
             'excludedFromIndexed': False,
@@ -144,6 +148,9 @@ class TestValue:
 
         assert r['timestampValue'] == '2018-07-15T11:22:33.456789000Z'
 
+    @pytest.mark.skipif(sys.version_info[0] < 3,
+                        reason='skipping because python2 has same '
+                               'type for str and bytes')
     @staticmethod
     def test_to_repr_with_blob_value():
         value = Value(b'foobar')

--- a/datastore/tests/unit/value_test.py
+++ b/datastore/tests/unit/value_test.py
@@ -11,22 +11,10 @@ from gcloud.aio.datastore import Value
 class TestValue:
     @staticmethod
     @pytest.mark.parametrize('json_key,json_value', [
-        pytest.param(
-            'blobValue', b'foobar',
-            marks=pytest.mark.skipif(sys.version_info[0] < 3,
-                                     reason='skipping because python2 has same '
-                                            'type for str and bytes')
-        ),
         ('booleanValue', True),
         ('doubleValue', 34.48),
         ('integerValue', 8483),
         ('stringValue', 'foobar'),
-        pytest.param(
-            'blobValue', b'',
-            marks=pytest.mark.skipif(sys.version_info[0] < 3,
-                                     reason='skipping because python2 has same '
-                                            'type for str and bytes')
-        ),
         ('booleanValue', False),
         ('doubleValue', 0.0),
         ('integerValue', 0),
@@ -77,6 +65,16 @@ class TestValue:
         assert value.value == expected
 
     @staticmethod
+    def test_from_repr_with_blob_value():
+        data = {
+            'excludedFromIndexed': False,
+            'blobValue': 'Zm9vYmFy'
+        }
+
+        value = Value.from_repr(data)
+        assert value.value == b'foobar'
+
+    @staticmethod
     def test_from_repr_with_key_value(key):
         data = {
             'excludeFromIndexes': False,
@@ -111,22 +109,10 @@ class TestValue:
 
     @staticmethod
     @pytest.mark.parametrize('v,expected_json_key', [
-        pytest.param(
-            b'foobar', 'blobValue',
-            marks=pytest.mark.skipif(sys.version_info[0] < 3,
-                                     reason='skipping because python2 has same '
-                                            'type for str and bytes')
-        ),
         (True, 'booleanValue'),
         (34.48, 'doubleValue'),
         (8483, 'integerValue'),
         ('foobar', 'stringValue'),
-        pytest.param(
-            b'', 'blobValue',
-            marks=pytest.mark.skipif(sys.version_info[0] < 3,
-                                     reason='skipping because python2 has same '
-                                            'type for str and bytes')
-        ),
         (False, 'booleanValue'),
         (0.0, 'doubleValue'),
         (0, 'integerValue'),
@@ -158,6 +144,13 @@ class TestValue:
         r = value.to_repr()
 
         assert r['timestampValue'] == '2018-07-15T11:22:33.456789000Z'
+
+    @staticmethod
+    def test_to_repr_with_blob_value():
+        value = Value(b'foobar')
+
+        r = value.to_repr()
+        assert r['blobValue'] == 'Zm9vYmFy'
 
     @staticmethod
     def test_to_repr_with_key_value(key):


### PR DESCRIPTION
Fix for #150 - encode/decode base64 blob values