### PR TITLE
Added template_suffix to table.insert

### DIFF
--- a/bigquery/gcloud/aio/bigquery/bigquery.py
+++ b/bigquery/gcloud/aio/bigquery/bigquery.py
@@ -80,7 +80,7 @@ class Table:
     @staticmethod
     def _make_insert_body(
             rows: List[Dict[str, Any]], *, skip_invalid: bool,
-            ignore_unknown: bool, template_suffix: str,
+            ignore_unknown: bool, template_suffix: Optional[str],
             insert_id_fn: Callable[[Dict[str, Any]], str]) -> Dict[str, Any]:
         body = {
             'kind': 'bigquery#tableDataInsertAllRequest',
@@ -93,7 +93,7 @@ class Table:
         }
 
         if template_suffix is not None:
-            body["templateSuffix"] = template_suffix
+            body['templateSuffix'] = template_suffix
 
         return body
 

--- a/bigquery/gcloud/aio/bigquery/bigquery.py
+++ b/bigquery/gcloud/aio/bigquery/bigquery.py
@@ -80,9 +80,9 @@ class Table:
     @staticmethod
     def _make_insert_body(
             rows: List[Dict[str, Any]], *, skip_invalid: bool,
-            ignore_unknown: bool,
+            ignore_unknown: bool, template_suffix: str,
             insert_id_fn: Callable[[Dict[str, Any]], str]) -> Dict[str, Any]:
-        return {
+        body = {
             'kind': 'bigquery#tableDataInsertAllRequest',
             'skipInvalidRows': skip_invalid,
             'ignoreUnknownValues': ignore_unknown,
@@ -91,6 +91,11 @@ class Table:
                 'json': row,
             } for row in rows],
         }
+
+        if template_suffix is not None:
+            body["templateSuffix"] = template_suffix
+
+        return body
 
     def _make_load_body(
             self, source_uris: List[str], project: str) -> Dict[str, Any]:
@@ -183,6 +188,7 @@ class Table:
     async def insert(
             self, rows: List[Dict[str, Any]], skip_invalid: bool = False,
             ignore_unknown: bool = True, session: Optional[Session] = None,
+            template_suffix: Optional[str] = None,
             timeout: int = 60, *,
             insert_id_fn: Optional[Callable[[Dict[str, Any]], str]] = None
     ) -> Dict[str, Any]:
@@ -205,7 +211,9 @@ class Table:
 
         body = self._make_insert_body(
             rows, skip_invalid=skip_invalid, ignore_unknown=ignore_unknown,
+            template_suffix=template_suffix,
             insert_id_fn=insert_id_fn or self._mk_unique_insert_id)
+
         payload = json.dumps(body).encode('utf-8')
 
         headers = await self.headers()

--- a/bigquery/tests/unit/bigquery_test.py
+++ b/bigquery/tests/unit/bigquery_test.py
@@ -25,7 +25,7 @@ def test_make_insert_body_template_suffix():
     # pylint: disable=protected-access
     body = bigquery.Table._make_insert_body(
         [{'foo': 'herp', 'bar': 42}, {'foo': 'derp', 'bar': 13}],
-        skip_invalid=False, ignore_unknown=False, template_suffix="suffix",
+        skip_invalid=False, ignore_unknown=False, template_suffix='suffix',
         insert_id_fn=lambda b: b['bar'])
 
     expected = {

--- a/bigquery/tests/unit/bigquery_test.py
+++ b/bigquery/tests/unit/bigquery_test.py
@@ -5,7 +5,7 @@ def test_make_insert_body():
     # pylint: disable=protected-access
     body = bigquery.Table._make_insert_body(
         [{'foo': 'herp', 'bar': 42}, {'foo': 'derp', 'bar': 13}],
-        skip_invalid=False, ignore_unknown=False,
+        skip_invalid=False, ignore_unknown=False, template_suffix=None,
         insert_id_fn=lambda b: b['bar'])
 
     expected = {
@@ -21,11 +21,32 @@ def test_make_insert_body():
     assert body == expected
 
 
+def test_make_insert_body_template_suffix():
+    # pylint: disable=protected-access
+    body = bigquery.Table._make_insert_body(
+        [{'foo': 'herp', 'bar': 42}, {'foo': 'derp', 'bar': 13}],
+        skip_invalid=False, ignore_unknown=False, template_suffix="suffix",
+        insert_id_fn=lambda b: b['bar'])
+
+    expected = {
+        'kind': 'bigquery#tableDataInsertAllRequest',
+        'skipInvalidRows': False,
+        'ignoreUnknownValues': False,
+        'templateSuffix': 'suffix',
+        'rows': [
+            {'insertId': 42, 'json': {'foo': 'herp', 'bar': 42}},
+            {'insertId': 13, 'json': {'foo': 'derp', 'bar': 13}},
+        ],
+    }
+
+    assert body == expected
+
+
 def test_make_insert_body_defult_id_fn():
     # pylint: disable=protected-access
     body = bigquery.Table._make_insert_body(
         [{'foo': 'herp', 'bar': 42}, {'foo': 'derp', 'bar': 13}],
-        skip_invalid=False, ignore_unknown=False,
+        skip_invalid=False, ignore_unknown=False, template_suffix=None,
         insert_id_fn=bigquery.Table._mk_unique_insert_id)
 
     assert len(body['rows']) == 2


### PR DESCRIPTION
For cases when table name is merely a template, insert requires `template_suffix`. I added an optional parameter to `Table.insert`. This follows google cloud bigquery client where `Client.insert_rows_json` accepts such parameter and includes in the request body is it is not `None`