### PR TITLE
fix(datastore): handle additional legacy date formats

### DIFF
--- a/datastore/gcloud/aio/datastore/value.py
+++ b/datastore/gcloud/aio/datastore/value.py
@@ -38,8 +38,10 @@ class Value:  # pylint:disable=useless-object-inheritance
                 elif json_key == 'blobValue':
                     value = base64.b64decode(data[json_key])
                 elif value_type == datetime:
-                    value = datetime.strptime(data[json_key][:-1][:26],
-                                              '%Y-%m-%dT%H:%M:%S.%f')
+                    date_string = data[json_key].rstrip('Z')[:26]
+                    value = datetime.strptime(
+                        date_string, '%Y-%m-%dT%H:%M:%S.%f'
+                        if '.' in date_string else '%Y-%m-%dT%H:%M:%S')
                 elif hasattr(value_type, 'from_repr'):
                     value = value_type.from_repr(data[json_key])
                 else:

--- a/datastore/tests/unit/value_test.py
+++ b/datastore/tests/unit/value_test.py
@@ -53,7 +53,10 @@ class TestValue:
                   minute=22, second=33, microsecond=456789)),
         ('1998-07-12T11:22:33.456Z',
          datetime(year=1998, month=7, day=12, hour=11,
-                  minute=22, second=33, microsecond=456000))
+                  minute=22, second=33, microsecond=456000)),
+        ('1998-07-12T11:22:33',
+         datetime(year=1998, month=7, day=12, hour=11,
+                  minute=22, second=33, microsecond=0)),
     ])
     def test_from_repr_with_datetime_value(v, expected):
         data = {


### PR DESCRIPTION
I found one more corner case: datetimes with second resolution.