### PR TITLE
feat(gcloud-aio): pin yarl for google cloud function compat

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,6 +202,7 @@ jobs:
       - run: find . -type f -path '*py' | xargs -L1 sed -Ei 's/__aexit__/__exit__/g'
       # aiohttp vs requests
       - run: find . -type f -path '*py' | xargs -L1 sed -Ei 's/content_type=None//g'
+      - run: find . -type f -path '*requirements.txt' | xargs -L1 sed -Ei 's/yarl/# yarl/g'
 
       # Update the nox files
       - run: find . -type f -path '*noxfile.py' | xargs -L1 sed -Ei "s/'aiohttp',//g"

--- a/auth/requirements.txt
+++ b/auth/requirements.txt
@@ -9,4 +9,4 @@ typing>=3.7.4.1,<4.0.0; python_version<"3.6" or python_full_version<"3.6.2"
 # yarl is a shared requirement via aiohttp with google cloud functions;
 # pinned version allows cloud functions to deploy when using gcloud-aio
 # the yarl requirement is removed for python2 -rest by .circleci/config.yaml
-yarl==1.4.2
+yarl<1.4.3

--- a/auth/requirements.txt
+++ b/auth/requirements.txt
@@ -6,3 +6,7 @@ pyjwt>=1.5.3,<2.0.0
 # requests>=2.20.0,<3.0.0
 six>=1.11.0,<2.0.0
 typing>=3.7.4.1,<4.0.0; python_version<"3.6" or python_full_version<"3.6.2"
+# yarl is a shared requirement via aiohttp with google cloud functions;
+# pinned version allows cloud functions to deploy when using gcloud-aio
+# the yarl requirement is removed for python2 -rest by .circleci/config.yaml
+yarl==1.4.2


### PR DESCRIPTION
Fixes a problem that prevents projects using gcloud-aio-storage from deploying into Google Cloud Functions.

- common requirement in gcloud-aio + google cloud function is yarl (required by aiohttp)
- yarl received a breaking change a few days ago; pinning this version lets deployment succeed
- will get in touch w aiohttp and yarl projects about the breaking change
