### PR TITLE
Revert "chore(deps): pin yarl for google cloud function compat (#185)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ jobs:
       - run: echo ${GOOGLE_SERVICE_PUBLIC} | base64 -d > ${GOOGLE_APPLICATION_CREDENTIALS}
       - attach_workspace:
           at: rest
+      - run: python3 -m pip install -U pip  # TODO: remove after nox base image updated
       - run: python3 -m pip install future==0.18.2
       - run: nox -f rest/<<parameters.folder>>/noxfile.py
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,6 @@ jobs:
       - run: find . -type f -path '*py' | xargs -L1 sed -Ei 's/__aexit__/__exit__/g'
       # aiohttp vs requests
       - run: find . -type f -path '*py' | xargs -L1 sed -Ei 's/content_type=None//g'
-      - run: find . -type f -path '*requirements.txt' | xargs -L1 sed -Ei 's/yarl/# yarl/g'
 
       # Update the nox files
       - run: find . -type f -path '*noxfile.py' | xargs -L1 sed -Ei "s/'aiohttp',//g"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
 
   nox:
     docker:
-      - image: thekevjames/nox:2019.11.9
+      - image: thekevjames/nox:2020.5.24
     environment:
       GOOGLE_APPLICATION_CREDENTIALS: /key.json
     parameters:
@@ -32,12 +32,11 @@ jobs:
           apt-get -qy install libssl-dev
       - run: echo ${GOOGLE_SERVICE_PUBLIC} | base64 -d > "${GOOGLE_APPLICATION_CREDENTIALS}"
       - checkout
-      - run: python3 -m pip install -U pip  # TODO: remove after nox base image updated
       - run: nox -f <<parameters.folder>>/noxfile.py
 
   nox-rest:
     docker:
-      - image: thekevjames/nox:2019.11.9
+      - image: thekevjames/nox:2020.5.24
     environment:
       GOOGLE_APPLICATION_CREDENTIALS: /key.json
     parameters:
@@ -47,7 +46,6 @@ jobs:
       - run: echo ${GOOGLE_SERVICE_PUBLIC} | base64 -d > ${GOOGLE_APPLICATION_CREDENTIALS}
       - attach_workspace:
           at: rest
-      - run: python3 -m pip install -U pip  # TODO: remove after nox base image updated
       - run: python3 -m pip install future==0.18.2
       - run: nox -f rest/<<parameters.folder>>/noxfile.py
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,7 +241,7 @@ workflows:
               only: /.*/
 
       - linter/pre-commit:
-          python_version: 3.6.6
+          python_version: 3.7.8
           filters:
             tags:
               only: /.*/
@@ -255,31 +255,31 @@ workflows:
       - tester/pipcheck:
           name: pipcheck-auth
           install_args: auth/
-          python_version: 3.6.6
+          python_version: 3.7.8
       - tester/pipcheck:
           name: pipcheck-bigquery
           install_args: bigquery/
-          python_version: 3.6.6
+          python_version: 3.7.8
       - tester/pipcheck:
           name: pipcheck-datastore
           install_args: datastore/
-          python_version: 3.6.6
+          python_version: 3.7.8
       - tester/pipcheck:
           name: pipcheck-kms
           install_args: kms/
-          python_version: 3.6.6
+          python_version: 3.7.8
       - tester/pipcheck:
           name: pipcheck-pubsub
           install_args: pubsub/
-          python_version: 3.6.6
+          python_version: 3.7.8
       - tester/pipcheck:
           name: pipcheck-storage
           install_args: storage/
-          python_version: 3.6.6
+          python_version: 3.7.8
       - tester/pipcheck:
           name: pipcheck-taskqueue
           install_args: taskqueue/
-          python_version: 3.6.6
+          python_version: 3.7.8
 
       # build docs
       - docs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
           apt-get -qy install libssl-dev
       - run: echo ${GOOGLE_SERVICE_PUBLIC} | base64 -d > "${GOOGLE_APPLICATION_CREDENTIALS}"
       - checkout
+      - run: python3 -m pip install -U pip  # TODO: remove after nox base image updated
       - run: nox -f <<parameters.folder>>/noxfile.py
 
   nox-rest:

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,20 @@ Installation
 
     $ pip install --upgrade gcloud-{aio,rest}-{client_name}
 
+Compatibility
+-------------
+
+These libraries are used with Google projects. Here are notes on compatibility
+issues. While we cannot offer specific support for issues originating from
+other projects, we can point toward known resolutions.
+
+- Google Cloud Functions pins ``yarl``; ``gcloud-aio-*`` indirectly requires
+  ``yarl`` via ``aiohttp`` and an unpinned version of ``yarl`` can cause your
+  cloud functions to stop building. Please pin your requirements as described
+  here: `Google Cloud Function Dependencies`_.
+
+.. gcloud-aio links
+
 .. _Google Cloud Auth: https://github.com/talkiq/gcloud-aio/blob/master/auth/README.rst
 .. _Google Cloud BigQuery: https://github.com/talkiq/gcloud-aio/blob/master/bigquery/README.rst
 .. _Google Cloud Datastore: https://github.com/talkiq/gcloud-aio/blob/master/datastore/README.rst
@@ -73,3 +87,7 @@ Installation
 .. |pythons-rest| image:: https://img.shields.io/pypi/pyversions/gcloud-rest-auth.svg?style=flat-square&label=python (rest)
     :alt: Python Version Support (rest)
     :target: https://pypi.org/project/gcloud-rest-auth/
+
+.. external links
+
+.. _Google Cloud Function Dependencies: https://cloud.google.com/functions/docs/writing/specifying-dependencies-python

--- a/README.rst
+++ b/README.rst
@@ -29,9 +29,9 @@ Installation
 Compatibility
 -------------
 
-These libraries are used with Google projects. Here are notes on compatibility
-issues. While we cannot offer specific support for issues originating from
-other projects, we can point toward known resolutions.
+Here are notes on compatibility issues. While we cannot offer specific support
+for issues originating from other projects, we can point toward known
+resolutions.
 
 - Google Cloud Functions pins ``yarl``; ``gcloud-aio-*`` indirectly requires
   ``yarl`` via ``aiohttp`` and an unpinned version of ``yarl`` can cause your

--- a/auth/requirements.txt
+++ b/auth/requirements.txt
@@ -6,7 +6,3 @@ pyjwt>=1.5.3,<2.0.0
 # requests>=2.20.0,<3.0.0
 six>=1.11.0,<2.0.0
 typing>=3.7.4.1,<4.0.0; python_version<"3.6" or python_full_version<"3.6.2"
-# yarl is a shared requirement via aiohttp with google cloud functions;
-# pinned version allows cloud functions to deploy when using gcloud-aio
-# the yarl requirement is removed for python2 -rest by .circleci/config.yaml
-yarl<1.4.3


### PR DESCRIPTION
This reverts commit 099cb35ed1c074ac4b226ae73e923814ddc6c927.

We determined that the yarl incompatibility only affects Google Cloud Functions (GCF), and is known to be pinned there at 1.4.2 -- we recommend users who use GCF to pin according to their docs here: https://cloud.google.com/functions/docs/writing/specifying-dependencies-python