### PR TITLE
chore(auth): bump minimum aiohttp compatibility

### DIFF
--- a/auth/gcloud/aio/auth/session.py
+++ b/auth/gcloud/aio/auth/session.py
@@ -16,12 +16,11 @@ log = logging.getLogger(__name__)
 class BaseSession:
     __metaclass__ = ABCMeta
 
-    def __init__(self, session=None, conn_timeout: int = 10,
-                 read_timeout: int = 10, verify_ssl: bool = True):
-        self.conn_timeout = conn_timeout
-        self.read_timeout = read_timeout
+    def __init__(self, session=None, timeout: int = 10,
+                 verify_ssl: bool = True):
         self._session = session
         self._ssl = verify_ssl
+        self._timeout = timeout
 
     @abstractproperty
     def session(self):
@@ -94,8 +93,7 @@ if not BUILD_GCLOUD_REST:
         def session(self) -> aiohttp.ClientSession:
             connector = aiohttp.TCPConnector(ssl=self._ssl)
             self._session = self._session or aiohttp.ClientSession(
-                conn_timeout=self.conn_timeout, read_timeout=self.read_timeout,
-                connector=connector)
+                connector=connector, timeout=self._timeout)
             return self._session
 
         async def post(self, url: str, headers: Dict[str, str],

--- a/auth/requirements.txt
+++ b/auth/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp>=2.0.0,<4.0.0
+aiohttp>=3.0.0,<4.0.0
 backoff>=1.0.0,<2.0.0
 cryptography>=2.0.0,<4.0.0
 future>=0.17.0,<0.18.3

--- a/auth/requirements.txt
+++ b/auth/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp>=3.0.0,<4.0.0
+aiohttp>=3.3.0,<4.0.0
 backoff>=1.0.0,<2.0.0
 cryptography>=2.0.0,<4.0.0
 future>=0.17.0,<0.18.3

--- a/auth/tests/integration/smoke_test.py
+++ b/auth/tests/integration/smoke_test.py
@@ -74,7 +74,7 @@ async def verify_signature(data, signature, key_name, iam_client):
 async def test_sign_blob(creds: str) -> None:
     data = 'Testing Can be confidential!'
 
-    async with Session(conn_timeout=10, read_timeout=10) as s:
+    async with Session(timeout=10) as s:
         iam_client = IamClient(service_file=creds, session=s)
         resp = await iam_client.sign_blob(data)
         signed_data = resp['signedBlob']
@@ -83,7 +83,7 @@ async def test_sign_blob(creds: str) -> None:
 
 @pytest.mark.asyncio  # type: ignore
 async def test_get_service_account_public_key_names(creds: str) -> None:
-    async with Session(conn_timeout=10, read_timeout=10) as s:
+    async with Session(timeout=10) as s:
         iam_client = IamClient(service_file=creds, session=s)
         resp = await iam_client.list_public_keys()
         assert len(resp) >= 1, '0 public keys found.'
@@ -91,7 +91,7 @@ async def test_get_service_account_public_key_names(creds: str) -> None:
 
 @pytest.mark.asyncio  # type: ignore
 async def test_get_service_account_public_key(creds: str) -> None:
-    async with Session(conn_timeout=10, read_timeout=10) as s:
+    async with Session(timeout=10) as s:
         iam_client = IamClient(service_file=creds, session=s)
         resp = await iam_client.list_public_keys(session=s)
         pub_key_data = await iam_client.get_public_key(key=resp[0]['name'],


### PR DESCRIPTION
Fixes #57 and #188

```
fb41299 (Kevin James, 71 seconds ago)
   chore(auth): bump minimum aiohttp

   aiohttp v4.0 is gearing up to be hard to support if we also want to work 
   with aiohttp <v3.3. Since 3.3 is now over two years old, I feel comfortable
   deprecating it to avoid the future headaches and complexity.

   Fixes #57

e03e021 (Kevin James, 2 minutes ago)
   fix(auth): fixup minimum aiohttp deps

   Fixes #188
```