### PR TITLE
chore(storage): bump version

### DIFF
--- a/storage/setup.py
+++ b/storage/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as f:
 
 setuptools.setup(
     name='gcloud-aio-storage',
-    version='5.5.4',
+    version='5.6.0',
     description='Python Client for Google Cloud Storage',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Bumping `gcloud-*-storage`: `5.5.4 -> 5.6.0`