### PR TITLE
Add header overrides to download function

### DIFF
--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -149,9 +149,11 @@ class Storage:
         return data
 
     async def download(self, bucket: str, object_name: str, *,
+                       headers: dict = {},
                        timeout: int = 10,
                        session: Optional[Session] = None) -> bytes:
-        return await self._download(bucket, object_name, timeout=timeout,
+        return await self._download(bucket, object_name, 
+                                    override_headers=headers, timeout=timeout,
                                     params={'alt': 'media'}, session=session)
 
     async def download_to_filename(self, bucket: str, object_name: str,
@@ -290,12 +292,14 @@ class Storage:
         return content_type, encoding
 
     async def _download(self, bucket: str, object_name: str, *,
-                        params: dict = None, timeout: int = 10,
+                        override_headers: dict = {}, params: dict = None, 
+                        timeout: int = 10,
                         session: Optional[Session] = None) -> bytes:
         # https://cloud.google.com/storage/docs/json_api/#encoding
         encoded_object_name = quote(object_name, safe='')
         url = f'{API_ROOT}/{bucket}/o/{encoded_object_name}'
         headers = await self._headers()
+        headers.update(override_headers)
 
         s = AioSession(session) if session else self.session
         response = await s.get(url, headers=headers, params=params or {},

--- a/storage/tests/integration/download_range_test.py
+++ b/storage/tests/integration/download_range_test.py
@@ -1,0 +1,50 @@
+import io
+import json
+import os
+import random
+import string
+import uuid
+
+import pytest
+from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
+from gcloud.aio.storage import Storage
+
+# Selectively load libraries based on the package
+if BUILD_GCLOUD_REST:
+    from requests import Session
+else:
+    from aiohttp import ClientSession as Session
+
+# TODO: use hypothesis
+RANDOM_BINARY = os.urandom(2045)
+
+# Updated statement to make it compatible with python2
+rand_str_list = [random.choice(string.ascii_letters) for r in range(0, 1054)]
+RANDOM_STRING = ''.join(rand_str_list)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'uploaded_data,range_header,expected_data,file_extension', [
+        (json.dumps([1, 2, 3]), "bytes=0-1", json.dumps(
+            [1, 2, 3]).encode('utf-8')[0:2], 'json'),
+        ('test'.encode('utf-8'), "bytes=2-3", 'test'.encode('utf-8')[2:4],
+         'bin'),
+        (io.BytesIO(RANDOM_BINARY), "bytes=1-1000", RANDOM_BINARY[1:1001],
+         'bin'),
+        (io.StringIO(RANDOM_STRING), "bytes=10-100",
+         RANDOM_STRING.encode('utf-8')[10:101], 'txt'),
+    ])
+async def test_download_range(bucket_name, creds, uploaded_data, range_header,
+                              expected_data, file_extension):
+    object_name = f'{uuid.uuid4().hex}/{uuid.uuid4().hex}.{file_extension}'
+
+    async with Session() as session:
+        storage = Storage(service_file=creds, session=session)
+        res = await storage.upload(bucket_name, object_name, uploaded_data)
+
+        downloaded_data = await storage.download(
+            bucket_name, res['name'], headers={"Range": range_header})
+        assert expected_data == downloaded_data
+
+        await storage.delete(bucket_name, res['name'])


### PR DESCRIPTION
Addresses #195 and other cases (toggling gzip transcoding, for example) by allowing the caller to supply a dictionary of headers. These headers are applied over the default session headers.

With this update, users can download ranges as follows:

```
await client.download(bucket,
                      blob,
                      headers={"Range": f"bytes={start}-{end}"})
```