### PR TITLE
feat(gcloud-aio-pubsub): start migrate subscriber to aio, wrap Message, FlowControl, nix Scheduler

### DIFF
--- a/pubsub/gcloud/aio/pubsub/__init__.py
+++ b/pubsub/gcloud/aio/pubsub/__init__.py
@@ -4,7 +4,7 @@ __version__ = get_distribution('gcloud-aio-pubsub').version
 from gcloud.aio.pubsub.publisher_client import PublisherClient
 from gcloud.aio.pubsub.subscriber_client import SubscriberClient
 from gcloud.aio.pubsub.utils import PubsubMessage
-from gcloud.aio.pubsub.subscriber_message import FlowControl
+from gcloud.aio.pubsub.subscriber_client import FlowControl
 from gcloud.aio.pubsub.subscriber_message import SubscriberMessage
 
 

--- a/pubsub/gcloud/aio/pubsub/__init__.py
+++ b/pubsub/gcloud/aio/pubsub/__init__.py
@@ -4,8 +4,9 @@ __version__ = get_distribution('gcloud-aio-pubsub').version
 from gcloud.aio.pubsub.publisher_client import PublisherClient
 from gcloud.aio.pubsub.subscriber_client import SubscriberClient
 from gcloud.aio.pubsub.utils import PubsubMessage
-from gcloud.aio.pubsub.subscriber_message import Message
+from gcloud.aio.pubsub.subscriber_message import FlowControl
+from gcloud.aio.pubsub.subscriber_message import SubscriberMessage
 
 
-__all__ = ['__version__', 'PublisherClient', 'Message', 'PubsubMessage',
-           'SubscriberClient']
+__all__ = ['__version__', 'FlowControl', 'PublisherClient', 'PubsubMessage',
+           'SubscriberClient', 'SubscriberMessage']

--- a/pubsub/gcloud/aio/pubsub/__init__.py
+++ b/pubsub/gcloud/aio/pubsub/__init__.py
@@ -4,7 +4,8 @@ __version__ = get_distribution('gcloud-aio-pubsub').version
 from gcloud.aio.pubsub.publisher_client import PublisherClient
 from gcloud.aio.pubsub.subscriber_client import SubscriberClient
 from gcloud.aio.pubsub.utils import PubsubMessage
+from gcloud.aio.pubsub.subscriber_message import Message
 
 
-__all__ = ['__version__', 'PublisherClient', 'PubsubMessage',
+__all__ = ['__version__', 'PublisherClient', 'Message', 'PubsubMessage',
            'SubscriberClient']

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -14,10 +14,12 @@ else:
 
     from google.api_core import exceptions
     from google.cloud import pubsub
-    from google.cloud.pubsub_v1.subscriber.message import Message
+    from google.cloud.pubsub_v1.subscriber.message import Message \
+        as GoogleMessage
     from google.cloud.pubsub_v1.subscriber.scheduler import Scheduler
     from google.cloud.pubsub_v1.types import FlowControl
 
+    from .message import Message
     from .utils import convert_google_future_to_concurrent_future
 
 
@@ -101,9 +103,10 @@ else:
 
         def _wrap_callback(self,
                            callback: Callable[[Message], None]
-                           ) -> Callable[[Message], None]:
+                           ) -> Callable[[GoogleMessage], None]:
             """Schedule callback to be called from the event loop"""
             def _callback_wrapper(message: Message) -> None:
-                asyncio.run_coroutine_threadsafe(callback(message), self.loop)
+                asyncio.run_coroutine_threadsafe(
+                    callback(message.google_message), self.loop)
 
             return _callback_wrapper

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -25,12 +25,13 @@ else:
     from .utils import convert_google_future_to_concurrent_future
 
 
-    class FlowControl:
+    class FlowControl(tuple):
         def __init__(self,
                      max_bytes: int = 100 * 1024 * 1024,
                      max_messages: int = 1000,
                      max_lease_duration: int = 1 * 60 * 60,
                      max_duration_per_lease_extension: int = 0) -> None:
+            super().__init__()
             self.max_bytes = max_bytes
             self.max_messages = max_messages
             self.max_lease_duration = max_lease_duration
@@ -118,8 +119,9 @@ else:
                            callback: Callable[[SubscriberMessage], None]
                            ) -> Callable[[Message], None]:
             """Schedule callback to be called from the event loop"""
-            def _callback_wrapper(message: SubscriberMessage) -> None:
+            def _callback_wrapper(message: Message) -> None:
                 asyncio.run_coroutine_threadsafe(
-                    callback(message.google_message), self.loop)
+                    callback(SubscriberMessage.from_google_cloud(message)),
+                    self.loop)
 
             return _callback_wrapper

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -1,13 +1,14 @@
 from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
 
 if BUILD_GCLOUD_REST:
+    class FlowControl:
+        def __init__(self, **kwargs) -> None:
+            raise NotImplementedError('this class is only implemented in aio')
+
     class SubscriberClient:
         def __init__(self, **kwargs) -> None:
             raise NotImplementedError('this class is only implemented in aio')
 
-    class FlowControl:
-        def __init__(self, **kwargs) -> None:
-            raise NotImplementedError('this class is only implemented in aio')
 else:
     import asyncio
     import concurrent.futures
@@ -21,8 +22,20 @@ else:
     from google.cloud.pubsub_v1.subscriber.message import Message
 
     from .subscriber_message import SubscriberMessage
-    from .subscriber_message import FlowControl
     from .utils import convert_google_future_to_concurrent_future
+
+
+    class FlowControl:
+        def __init__(self,
+                     max_bytes: int = 100 * 1024 * 1024,
+                     max_messages: int = 1000,
+                     max_lease_duration: int = 1 * 60 * 60,
+                     max_duration_per_lease_extension: int = 0) -> None:
+            self.max_bytes = max_bytes
+            self.max_messages = max_messages
+            self.max_lease_duration = max_lease_duration
+            self.max_duration_per_lease_extension = (
+                max_duration_per_lease_extension)
 
 
     class SubscriberClient:

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -25,18 +25,23 @@ else:
     from .utils import convert_google_future_to_concurrent_future
 
 
-    class FlowControl(tuple):
+    class FlowControl():
         def __init__(self,
                      max_bytes: int = 100 * 1024 * 1024,
                      max_messages: int = 1000,
                      max_lease_duration: int = 1 * 60 * 60,
                      max_duration_per_lease_extension: int = 0) -> None:
-            super(FlowControl, self).__init__()
             self.max_bytes = max_bytes
             self.max_messages = max_messages
             self.max_lease_duration = max_lease_duration
             self.max_duration_per_lease_extension = (
                 max_duration_per_lease_extension)
+
+        def __getitem__(self, index: int):
+            return (self.max_bytes,
+                    self.max_messages,
+                    self.max_lease_duration,
+                    self.max_duration_per_lease_extension)[index]
 
 
     class SubscriberClient:

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -4,6 +4,10 @@ if BUILD_GCLOUD_REST:
     class SubscriberClient:
         def __init__(self, **kwargs) -> None:
             raise NotImplementedError('this class is only implemented in aio')
+
+    class FlowControl:
+        def __init__(self, **kwargs) -> None:
+            raise NotImplementedError('this class is only implemented in aio')
 else:
     import asyncio
     import concurrent.futures
@@ -14,10 +18,9 @@ else:
 
     from google.api_core import exceptions
     from google.cloud import pubsub
-    from google.cloud.pubsub_v1.subscriber.message import Message \
-        as GoogleMessage
+    from google.cloud.pubsub_v1.subscriber.message import Message
 
-    from .subscriber_message import Message
+    from .subscriber_message import SubscriberMessage
     from .subscriber_message import FlowControl
     from .utils import convert_google_future_to_concurrent_future
 
@@ -49,7 +52,7 @@ else:
 
         def subscribe(self,
                       subscription: str,
-                      callback: Callable[[Message], None],
+                      callback: Callable[[SubscriberMessage], None],
                       *,
                       flow_control: FlowControl = ()
                       ) -> asyncio.Future:
@@ -99,10 +102,10 @@ else:
                 self.loop.stop()
 
         def _wrap_callback(self,
-                           callback: Callable[[Message], None]
-                           ) -> Callable[[GoogleMessage], None]:
+                           callback: Callable[[SubscriberMessage], None]
+                           ) -> Callable[[Message], None]:
             """Schedule callback to be called from the event loop"""
-            def _callback_wrapper(message: Message) -> None:
+            def _callback_wrapper(message: SubscriberMessage) -> None:
                 asyncio.run_coroutine_threadsafe(
                     callback(message.google_message), self.loop)
 

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -16,7 +16,6 @@ else:
     from google.cloud import pubsub
     from google.cloud.pubsub_v1.subscriber.message import Message \
         as GoogleMessage
-    from google.cloud.pubsub_v1.subscriber.scheduler import Scheduler
     from google.cloud.pubsub_v1.types import FlowControl
 
     from .message import Message
@@ -52,8 +51,7 @@ else:
                       subscription: str,
                       callback: Callable[[Message], None],
                       *,
-                      flow_control: FlowControl = (),
-                      scheduler: Optional[Scheduler] = None
+                      flow_control: FlowControl = ()
                       ) -> asyncio.Future:
             """
             Create subscription through pubsub client, hijack the returned
@@ -63,8 +61,7 @@ else:
             sub_keepalive: asyncio.Future = self._subscriber.subscribe(
                 subscription,
                 self._wrap_callback(callback),
-                flow_control=flow_control,
-                scheduler=scheduler
+                flow_control=flow_control
             )
 
             convert_google_future_to_concurrent_future(

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -30,7 +30,7 @@ else:
     from .utils import convert_google_future_to_concurrent_future
 
 
-    class FlowControl():
+    class FlowControl:
         def __init__(self, *args: List[Any], **kwargs: Dict[str, Any]) -> None:
             """
             FlowControl transitional wrapper.

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -16,9 +16,9 @@ else:
     from google.cloud import pubsub
     from google.cloud.pubsub_v1.subscriber.message import Message \
         as GoogleMessage
-    from google.cloud.pubsub_v1.types import FlowControl
 
-    from .message import Message
+    from .subscriber_message import Message
+    from .subscriber_message import FlowControl
     from .utils import convert_google_future_to_concurrent_future
 
 

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -16,12 +16,14 @@ else:
     from typing import Any
     from typing import Callable
     from typing import Dict
+    from typing import List
     from typing import Optional
     from typing import Tuple
     from typing import Union
 
     from google.api_core import exceptions
     from google.cloud import pubsub
+    from google.cloud.pubsub_v1.types import FlowControl as _FlowControl
     from google.cloud.pubsub_v1.subscriber.message import Message
 
     from .subscriber_message import SubscriberMessage
@@ -29,22 +31,20 @@ else:
 
 
     class FlowControl():
-        def __init__(self,
-                     max_bytes: int = 100 * 1024 * 1024,
-                     max_messages: int = 1000,
-                     max_lease_duration: int = 1 * 60 * 60,
-                     max_duration_per_lease_extension: int = 0) -> None:
-            self.max_bytes = max_bytes
-            self.max_messages = max_messages
-            self.max_lease_duration = max_lease_duration
-            self.max_duration_per_lease_extension = (
-                max_duration_per_lease_extension)
+        def __init__(self, *args: List[Any], **kwargs: Dict[str, Any]) -> None:
+            """
+            FlowControl transitional wrapper.
+            (FlowControl fields docs)[https://github.com/googleapis/python-pubsub/blob/6b9eec81ccee81ab93646eaf7652139fc218ed36/google/cloud/pubsub_v1/types.py#L139-L159]  # pylint: disable=line-too-long
+            Google uses a named tuple; here are the fields, defaults:
+            - max_bytes: int = 100 * 1024 * 1024
+            - max_messages: int = 1000
+            - max_lease_duration: int = 1 * 60 * 60
+            - max_duration_per_lease_extension: int = 0
+            """
+            self._flow_control = _FlowControl(*args, **kwargs)
 
         def __getitem__(self, index: int) -> int:
-            return (self.max_bytes,
-                    self.max_messages,
-                    self.max_lease_duration,
-                    self.max_duration_per_lease_extension)[index]
+            return self._flow_control[index]
 
 
     class SubscriberClient:

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -31,7 +31,7 @@ else:
                      max_messages: int = 1000,
                      max_lease_duration: int = 1 * 60 * 60,
                      max_duration_per_lease_extension: int = 0) -> None:
-            super().__init__()
+            super(FlowControl, self).__init__()
             self.max_bytes = max_bytes
             self.max_messages = max_messages
             self.max_lease_duration = max_lease_duration

--- a/pubsub/gcloud/aio/pubsub/subscriber_message.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_message.py
@@ -36,7 +36,6 @@ else:
         def message_id(self) -> str:  # indirects to a Google protobuff field
             return str(self._message.message_id)
 
-        @property
         def __repr__(self) -> str:
             return repr(self._message)
 

--- a/pubsub/gcloud/aio/pubsub/subscriber_message.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_message.py
@@ -1,63 +1,71 @@
-from typing import Any
-from typing import Dict
-from typing import Optional
+from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
 
-from google.cloud.pubsub_v1.subscriber.message import Message as GoogleMessage
+if BUILD_GCLOUD_REST:
+    class Message:
+        def __init__(self, **kwargs) -> None:
+            raise NotImplementedError('this class is only implemented in aio')
+else:
+    from typing import Any
+    from typing import Dict
+    from typing import Optional
 
-class Message:
-    def __init__(self, **kwargs: Dict[str, Any]) -> None:
-        self._message = GoogleMessage(**kwargs)
+    from google.cloud.pubsub_v1.subscriber.message import Message \
+        as GoogleMessage
 
-    @property
-    def google_message(self):
-        return self._message
+    class Message:
+        def __init__(self, **kwargs: Dict[str, Any]) -> None:
+            self._message = GoogleMessage(**kwargs)
 
-    @property
-    def message_id(self):
-        return self._message.message_id  # indirects to: protocol buffer field
+        @property
+        def google_message(self):
+            return self._message
 
-    @property
-    def __repr__(self) -> str:
-        return repr(self._message)
+        @property
+        def message_id(self):
+            return self._message.message_id  # indirects: protocol buffer field
 
-    @property
-    def attributes(self) -> Any:  # ScalarMapContainer
-        return self._message.attributes
+        @property
+        def __repr__(self) -> str:
+            return repr(self._message)
 
-    @property
-    def data(self) -> bytes:
-        return bytes(self._message.data)
+        @property
+        def attributes(self) -> Any:  # ScalarMapContainer
+            return self._message.attributes
 
-    @property
-    def publish_time(self):  # datetime
-        return self._message.publish_time
+        @property
+        def data(self) -> bytes:
+            return bytes(self._message.data)
 
-    @property
-    def ordering_key(self) -> str:
-        return str(self._message.ordering_key)
+        @property
+        def publish_time(self):  # datetime
+            return self._message.publish_time
 
-    @property
-    def size(self) -> int:
-        return int(self._message.size)
+        @property
+        def ordering_key(self) -> str:
+            return str(self._message.ordering_key)
 
-    @property
-    def ack_id(self) -> str:
-        return str(self._message.ack_id)
+        @property
+        def size(self) -> int:
+            return int(self._message.size)
 
-    @property
-    def delivery_attempt(self) -> Optional[int]:
-        if self._message.delivery_attempt:
-            return int(self._message.delivery_attempt)
-        return None
+        @property
+        def ack_id(self) -> str:
+            return str(self._message.ack_id)
 
-    def ack(self) -> None:
-        self._message.ack()
+        @property
+        def delivery_attempt(self) -> Optional[int]:
+            if self._message.delivery_attempt:
+                return int(self._message.delivery_attempt)
+            return None
 
-    def drop(self) -> None:
-        self._message.drop()
+        def ack(self) -> None:
+            self._message.ack()
 
-    def modify_ack_deadline(self, seconds: int) -> None:
-        self._message.modify_ack_deadline(seconds)
+        def drop(self) -> None:
+            self._message.drop()
 
-    def nack(self) -> None:
-        self._message.nack()
+        def modify_ack_deadline(self, seconds: int) -> None:
+            self._message.modify_ack_deadline(seconds)
+
+        def nack(self) -> None:
+            self._message.nack()

--- a/pubsub/gcloud/aio/pubsub/subscriber_message.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_message.py
@@ -5,6 +5,8 @@ if BUILD_GCLOUD_REST:
         def __init__(self, **kwargs) -> None:
             raise NotImplementedError('this class is only implemented in aio')
 else:
+    import datetime
+
     from typing import Any
     from typing import Dict
     from typing import Optional
@@ -13,23 +15,23 @@ else:
         as GoogleMessage
 
     class Message:
-        def __init__(self, **kwargs: Dict[str, Any]) -> None:
-            self._message = GoogleMessage(**kwargs)
+        def __init__(self, *args, **kwargs: Dict[str, Any]) -> None:
+            self._message = GoogleMessage(*args, **kwargs)
 
         @property
-        def google_message(self):
+        def google_message(self) -> GoogleMessage:
             return self._message
 
         @property
-        def message_id(self):
-            return self._message.message_id  # indirects: protocol buffer field
+        def message_id(self) -> str:  # indirects to a Google protobuff field
+            return str(self._message.message_id)
 
         @property
         def __repr__(self) -> str:
             return repr(self._message)
 
         @property
-        def attributes(self) -> Any:  # ScalarMapContainer
+        def attributes(self) -> Any:  # Google .ScalarMapContainer
             return self._message.attributes
 
         @property
@@ -37,8 +39,9 @@ else:
             return bytes(self._message.data)
 
         @property
-        def publish_time(self):  # datetime
-            return self._message.publish_time
+        def publish_time(self) -> datetime.datetime:
+            published: datetime.datetime = self._message.publish_time
+            return published
 
         @property
         def ordering_key(self) -> str:

--- a/pubsub/gcloud/aio/pubsub/subscriber_message.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_message.py
@@ -1,0 +1,63 @@
+from typing import Any
+from typing import Dict
+from typing import Optional
+
+from google.cloud.pubsub_v1.subscriber.message import Message as GoogleMessage
+
+class Message:
+    def __init__(self, **kwargs: Dict[str, Any]) -> None:
+        self._message = GoogleMessage(**kwargs)
+
+    @property
+    def google_message(self):
+        return self._message
+
+    @property
+    def message_id(self):
+        return self._message.message_id  # indirects to: protocol buffer field
+
+    @property
+    def __repr__(self) -> str:
+        return repr(self._message)
+
+    @property
+    def attributes(self) -> Any:  # ScalarMapContainer
+        return self._message.attributes
+
+    @property
+    def data(self) -> bytes:
+        return bytes(self._message.data)
+
+    @property
+    def publish_time(self):  # datetime
+        return self._message.publish_time
+
+    @property
+    def ordering_key(self) -> str:
+        return str(self._message.ordering_key)
+
+    @property
+    def size(self) -> int:
+        return int(self._message.size)
+
+    @property
+    def ack_id(self) -> str:
+        return str(self._message.ack_id)
+
+    @property
+    def delivery_attempt(self) -> Optional[int]:
+        if self._message.delivery_attempt:
+            return int(self._message.delivery_attempt)
+        return None
+
+    def ack(self) -> None:
+        self._message.ack()
+
+    def drop(self) -> None:
+        self._message.drop()
+
+    def modify_ack_deadline(self, seconds: int) -> None:
+        self._message.modify_ack_deadline(seconds)
+
+    def nack(self) -> None:
+        self._message.nack()

--- a/pubsub/gcloud/aio/pubsub/subscriber_message.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_message.py
@@ -1,11 +1,11 @@
 from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
 
 if BUILD_GCLOUD_REST:
-    class Message:
+    class FlowControl:
         def __init__(self, **kwargs) -> None:
             raise NotImplementedError('this class is only implemented in aio')
 
-    class FlowControl:
+    class SubscriberMessage:
         def __init__(self, **kwargs) -> None:
             raise NotImplementedError('this class is only implemented in aio')
 
@@ -16,8 +16,7 @@ else:
     from typing import Dict
     from typing import Optional
 
-    from google.cloud.pubsub_v1.subscriber.message import Message \
-        as GoogleMessage
+    from google.cloud.pubsub_v1.subscriber.message import Message
 
 
     class FlowControl:
@@ -33,12 +32,12 @@ else:
                 max_duration_per_lease_extension)
 
 
-    class Message:
+    class SubscriberMessage:
         def __init__(self, *args, **kwargs: Dict[str, Any]) -> None:
-            self._message = GoogleMessage(*args, **kwargs)
+            self._message = Message(*args, **kwargs)
 
         @property
-        def google_message(self) -> GoogleMessage:
+        def google_message(self) -> Message:
             return self._message
 
         @property

--- a/pubsub/gcloud/aio/pubsub/subscriber_message.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_message.py
@@ -9,17 +9,27 @@ else:
 
     from typing import Any
     from typing import Dict
+    from typing import List
     from typing import Optional
 
     from google.cloud.pubsub_v1.subscriber.message import Message
 
 
     class SubscriberMessage:
-        def __init__(self, *args, **kwargs: Dict[str, Any]) -> None:
+        def __init__(self, *args: List[Any],
+                     google_cloud_message: Message = None,
+                     **kwargs: Dict[str, Any]) -> None:
+            if google_cloud_message:
+                self._message = google_cloud_message
+                return
             self._message = Message(*args, **kwargs)
 
+        @staticmethod
+        def from_google_cloud(message: Message) -> 'SubscriberMessage':
+            return SubscriberMessage(google_cloud_message=message)
+
         @property
-        def google_message(self) -> Message:
+        def google_cloud_message(self) -> Message:
             return self._message
 
         @property

--- a/pubsub/gcloud/aio/pubsub/subscriber_message.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_message.py
@@ -4,6 +4,11 @@ if BUILD_GCLOUD_REST:
     class Message:
         def __init__(self, **kwargs) -> None:
             raise NotImplementedError('this class is only implemented in aio')
+
+    class FlowControl:
+        def __init__(self, **kwargs) -> None:
+            raise NotImplementedError('this class is only implemented in aio')
+
 else:
     import datetime
 
@@ -13,6 +18,20 @@ else:
 
     from google.cloud.pubsub_v1.subscriber.message import Message \
         as GoogleMessage
+
+
+    class FlowControl:
+        def __init__(self,
+                     max_bytes: int = 100 * 1024 * 1024,
+                     max_messages: int = 1000,
+                     max_lease_duration: int = 1 * 60 * 60,
+                     max_duration_per_lease_extension: int = 0) -> None:
+            self.max_bytes = max_bytes
+            self.max_messages = max_messages
+            self.max_lease_duration = max_lease_duration
+            self.max_duration_per_lease_extension = (
+                max_duration_per_lease_extension)
+
 
     class Message:
         def __init__(self, *args, **kwargs: Dict[str, Any]) -> None:

--- a/pubsub/gcloud/aio/pubsub/subscriber_message.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_message.py
@@ -1,14 +1,9 @@
 from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
 
 if BUILD_GCLOUD_REST:
-    class FlowControl:
-        def __init__(self, **kwargs) -> None:
-            raise NotImplementedError('this class is only implemented in aio')
-
     class SubscriberMessage:
         def __init__(self, **kwargs) -> None:
             raise NotImplementedError('this class is only implemented in aio')
-
 else:
     import datetime
 
@@ -17,19 +12,6 @@ else:
     from typing import Optional
 
     from google.cloud.pubsub_v1.subscriber.message import Message
-
-
-    class FlowControl:
-        def __init__(self,
-                     max_bytes: int = 100 * 1024 * 1024,
-                     max_messages: int = 1000,
-                     max_lease_duration: int = 1 * 60 * 60,
-                     max_duration_per_lease_extension: int = 0) -> None:
-            self.max_bytes = max_bytes
-            self.max_messages = max_messages
-            self.max_lease_duration = max_lease_duration
-            self.max_duration_per_lease_extension = (
-                max_duration_per_lease_extension)
 
 
     class SubscriberMessage:

--- a/pubsub/gcloud/aio/pubsub/utils.py
+++ b/pubsub/gcloud/aio/pubsub/utils.py
@@ -1,3 +1,4 @@
+from typing import Any
 from typing import Dict
 from typing import Union
 
@@ -62,14 +63,14 @@ else:
 # https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage
 class PubsubMessage:
     def __init__(self, data: Union[bytes, str],
-                 **kwargs: Dict[str, str]) -> None:
+                 **kwargs: Dict[str, Any]) -> None:
         self.data = data
         self.attributes = kwargs
 
     def __repr__(self) -> str:
         return str(self.to_repr())
 
-    def to_repr(self) -> Dict[str, str]:
+    def to_repr(self) -> Dict[str, Any]:
         return {
             'data': encode(self.data).decode('utf-8'),
             'attributes': self.attributes,

--- a/pubsub/tests/unit/subscription_test.py
+++ b/pubsub/tests/unit/subscription_test.py
@@ -10,9 +10,10 @@ if BUILD_GCLOUD_REST:
 
 
 else:
+    from gcloud.aio.pubsub.subscriber_client import FlowControl
     from gcloud.aio.pubsub.subscriber_client import SubscriberClient
     from gcloud.aio.pubsub.subscriber_message import SubscriberMessage  # pylint: disable=unused-import
-    from gcloud.aio.pubsub.subscriber_message import FlowControl
+
 
     def test_construct_subscriber_client():
         SubscriberClient()

--- a/pubsub/tests/unit/subscription_test.py
+++ b/pubsub/tests/unit/subscription_test.py
@@ -1,2 +1,21 @@
+from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
+
+
 def test_importable():
     assert True
+
+
+if BUILD_GCLOUD_REST:
+    pass
+
+
+else:
+    from gcloud.aio.pubsub.subscriber_client import SubscriberClient
+    from gcloud.aio.pubsub.subscriber_message import SubscriberMessage  # pylint: disable=unused-import
+    from gcloud.aio.pubsub.subscriber_message import FlowControl
+
+    def test_construct_subscriber_client():
+        SubscriberClient()
+
+    def test_construct_flow_control():
+        FlowControl()


### PR DESCRIPTION
Add a layer of indirection for Google's Message class (`google.cloud.pubsub_v1.subscriber.message.Message`) with (`gcloud.aio.pubsub.subscriber_message.Message`);

Provide our own FlowControl class

Try removing scheduler --

This allows us to change the implementation details of our Message without the user having to change their usage of it, so that migration to full gcloud-aio can proceed underneath.

FlowControl is just a named tuple, so implementing it here means the user can stop importing it from google-cloud.

Finally, the Scheduler argument doesn't really make sense if we're migrating to fully asyncio since it allows the user to submit a custom queue for retrieving messages -- something that really makes more sense in a multi-thread context.

Steps ...
• ✅ evaluate if this is ergonomic
• ✅ stage this lib so we can tell if I've gotten wrapping the callbacks correct
• ✅ stage this by injecting it into an app that uses the named Subscriber features.
• ✅ copy changes learned from injection staging, and stage here one more time using example code.