### PR TITLE
chore(pubsub): update docs and FlowControl

### DIFF
--- a/pubsub/README.rst
+++ b/pubsub/README.rst
@@ -76,7 +76,7 @@ find in the `official Google documentation`_.
 Since the underlying Google implementation of ``Scheduler`` only allows for the
 concrete ``ThreadScheduler`` which is also the default, we have opted not to
 expose this configuration option. Additionally, we would like to fully
-deprecate said Google implementation in favour of a fully `asyncio`
+deprecate said Google implementation in favour of a fully ``asyncio``
 implementation which uses the event loop as the scheduler.
 
 When subscribing to a subscription you can optionally pass in a ``FlowControl``

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -5,6 +5,13 @@ if BUILD_GCLOUD_REST:
         def __init__(self, **kwargs) -> None:
             raise NotImplementedError('this class is only implemented in aio')
 
+        def __getattr__(self, attr: str) -> Any:
+            # N.B. Minimal interface required for unit testing aio version of
+            # FlowControl. Pylint sees unit tests' use of attributes on
+            # FlowControl but does not see those attributes in this (unused)
+            # REST definition and therefore fails.
+            pass
+
     class SubscriberClient:
         def __init__(self, **kwargs) -> None:
             raise NotImplementedError('this class is only implemented in aio')
@@ -49,21 +56,8 @@ else:
         def __getitem__(self, index: int) -> int:
             return self._flow_control[index]
 
-        @property
-        def max_bytes(self) -> int:
-            return self._flow_control.max_bytes
-
-        @property
-        def max_messages(self) -> int:
-            return self._flow_control.max_messages
-
-        @property
-        def max_lease_duration(self) -> int:
-            return self._flow_control.max_lease_duration
-
-        @property
-        def max_duration_per_lease_extension(self) -> int:
-            return self._flow_control.max_duration_per_lease_extension
+        def __getattr__(self, attr: str) -> Any:
+            return getattr(self._flow_control, attr)
 
 
     class SubscriberClient:

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -34,7 +34,7 @@ else:
         def __init__(self, *args: List[Any], **kwargs: Dict[str, Any]) -> None:
             """
             FlowControl transitional wrapper.
-            (FlowControl fields docs)[https://github.com/googleapis/python-pubsub/blob/6b9eec81ccee81ab93646eaf7652139fc218ed36/google/cloud/pubsub_v1/types.py#L139-L159]  # pylint: disable=line-too-long
+            (FlowControl fields docs)[https://github.com/googleapis/python-pubsub/blob/v1.7.0/google/cloud/pubsub_v1/types.py#L124-L166]  # pylint: disable=line-too-long
             Google uses a named tuple; here are the fields, defaults:
             - max_bytes: int = 100 * 1024 * 1024
             - max_messages: int = 1000
@@ -43,8 +43,27 @@ else:
             """
             self._flow_control = _FlowControl(*args, **kwargs)
 
+        def __repr__(self) -> str:
+            return self._flow_control.__repr__()
+
         def __getitem__(self, index: int) -> int:
             return self._flow_control[index]
+
+        @property
+        def max_bytes(self) -> int:
+            return self._flow_control.max_bytes
+
+        @property
+        def max_messages(self) -> int:
+            return self._flow_control.max_messages
+
+        @property
+        def max_lease_duration(self) -> int:
+            return self._flow_control.max_lease_duration
+
+        @property
+        def max_duration_per_lease_extension(self) -> int:
+            return self._flow_control.max_duration_per_lease_extension
 
 
     class SubscriberClient:

--- a/pubsub/tests/unit/subscription_test.py
+++ b/pubsub/tests/unit/subscription_test.py
@@ -18,5 +18,19 @@ else:
     def test_construct_subscriber_client():
         SubscriberClient()
 
+
     def test_construct_flow_control():
         FlowControl()
+
+
+    def test_flow_control_getattr():
+        f = FlowControl(
+            max_messages=1,
+            max_bytes=100,
+            max_lease_duration=10,
+            max_duration_per_lease_extension=0)
+
+        assert f.max_messages == 1
+        assert f.max_bytes == 100
+        assert f.max_lease_duration == 10
+        assert f.max_duration_per_lease_extension == 0


### PR DESCRIPTION
I noticed that our docs on the `SubscriberClient` and `FlowControl` were out of date with the version of `google-cloud-pubsub` we are now using. I updated them to reflect the state of internals of `google-cloud-pubsub==1.7.0` (the version we are on) after digging through its source.

In addition, I noticed that the examples use `f = FlowControl(); f.max_messages` and such types of property lookups which our version of `FlowControl` doesn't have so I updated it to make the docs easy to follow.