### PR TITLE
chore(pubsub): bump version

### DIFF
--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as f:
 
 setuptools.setup(
     name='gcloud-aio-pubsub',
-    version='2.0.0',
+    version='2.0.1',
     description='Python Client for Google Cloud Pub/Sub',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Bump `pubsub-2.0.0 -> pubsub-2.0.1` to pick up documentation updates and minor fixes outlined in https://github.com/talkiq/gcloud-aio/pull/209.