### PR TITLE
chore(pubsub): bump pubsub from 2.0.1 to 2.1.0

### DIFF
--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as f:
 
 setuptools.setup(
     name='gcloud-aio-pubsub',
-    version='2.0.1',
+    version='2.1.0',
     description='Python Client for Google Cloud Pub/Sub',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Releases `SubscriberClient` for `gcloud-rest-pubsub`. (https://github.com/talkiq/gcloud-aio/pull/210)