### PR TITLE
fix(pubsub) Cast Message to SubscriberMessage in a callback passed to subscribe()

### DIFF
--- a/pubsub/gcloud/aio/pubsub/subscriber_message.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_message.py
@@ -1,88 +1,75 @@
+import datetime
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
 
-from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
+from google.cloud.pubsub_v1.subscriber.message import Message
 
 
-if BUILD_GCLOUD_REST:
-    class SubscriberMessage:
-        def __init__(self, **kwargs: Any) -> None:
-            raise NotImplementedError('this class is only implemented in aio')
+class SubscriberMessage:
+    def __init__(self, *args: List[Any],
+                 google_cloud_message: Message = None,
+                 **kwargs: Dict[str, Any]) -> None:
+        if google_cloud_message:
+            self._message = google_cloud_message
+            return
+        self._message = Message(*args, **kwargs)
 
-        @staticmethod
-        def from_google_cloud(message: Any) -> 'SubscriberMessage':
-            raise NotImplementedError('this class is only implemented in aio')
-else:
-    import datetime
+    @staticmethod
+    def from_google_cloud(message: Message) -> 'SubscriberMessage':
+        return SubscriberMessage(google_cloud_message=message)
 
-    from google.cloud.pubsub_v1.subscriber.message import Message
+    @property
+    def google_cloud_message(self) -> Message:
+        return self._message
 
+    @property
+    def message_id(self) -> str:  # indirects to a Google protobuff field
+        return str(self._message.message_id)
 
-    class SubscriberMessage:  # type: ignore[no-redef]
-        def __init__(self, *args: List[Any],
-                     google_cloud_message: Message = None,
-                     **kwargs: Dict[str, Any]) -> None:
-            if google_cloud_message:
-                self._message = google_cloud_message
-                return
-            self._message = Message(*args, **kwargs)
+    def __repr__(self) -> str:
+        return repr(self._message)
 
-        @staticmethod
-        def from_google_cloud(message: Message) -> 'SubscriberMessage':
-            return SubscriberMessage(google_cloud_message=message)
+    @property
+    def attributes(self) -> Any:  # Google .ScalarMapContainer
+        return self._message.attributes
 
-        @property
-        def google_cloud_message(self) -> Message:
-            return self._message
+    @property
+    def data(self) -> bytes:
+        return bytes(self._message.data)
 
-        @property
-        def message_id(self) -> str:  # indirects to a Google protobuff field
-            return str(self._message.message_id)
+    @property
+    def publish_time(self) -> datetime.datetime:
+        published: datetime.datetime = self._message.publish_time
+        return published
 
-        def __repr__(self) -> str:
-            return repr(self._message)
+    @property
+    def ordering_key(self) -> str:
+        return str(self._message.ordering_key)
 
-        @property
-        def attributes(self) -> Any:  # Google .ScalarMapContainer
-            return self._message.attributes
+    @property
+    def size(self) -> int:
+        return int(self._message.size)
 
-        @property
-        def data(self) -> bytes:
-            return bytes(self._message.data)
+    @property
+    def ack_id(self) -> str:
+        return str(self._message.ack_id)
 
-        @property
-        def publish_time(self) -> datetime.datetime:
-            published: datetime.datetime = self._message.publish_time
-            return published
+    @property
+    def delivery_attempt(self) -> Optional[int]:
+        if self._message.delivery_attempt:
+            return int(self._message.delivery_attempt)
+        return None
 
-        @property
-        def ordering_key(self) -> str:
-            return str(self._message.ordering_key)
+    def ack(self) -> None:
+        self._message.ack()
 
-        @property
-        def size(self) -> int:
-            return int(self._message.size)
+    def drop(self) -> None:
+        self._message.drop()
 
-        @property
-        def ack_id(self) -> str:
-            return str(self._message.ack_id)
+    def modify_ack_deadline(self, seconds: int) -> None:
+        self._message.modify_ack_deadline(seconds)
 
-        @property
-        def delivery_attempt(self) -> Optional[int]:
-            if self._message.delivery_attempt:
-                return int(self._message.delivery_attempt)
-            return None
-
-        def ack(self) -> None:
-            self._message.ack()
-
-        def drop(self) -> None:
-            self._message.drop()
-
-        def modify_ack_deadline(self, seconds: int) -> None:
-            self._message.modify_ack_deadline(seconds)
-
-        def nack(self) -> None:
-            self._message.nack()
+    def nack(self) -> None:
+        self._message.nack()

--- a/pubsub/tests/unit/subscription_test.py
+++ b/pubsub/tests/unit/subscription_test.py
@@ -1,55 +1,47 @@
-from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
+from queue import Queue
+
+from gcloud.aio.pubsub.subscriber_client import FlowControl
+from gcloud.aio.pubsub.subscriber_client import SubscriberClient
+from gcloud.aio.pubsub.subscriber_message import SubscriberMessage  # pylint: disable=unused-import
+from google.cloud.pubsub_v1.subscriber.message import Message
+from google.cloud.pubsub_v1.types import PubsubMessage
 
 
 def test_importable():
     assert True
 
 
-if BUILD_GCLOUD_REST:
-    pass
+def test_construct_subscriber_client():
+    SubscriberClient()
 
 
-else:
-    from queue import Queue
-
-    from gcloud.aio.pubsub.subscriber_client import FlowControl
-    from gcloud.aio.pubsub.subscriber_client import SubscriberClient
-    from gcloud.aio.pubsub.subscriber_message import SubscriberMessage
-    from google.cloud.pubsub_v1.subscriber.message import Message
-    from google.cloud.pubsub_v1.types import PubsubMessage
+def test_construct_flow_control():
+    FlowControl()
 
 
-    def test_construct_subscriber_client():
-        SubscriberClient()
+def test_flow_control_getattr():
+    f = FlowControl(
+        max_messages=1,
+        max_bytes=100,
+        max_lease_duration=10,
+        max_duration_per_lease_extension=0)
 
+    assert f.max_messages == 1
+    assert f.max_bytes == 100
+    assert f.max_lease_duration == 10
+    assert f.max_duration_per_lease_extension == 0
 
-    def test_construct_flow_control():
-        FlowControl()
+def test_construct_subscriber_message_from_google_message():
+    ack_id = 'some_ack_id'
+    delivery_attempt = 0
+    request_queue = Queue()
 
+    pubsub_message = PubsubMessage()
+    pubsub_message.attributes['style'] = 'cool'
+    google_message = Message(pubsub_message, ack_id, delivery_attempt,
+                             request_queue)
 
-    def test_flow_control_getattr():
-        f = FlowControl(
-            max_messages=1,
-            max_bytes=100,
-            max_lease_duration=10,
-            max_duration_per_lease_extension=0)
-
-        assert f.max_messages == 1
-        assert f.max_bytes == 100
-        assert f.max_lease_duration == 10
-        assert f.max_duration_per_lease_extension == 0
-
-    def test_construct_subscriber_message_from_google_message():
-        ack_id = 'some_ack_id'
-        delivery_attempt = 0
-        request_queue = Queue()
-
-        pubsub_message = PubsubMessage()
-        pubsub_message.attributes['style'] = 'cool'
-        google_message = Message(pubsub_message, ack_id, delivery_attempt,
-                                 request_queue)
-
-        subscriber_message = SubscriberMessage.from_google_cloud(google_message)
-        assert subscriber_message.ack_id == ack_id
-        assert subscriber_message.delivery_attempt is None  # only an int if >0
-        assert subscriber_message.attributes['style'] == 'cool'
+    subscriber_message = SubscriberMessage.from_google_cloud(google_message)
+    assert subscriber_message.ack_id == ack_id
+    assert subscriber_message.delivery_attempt is None  # only an int if >0
+    assert subscriber_message.attributes['style'] == 'cool'


### PR DESCRIPTION
so @jonathan-johnston draw my attention to the fact that things like that:

```
if BUILD_GCLOUD_REST:
    class SubscriberMessage:
        def __init__(self, **kwargs: Any) -> None:
            raise NotImplementedError('this class is only implemented in aio')

        @staticmethod
        def from_google_cloud(message: Any) -> 'SubscriberMessage':
            raise NotImplementedError('this class is only implemented in aio')
```

Should probably not exist in a working `gcloud-rest-*` library.

In this PR:
1. Remove `if BUILD_GCLOUD_REST` and define `SubscriberMessage` for both `-aio-` and `-rest-` variants
2. Cast `Message` to `SubscriberMessage` in  `callback` provided to `SubscriberClient.subscribe` method