### PR TITLE
chore(bq): bump bigquery 4.1.0 -> 4.1.1

### DIFF
--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as f:
 
 setuptools.setup(
     name='gcloud-aio-bigquery',
-    version='4.1.0',
+    version='4.1.1',
     description='Python Client for Google Cloud BigQuery',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Picks up #214 to allow arbitrary project selection for development.