### PR TITLE
feat(pubsub): proper subscriber cleanup

### DIFF
--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -107,8 +107,6 @@ else:
 
     from google.cloud import pubsub
 
-    from .utils import convert_google_future_to_concurrent_future
-
 
     class SubscriberClient:  # type: ignore[no-redef]
         def __init__(self, *, loop: Optional[asyncio.AbstractEventLoop] = None,
@@ -152,10 +150,6 @@ else:
                     self._wrap_callback(callback),
                     flow_control=flow_control))
 
-            convert_google_future_to_concurrent_future(
-                sub_keepalive, loop=self.loop)
-
-            _ = asyncio.wrap_future(sub_keepalive)
             self.loop.add_signal_handler(signal.SIGTERM, sub_keepalive.cancel)
 
             return sub_keepalive

--- a/pubsub/gcloud/aio/pubsub/utils.py
+++ b/pubsub/gcloud/aio/pubsub/utils.py
@@ -2,62 +2,7 @@ from typing import Any
 from typing import Dict
 from typing import Union
 
-from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
 from gcloud.aio.auth import encode  # pylint: disable=no-name-in-module
-
-
-if BUILD_GCLOUD_REST:
-    pass
-else:
-    import asyncio
-    import concurrent
-    import threading
-
-    import google.api_core.future
-
-
-    def convert_google_future_to_concurrent_future(
-            future: google.api_core.future.Future, *,
-            loop: asyncio.AbstractEventLoop) -> None:
-        """
-        The google-cloud-pubsub subscription library returns a
-        `google.cloud.pubsub_v1.subscriber.futures.StreamingPullFuture`,
-        which is a subclass of `google.api_core.future.Future`, which in turn
-        is NOT a subclass of `concurrent.futures.Future` (even though it is
-        explicitly designed to be interface-identical).
-
-        A `concurrent.futures.Future` can be added to an asyncio task queue
-        with `asyncio.wrap_future`, but that method explicitly calls
-        `isinstance` rather than duck-typing the future.
-
-        This method exists as a hack to make `asyncio.wrap_future` think that
-        a google `Future` is valid.
-
-        Here are the gotchas is uses to do so:
-        - sets `future.__class__` so the `isinstance` check works
-        - sets `future._condition`, `future._state`, `future._done_callbacks`
-          and `future._waiters` to their equivalent expected values (these are
-          the attributes which Google decided to avoid mirroring from
-          `concurrent.futures`)
-        - spawns an infinite task which `await`s every second, which prevents
-          the Google future from occasionally getting stuck
-        """
-        # BEWARE: here be dragons
-        async def await_on_interval(interval: int) -> None:
-            while True:
-                await asyncio.sleep(interval)
-
-        def _state(self: concurrent.futures.Future) -> str:  # type: ignore
-            return 'RUNNING' if self.running() else 'FINISHED'
-
-        future._condition = threading.Condition()  # pylint: disable=protected-access
-        future.__class__ = concurrent.futures.Future
-        setattr(future, '_state', property(_state))
-        setattr(future, '_done_callbacks',
-                future._callbacks)  # pylint: disable=protected-access
-        setattr(future, '_waiters', [])
-
-        loop.create_task(await_on_interval(1))
 
 
 # https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage


### PR DESCRIPTION
Currently calling [sub_keepalive.cancel()](https://github.com/talkiq/gcloud-aio/blob/pubsub-2.1.2/pubsub/gcloud/aio/pubsub/subscriber_client.py#L181) on the `asyncio.Future` returned by the subscriber does not properly invoke the original `cancel` method of Google's `StreamingPullFuture`. This fact was due to modifying and wrapping the future with the intention of getting Pub/Sub to correctly run callbacks on the asyncio event loop.

After some investigation, it was discovered that wrapping the future was not needed, and in fact only running the callback via `asyncio.run_coroutine_threadsafe`, which was added _after_ these changes, is needed to have Pub/Sub and asyncio play nicely together.

Now, `cancel`ling the returned future invokes the behaviour [here](https://github.com/googleapis/python-pubsub/blob/v1.7.0/google/cloud/pubsub_v1/subscriber/futures.py#L46) and so we cleanup properly as desired (i.e. stop pulling messages).

More details: [VAE-2169](https://switchcomm.atlassian.net/browse/VAE-2169)

NOTE: This change _probably_ requires a major version bump, since `cancel` now has new behavior, and typing has changed.

- [x] This change has been tested in realtime-egress and offline runner. (apps run properly, termination invokes `cancel` which correctly stops pulling messages)