### PR TITLE
feat(bq) Add method for v2/jobs/get

### DIFF
--- a/bigquery/gcloud/aio/bigquery/__init__.py
+++ b/bigquery/gcloud/aio/bigquery/__init__.py
@@ -6,7 +6,8 @@ from gcloud.aio.bigquery.bigquery import SCOPES
 from gcloud.aio.bigquery.bigquery import SourceFormat
 from gcloud.aio.bigquery.bigquery import SchemaUpdateOption
 from gcloud.aio.bigquery.bigquery import Table
+from gcloud.aio.bigquery.bigquery import Job
 
 
 __all__ = ['__version__', 'Disposition', 'SCOPES', 'SourceFormat',
-           'SchemaUpdateOption', 'Table']
+           'SchemaUpdateOption', 'Table', 'Job']

--- a/bigquery/gcloud/aio/bigquery/bigquery.py
+++ b/bigquery/gcloud/aio/bigquery/bigquery.py
@@ -326,6 +326,22 @@ class Table:
         body = self._make_query_body(query, project, write_disposition)
         return await self._post_json(url, body, session, timeout)
 
+    # https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/get
+    async def get_job(self, job_id: str,
+                      session: Optional[Session] = None,
+                      timeout: int = 60) -> Dict[str, Any]:
+        """Get the specified job resource by job ID."""
+
+        project = await self.project()
+        url = f'{API_ROOT}/projects/{project}/jobs/{job_id}'
+
+        headers = await self.headers()
+
+        s = AioSession(session) if session else self.session
+        resp = await s.get(url, headers=headers, timeout=timeout)
+        data: Dict[str, Any] = await resp.json()
+        return data
+
     async def close(self) -> None:
         await self.session.close()
 


### PR DESCRIPTION
I don't like this PR. There is no reason `get_job` should be a method of `Table` class, yet there is no other place for it. Unless we want to redesign `gcloud-aio-bigquery` :(

Let me know what you think