### PR TITLE
chore(pubsub): bump pubsub 2.1.2 -> 3.0.0

### DIFF
--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as f:
 
 setuptools.setup(
     name='gcloud-aio-pubsub',
-    version='2.1.2',
+    version='3.0.0',
     description='Python Client for Google Cloud Pub/Sub',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Major version bump for backwards incompatible change https://github.com/talkiq/gcloud-aio/pull/223.