### PR TITLE
chore(bigquery): bump version from 4.1.1 -> 5.0.0

### DIFF
--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as f:
 
 setuptools.setup(
     name='gcloud-aio-bigquery',
-    version='4.1.1',
+    version='5.0.0',
     description='Python Client for Google Cloud BigQuery',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Create a release for https://github.com/talkiq/gcloud-aio/pull/224 which introduces the following changes:

- Introduce `SchemaUpdateOption` which can be used in `Table.insert_via_load` to (1) allow new fields to be added, and (2) allow relaxing `REQUIRED` fields to `NULLABLE` via the respective options (1) `ALLOW_FIELD_ADDITION` and (2) `ALLOW_FIELD_RELAXATION`
- Add option `ignore_unknown_values` to `Table.insert_via_load` which, when specified, ignores any values in a row that are not present in the table schema
- Introduce a `Job` class which replaces the JSON dictionary returned by the API and enables actions to be taken on the created job like `Job.get_job`, `Job.get_query_results`, and `Job.cancel`

These changes are more ergonomic but breaking and thus requires a major version bump. The return type of public methods have changed and thus user code must change to handle the `Job` class rather than JSON.