### PR TITLE
feat(bigquery) Move insert_via_query to Job class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,8 @@ jobs:
 
       # Backport other things like type hints, exception handling, etc.
       - run: find . -type f -path '*py' | grep -Ev "datastore.*(value|constants|value_types_test|value_test)\.py$" | xargs -L1 pasteurize --nobackups --write
+      # Delete imports that will be reintroduced later
+      - run: find . -type f -path '*py' | xargs -L1 sed -Ei '/import warnings/d'
       # https://github.com/PythonCharmers/python-future/issues/551
       - run: find . -type f -path '*py' | xargs -L1 sed -Ei 's/^(.*)from future import standard_library/\1import warnings\n\1with warnings.catch_warnings():\n\1    warnings.simplefilter("ignore")\n\1    from future import standard_library/g'
 

--- a/bigquery/gcloud/aio/bigquery/bigquery.py
+++ b/bigquery/gcloud/aio/bigquery/bigquery.py
@@ -2,7 +2,6 @@ import io
 import json
 import os
 import uuid
-import warnings
 from enum import Enum
 from typing import Any
 from typing import Callable
@@ -468,6 +467,7 @@ class Table:
             timeout: int = 60, use_query_cache: bool = True,
             dry_run: bool = False, use_legacy_sql: bool = True) -> Job:
         """Create table as a result of the query"""
+        import warnings
         warnings.warn('using Table#insert_via_query is deprecated.'
                       'use Job#insert_via_query instead', DeprecationWarning)
         project = await self.project()

--- a/bigquery/gcloud/aio/bigquery/bigquery.py
+++ b/bigquery/gcloud/aio/bigquery/bigquery.py
@@ -1,4 +1,3 @@
-# pylint disable=reimported
 import io
 import json
 import os

--- a/bigquery/gcloud/aio/bigquery/bigquery.py
+++ b/bigquery/gcloud/aio/bigquery/bigquery.py
@@ -192,7 +192,8 @@ class Job:
                                      use_legacy_sql=use_legacy_sql,
                                      destination_table=destination_table)
         response = await self._post_json(url, body, session, timeout)
-        self.job_id = response['jobReference']['jobId']
+        if not dry_run:
+            self.job_id = response['jobReference']['jobId']
         return response
 
 
@@ -476,7 +477,8 @@ class Table:
         body = self._make_query_body(query, project, write_disposition,
                                      use_query_cache, dry_run, use_legacy_sql)
         response = await self._post_json(url, body, session, timeout)
-        return Job(response['jobReference']['jobId'], self._project,
+        job_id = response['jobReference']['jobId'] if not dry_run else None
+        return Job(job_id, self._project,
                    session=self.session, token=self.token)
 
     async def close(self) -> None:

--- a/bigquery/gcloud/aio/bigquery/bigquery.py
+++ b/bigquery/gcloud/aio/bigquery/bigquery.py
@@ -176,7 +176,7 @@ class Job:
             write_disposition: Disposition = Disposition.WRITE_EMPTY,
             timeout: int = 60, use_query_cache: bool = True,
             dry_run: bool = False, use_legacy_sql: bool = True,
-            table: Optional[Table] = None) -> Dict[str, Any]:
+            table: Optional['Table'] = None) -> Dict[str, Any]:
         """Create table as a result of the query"""
         project = await self.project()
         url = f'{API_ROOT}/projects/{project}/jobs'

--- a/bigquery/gcloud/aio/bigquery/bigquery.py
+++ b/bigquery/gcloud/aio/bigquery/bigquery.py
@@ -1,7 +1,9 @@
+# pylint disable=reimported
 import io
 import json
 import os
 import uuid
+import warnings
 from enum import Enum
 from typing import Any
 from typing import Callable
@@ -467,7 +469,6 @@ class Table:
             timeout: int = 60, use_query_cache: bool = True,
             dry_run: bool = False, use_legacy_sql: bool = True) -> Job:
         """Create table as a result of the query"""
-        import warnings
         warnings.warn('using Table#insert_via_query is deprecated.'
                       'use Job#insert_via_query instead', DeprecationWarning)
         project = await self.project()

--- a/bigquery/gcloud/aio/bigquery/bigquery.py
+++ b/bigquery/gcloud/aio/bigquery/bigquery.py
@@ -93,13 +93,17 @@ class Job:
             write_disposition: Disposition,
             use_query_cache: bool,
             dry_run: bool, use_legacy_sql: bool,
-            destination_table: Optional[Dict[str, object]]) -> Dict[str, Any]:
+            destination_table: Optional['Table']) -> Dict[str, Any]:
         return {
             'configuration': {
                 'query': {
                     'query': query,
                     'writeDisposition': write_disposition.value,
-                    'destinationTable': destination_table,
+                    'destinationTable': {
+                        'projectId': destination_table.project,
+                        'datasetId': destination_table.dataset_name,
+                        'tableId': destination_table.table_name,
+                    } if destination_table else destination_table,
                     'useQueryCache': use_query_cache,
                     'useLegacySql': use_legacy_sql,
                 },
@@ -176,17 +180,10 @@ class Job:
             write_disposition: Disposition = Disposition.WRITE_EMPTY,
             timeout: int = 60, use_query_cache: bool = True,
             dry_run: bool = False, use_legacy_sql: bool = True,
-            table: Optional['Table'] = None) -> Dict[str, Any]:
+            destination_table: Optional['Table'] = None) -> Dict[str, Any]:
         """Create table as a result of the query"""
         project = await self.project()
         url = f'{API_ROOT}/projects/{project}/jobs'
-        destination_table = None
-        if table:
-            destination_table = {
-                'projectId': table.project,
-                'datasetId': table.dataset_name,
-                'tableId': table.table_name,
-            }
 
         body = self._make_query_body(query=query,
                                      write_disposition=write_disposition,

--- a/bigquery/gcloud/aio/bigquery/bigquery.py
+++ b/bigquery/gcloud/aio/bigquery/bigquery.py
@@ -310,7 +310,7 @@ class Table:
             self, query: str, project: str,
             write_disposition: Disposition,
             use_query_cache: bool,
-            dry_run: bool, use_legacy_sql: bool) -> Dict[str, Any]:
+            dry_run: bool) -> Dict[str, Any]:
         return {
             'configuration': {
                 'query': {
@@ -322,7 +322,6 @@ class Table:
                         'tableId': self.table_name,
                     },
                     'useQueryCache': use_query_cache,
-                    'useLegacySql': use_legacy_sql,
                 },
                 'dryRun': dry_run,
             },
@@ -467,7 +466,7 @@ class Table:
             self, query: str, session: Optional[Session] = None,
             write_disposition: Disposition = Disposition.WRITE_EMPTY,
             timeout: int = 60, use_query_cache: bool = True,
-            dry_run: bool = False, use_legacy_sql: bool = True) -> Job:
+            dry_run: bool = False) -> Job:
         """Create table as a result of the query"""
         warnings.warn('using Table#insert_via_query is deprecated.'
                       'use Job#insert_via_query instead', DeprecationWarning)
@@ -475,7 +474,7 @@ class Table:
         url = f'{API_ROOT}/projects/{project}/jobs'
 
         body = self._make_query_body(query, project, write_disposition,
-                                     use_query_cache, dry_run, use_legacy_sql)
+                                     use_query_cache, dry_run)
         response = await self._post_json(url, body, session, timeout)
         job_id = response['jobReference']['jobId'] if not dry_run else None
         return Job(job_id, self._project,


### PR DESCRIPTION
Here we go again. So turned out `insert_via_query` can be totally executed against `destinationTable: null`. That kind of defeats the purpose of having this method in the `Table` class. So in this PR we move the method to `Job` (making `job_id` optional along the way) and mark previous one as deprecated.