### PR TITLE
feat(pubsub) Add rest endpoints to pull, ack and nack messages

### DIFF
--- a/pubsub/README.rst
+++ b/pubsub/README.rst
@@ -19,18 +19,10 @@ Usage
 Subscriber
 ~~~~~~~~~~
 
-The official Google publisher returns a future which is mostly useable as-is.
-``gcloud-rest`` returns the future without change while ``gcloud-aio`` wraps it in ``asyncio`` terms.
+At the moment, ``gcloud-{aio,rest}-pubsub`` only provides a set of handles
+to call Pubsub REST API.
 
-An HTTP-oriented version, in keeping with the other ``gcloud-{aio,rest}-*`` libraries,
-will likely be coming soon -- though our current approach works reasonably well
-for allowing the official ``grpc`` client to be used under ``asyncio``, we
-continue to see threading oddities now and again which we've not been able to
-solve. As such, we do not wholeheartedly recommend using the
-``SubscriberClient`` of this library in production, though a resilient enough
-environment for your use-case may be possible.
-
-Here's the rough usage pattern for subscribing:
+Here's the rough usage pattern for using ``SubscriberClient``:
 
 .. code-block:: python
 
@@ -38,155 +30,16 @@ Here's the rough usage pattern for subscribing:
     from gcloud.aio.pubsub import SubscriberMessage
 
     client = SubscriberClient()
-    # create subscription if it doesn't already exist
+    # create subscription
     client.create_subscription(
         'projects/<project_name>/subscriptions/<subscription_name>',
         'projects/<project_name>/topics/<topic_name>')
 
-    async def message_callback(message: SubscriberMessage) -> None:
-        try:
-            # just an example: process the message however you need to here...
-            result = handle(message)
-            await upload_result(result)
-        except Exception:
-            message.nack()
-        else:
-            message.ack()
-
-    # subscribe to the subscription, receiving a Future that acts as a keepalive
-    keep_alive = client.subscribe(
+    # pull messages
+    client.pull(
         'projects/<project_name>/subscriptions/<subscription_name>',
-        message_callback)
+        max_messages=10)
 
-    # have the client run forever, pulling messages from this subscription,
-    # passing them to the specified callback function, and wrapping it in an
-    # asyncio task.
-    client.run_forever(keep_alive)
-
-Configuration
-^^^^^^^^^^^^^
-
-Our create_subscription method is a thin wrapper and thus supports almost all
-keyword configuration arguments from the official pubsub client which you can
-find in the `official Google documentation`_.
-
-Since the underlying Google implementation of ``Scheduler`` only allows for the
-concrete ``ThreadScheduler`` which is also the default, we have opted not to
-expose this configuration option. Additionally, we would like to fully
-deprecate said Google implementation in favour of a fully ``asyncio``
-implementation which uses the event loop as the scheduler.
-
-When subscribing to a subscription you can optionally pass in a ``FlowControl``
-instance.
-
-.. code-block:: python
-
-    example_flow_control = FlowControl(
-        max_bytes=100*1024*1024,
-        max_messages=1,
-        max_lease_duration=10,
-        max_duration_per_lease_extension=0,
-    )
-
-    keep_alive = client.subscribe(
-        'projects/<project_name>/subscriptions/<subscription_name>',
-        message_callback,
-        flow_control=example_flow_control
-    )
-
-Understanding how modifying ``FlowControl`` affects how your pubsub runtime
-will operate can be confusing so here's a handy dandy guide!
-
-Welcome to @TheKevJames and @jonathan-johnston's guide to configuring Google
-Pubsub Subscription policies! Settle in, grab a drink, and stay a while.
-
-The Subscriber is controlled by a ``FlowControl`` configuration tuple defined `in gcloud-aio <https://github.com/talkiq/gcloud-aio/blob/pubsub-2.0.0/pubsub/gcloud/aio/pubsub/subscriber_client.py#L33>`_ and subsequently in
-`google-cloud-pubsub <https://github.com/googleapis/python-pubsub/blob/v1.7.0/google/cloud/pubsub_v1/types.py#L124-L166>`_.
-
-That configuration object ``f`` gets used by the ``Subscriber`` in the
-following ways:
-
-Max Concurrency
-_______________
-
-The subscriber stops leasing new tasks whenever too many messages or too many
-message bytes have been leased for currently leased tasks ``x``:
-
-.. code-block:: python
-
-    max(
-        len(x) / f.max_messages,
-        sum(x.bytes) / f.max_bytes
-    ) >= 1.0
-
-And leasing is resumed when there is some breathing room in terms of message
-counts or byte counts:
-
-.. code-block:: python
-
-    max(
-        len(x) / f.max_messages,
-        sum(x.bytes) / f.max_bytes
-    ) < 0.8
-
-In practice, this means we should set these values with the following
-restrictions:
-
-- the maximum number of concurrently leased messages at peak is:
-  ``= f.max_messages + f.max_messages mod batch_size``
-- the maximum memory usage of our leased messages at peak is:
-  ``= f.max_bytes + f.max_bytes mod (batch_size * bytes_per_messages)``
-- these values are constrain each other, ie. we limit ourselves to the lesser
-  of these values, with ``batch_size`` calculated dynamically in PubSub itself
-
-Aside: it seems like OCNs on Pubsub are ~1538 bytes each.
-
-Leasing Requests
-________________
-
-When leasing new tasks, the ``Subscriber`` simply continues to request messages
-from the PubSub subscription until the aforementioned message concurrency or
-total message bytes limits are hit. At that point, the message consumer is
-paused while the messages are processed and resumed when the resume condition
-is met.
-
-Message processing and message leasing are carried out in parallel. When a
-message batch is received from the PubSub subscription the messages are
-scheduled for processing immediately on a
-``concurrent.futures.ThreadPoolExecutor``. This ``Scheduler`` should be filling
-up as fast as grpc can make requests to Google Pubsub, which should be Fast
-Enough(tm) to keep it filled, given *those* requests are batched.
-
-Task Expiry
-___________
-
-Any task which has not been acked or nacked counts against the current leased
-task count. Our worker thread should ensure all tasks are acked or nacked, but
-the ``FlowControl`` config allows us to handle any other cases. Note that
-leasing works as follows:
-
-- When a subscriber leases a task, Google Pubsub will not re-lease that
-  task until ``subscription.ack_deadline_seconds = 10`` (configurable
-  per-subscription) seconds have passed.
-- If a client calls ``ack()`` on a task, it is immediately removed from Google
-  Pubsub.
-- If a client calls ``nack()`` on a task, it immediately allows Google Pubsub
-  to re-lease that task to a new client. The client drops the task from its
-  memory.
-- If ``f.max_lease_duration`` passes between a message being leased and acked,
-  the client will send a ``nack`` (see above workflow). It will NOT drop the
-  task from its memory -- eg. the ``worker(task)`` process may still be run.
-
-Notes:
-
-- all steps are best-effort, eg. read "a task will be deleted" as "a task will
-  probably get deleted, if the distributed-system luck is with you"
-- in the above workflow "Google Pubsub" refers to the server-side system, eg.
-  managed by Google where the tasks are actually stored.
-
-In practice, we should thus set ``f.max_lease_duration`` to no lower than
-our 95% percentile task latency at high load. The lower this value is,
-the better our throughput will be in extreme cases.
 
 Publisher
 ~~~~~~~~~

--- a/pubsub/README.rst
+++ b/pubsub/README.rst
@@ -31,12 +31,12 @@ Here's the rough usage pattern for using ``SubscriberClient``:
 
     client = SubscriberClient()
     # create subscription
-    client.create_subscription(
+    await client.create_subscription(
         'projects/<project_name>/subscriptions/<subscription_name>',
         'projects/<project_name>/topics/<topic_name>')
 
     # pull messages
-    client.pull(
+    await client.pull(
         'projects/<project_name>/subscriptions/<subscription_name>',
         max_messages=10)
 

--- a/pubsub/README.rst
+++ b/pubsub/README.rst
@@ -36,7 +36,7 @@ Here's the rough usage pattern for using ``SubscriberClient``:
         'projects/<project_name>/topics/<topic_name>')
 
     # pull messages
-    await client.pull(
+    messages: List[SubscriberMessage] = await client.pull(
         'projects/<project_name>/subscriptions/<subscription_name>',
         max_messages=10)
 

--- a/pubsub/gcloud/aio/pubsub/__init__.py
+++ b/pubsub/gcloud/aio/pubsub/__init__.py
@@ -4,9 +4,8 @@ __version__ = get_distribution('gcloud-aio-pubsub').version
 from gcloud.aio.pubsub.publisher_client import PublisherClient
 from gcloud.aio.pubsub.subscriber_client import SubscriberClient
 from gcloud.aio.pubsub.utils import PubsubMessage
-from gcloud.aio.pubsub.subscriber_client import FlowControl
 from gcloud.aio.pubsub.subscriber_message import SubscriberMessage
 
 
-__all__ = ['__version__', 'FlowControl', 'PublisherClient', 'PubsubMessage',
+__all__ = ['__version__', 'PublisherClient', 'PubsubMessage',
            'SubscriberClient', 'SubscriberMessage']

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -1,12 +1,18 @@
+import json
+import os
 from typing import Any
+from typing import AnyStr
 from typing import Callable
 from typing import Dict
+from typing import IO
 from typing import List
 from typing import Optional
 from typing import Tuple
 from typing import Union
 
+from gcloud.aio.auth import AioSession
 from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
+from gcloud.aio.auth import Token
 from google.api_core import exceptions
 from google.cloud.pubsub_v1.subscriber.futures import StreamingPullFuture
 from google.cloud.pubsub_v1.subscriber.message import Message
@@ -14,6 +20,17 @@ from google.cloud.pubsub_v1.types import FlowControl as _FlowControl
 
 from .subscriber_message import SubscriberMessage
 
+API_ROOT = 'https://pubsub.googleapis.com'
+VERIFY_SSL = True
+
+SCOPES = [
+    'https://www.googleapis.com/auth/pubsub'
+]
+
+PUBSUB_EMULATOR_HOST = os.environ.get('PUBSUB_EMULATOR_HOST')
+if PUBSUB_EMULATOR_HOST:
+    API_ROOT = f'https://{PUBSUB_EMULATOR_HOST}'
+    VERIFY_SSL = False
 
 class FlowControl:
     def __init__(self, *args: List[Any], **kwargs: Dict[str, Any]) -> None:
@@ -101,17 +118,29 @@ if BUILD_GCLOUD_REST:
             return _callback_wrapper
 
 else:
-    import asyncio
-    import concurrent.futures
-    import signal
-
     from google.cloud import pubsub
+    from aiohttp import ClientSession as Session
 
     class SubscriberClient:  # type: ignore[no-redef]
-        def __init__(self, *, loop: Optional[asyncio.AbstractEventLoop] = None,
+        def __init__(self, *,
+                     service_file: Optional[Union[str, IO[AnyStr]]] = None,
+                     token: Optional[Token] = None,
+                     session: Optional[Session] = None,
                      **kwargs: Dict[str, Any]) -> None:
             self._subscriber = pubsub.SubscriberClient(**kwargs)
-            self.loop = loop or asyncio.get_event_loop()
+            self.session = AioSession(session, verify_ssl=VERIFY_SSL)
+            self.token = token or Token(service_file=service_file,
+                                        scopes=SCOPES,
+                                        session=self.session.session)
+
+        async def _headers(self) -> Dict[str, str]:
+            if PUBSUB_EMULATOR_HOST:
+                return {}
+
+            token = await self.token.get()
+            return {
+                'Authorization': f'Bearer {token}'
+            }
 
         def create_subscription(self,
                                 subscription: str,
@@ -132,60 +161,56 @@ else:
             except exceptions.AlreadyExists:
                 pass
 
-        def subscribe(self,
-                      subscription: str,
-                      callback: Callable[[SubscriberMessage], Any],
-                      *,
-                      flow_control: Union[FlowControl, Tuple[int, ...]] = ()
-                      ) -> StreamingPullFuture:
+        async def pull(self, subscription: str, max_messages: int,
+                       *, session: Optional[Session] = None
+                       ) -> List[SubscriberMessage]:
             """
-            Create subscription through pubsub client, scheduling callbacks
-            on the event loop.
+            Pull messages from subscription
             """
-            sub_keepalive = self._subscriber.subscribe(
-                subscription,
-                self._wrap_callback(callback),
-                flow_control=flow_control)
+            url = f'{API_ROOT}/v1/{subscription}:pull'
+            headers = await self._headers()
+            body = {
+                'maxMessages': max_messages,
+            }
+            encoded = json.dumps(body).encode()
+            s = session or self.session
+            resp = await s.post(url, data=encoded, headers=headers)
+            resp = await resp.json()
+            messages = []
+            for m in resp['receivedMessages']:
+                messages.append(SubscriberMessage.from_api_dict(m))
+            return messages
 
-            self.loop.add_signal_handler(signal.SIGTERM, sub_keepalive.cancel)
-
-            return sub_keepalive
-
-        def run_forever(self, sub_keepalive: StreamingPullFuture) -> None:
+        async def acknowledge(self, subscription: str, ack_ids: List[str],
+                              *, session: Optional[Session] = None) -> None:
             """
-            Start the asyncio loop, running until it is either SIGTERM-ed or
-            killed by keyboard interrupt. The StreamingPullFuture parameter is
-            used to cancel subscription in the case that an unexpected
-            exception is thrown. You can also directly pass the `.subscribe()`
-            method call instead like so:
-                sub.run_forever(sub.subscribe(callback))
+            Acknowledge messages by ackIds
             """
-            try:
-                self.loop.run_forever()
-            except (KeyboardInterrupt, concurrent.futures.CancelledError):
-                pass
-            finally:
-                # 1. stop the `SubscriberClient` future, which will prevent
-                #    more tasks from being leased
-                if not sub_keepalive.cancelled():
-                    sub_keepalive.cancel()
-                # 2. cancel the tasks we already have, which should just be
-                #    `worker` instances; note they have
-                #    `except CancelledError: pass`
-                for task in asyncio.Task.all_tasks(loop=self.loop):
-                    task.cancel()
-                # 3. stop the `asyncio` event loop
-                self.loop.stop()
+            url = f'{API_ROOT}/v1/{subscription}:acknowledge'
+            headers = await self._headers()
+            body = {
+                'ackIds': ack_ids,
+            }
+            encoded = json.dumps(body).encode()
+            s = session or self.session
+            await s.post(url, data=encoded, headers=headers)
+            return
 
-        def _wrap_callback(self,
-                           callback: Callable[[SubscriberMessage], None]
-                           ) -> Callable[[Message], None]:
-            """Schedule callback to be called from the event loop"""
-            def _callback_wrapper(message: Message) -> None:
-                asyncio.run_coroutine_threadsafe(
-                    callback(  # type: ignore
-                        SubscriberMessage.from_google_cloud(
-                            message)),
-                    self.loop)
-
-            return _callback_wrapper
+        async def modify_ack_deadline(self, subscription: str,
+                                      ack_ids: List[str],
+                                      ack_deadline_seconds: int,
+                                      *, session: Optional[Session] = None
+                                      ) -> None:
+            """
+            Modify messages' ack deadline.
+            Set ack deadline to 0 to nack messages.
+            """
+            url = f'{API_ROOT}/v1/{subscription}:modifyAckDeadline'
+            headers = await self._headers()
+            body = {
+                'ackIds': ack_ids,
+                'ackDeadlineSeconds': ack_deadline_seconds,
+            }
+            s = session or self.session
+            await s.post(url, data=json.dumps(body).encode(), headers=headers)
+            return

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -43,17 +43,17 @@ class SubscriberClient:
                                     session=self.session.session)
 
     async def _headers(self) -> Dict[str, str]:
-        default_headers = {
+        headers = {
             'Content-Type': 'application/json'
         }
         if PUBSUB_EMULATOR_HOST:
-            return default_headers
+            return headers
 
         token = await self.token.get()
-        return {
-            **default_headers,
+        headers.update({
             'Authorization': f'Bearer {token}'
-        }
+        })
+        return headers
 
     # https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/create
     async def create_subscription(self,

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -43,11 +43,15 @@ class SubscriberClient:
                                     session=self.session.session)
 
     async def _headers(self) -> Dict[str, str]:
+        default_headers = {
+            'Content-Type': 'application/json'
+        }
         if PUBSUB_EMULATOR_HOST:
-            return {}
+            return default_headers
 
         token = await self.token.get()
         return {
+            **default_headers,
             'Authorization': f'Bearer {token}'
         }
 

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -146,3 +146,17 @@ class SubscriberClient:
         s = AioSession(session) if session else self.session
         await s.post(url, data=json.dumps(body).encode('utf-8'),
                      headers=headers)
+
+    # https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/get
+    async def get_subscription(self, subscription: str,
+                               *, session: Optional[Session] = None
+                               ) -> Dict[str, Any]:
+        """
+        Get Subscription
+        """
+        url = f'{API_ROOT}/v1/{subscription}'
+        headers = await self._headers()
+        s = AioSession(session) if session else self.session
+        resp = await s.get(url, headers=headers)
+        result: Dict[str, Any] = await resp.json()
+        return result

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -59,7 +59,7 @@ class SubscriberClient:
     async def create_subscription(self,
                                   subscription: str,
                                   topic: str,
-                                  body: Optional[Dict[str, Any]],
+                                  body: Optional[Dict[str, Any]] = None,
                                   *,
                                   session: Optional[Session] = None,
                                   ) -> Dict[str, Any]:

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -17,7 +17,7 @@ from .subscriber_message import SubscriberMessage
 if BUILD_GCLOUD_REST:
     from requests import Session
 else:
-    from aiohttp import ClientSession as Session
+    from aiohttp import ClientSession as Session  # type: ignore[no-redef]
 
 API_ROOT = 'https://pubsub.googleapis.com'
 VERIFY_SSL = True
@@ -122,7 +122,6 @@ class SubscriberClient:
         encoded = json.dumps(body).encode()
         s = AioSession(session) if session else self.session
         await s.post(url, data=encoded, headers=headers)
-
 
     # https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyAckDeadline
     async def modify_ack_deadline(self, subscription: str,

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -1,5 +1,6 @@
 import json
 import os
+from copy import deepcopy
 from typing import Any
 from typing import AnyStr
 from typing import Dict
@@ -69,10 +70,8 @@ class SubscriberClient:
         body = {} if not body else body
         url = f'{API_ROOT}/v1/{subscription}'
         headers = await self._headers()
-        payload: Dict[str, Any] = {
-            'topic': topic,
-            **body
-        }
+        payload: Dict[str, Any] = deepcopy(body)
+        payload.update({'topic': topic})
         encoded = json.dumps(payload).encode()
         s = AioSession(session) if session else self.session
         resp = await s.put(url, data=encoded, headers=headers)

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -2,23 +2,22 @@ import json
 import os
 from typing import Any
 from typing import AnyStr
-from typing import Callable
 from typing import Dict
 from typing import IO
 from typing import List
 from typing import Optional
-from typing import Tuple
 from typing import Union
 
 from gcloud.aio.auth import AioSession
 from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
 from gcloud.aio.auth import Token
-from google.api_core import exceptions
-from google.cloud.pubsub_v1.subscriber.futures import StreamingPullFuture
-from google.cloud.pubsub_v1.subscriber.message import Message
-from google.cloud.pubsub_v1.types import FlowControl as _FlowControl
 
 from .subscriber_message import SubscriberMessage
+
+if BUILD_GCLOUD_REST:
+    from requests import Session
+else:
+    from aiohttp import ClientSession as Session
 
 API_ROOT = 'https://pubsub.googleapis.com'
 VERIFY_SSL = True
@@ -32,187 +31,115 @@ if PUBSUB_EMULATOR_HOST:
     API_ROOT = f'http://{PUBSUB_EMULATOR_HOST}'
     VERIFY_SSL = False
 
-class FlowControl:
-    def __init__(self, *args: List[Any], **kwargs: Dict[str, Any]) -> None:
-        """
-        FlowControl transitional wrapper.
-        (FlowControl fields docs)[https://github.com/googleapis/python-pubsub/blob/v1.7.0/google/cloud/pubsub_v1/types.py#L124-L166]  # pylint: disable=line-too-long
-        Google uses a named tuple; here are the fields, defaults:
-        - max_bytes: int = 100 * 1024 * 1024
-        - max_messages: int = 1000
-        - max_lease_duration: int = 1 * 60 * 60
-        - max_duration_per_lease_extension: int = 0
-        """
-        self._flow_control = _FlowControl(*args, **kwargs)
 
-    def __repr__(self) -> str:
-        result: str = self._flow_control.__repr__()
+class SubscriberClient:
+    def __init__(self, *,
+                 service_file: Optional[Union[str, IO[AnyStr]]] = None,
+                 token: Optional[Token] = None,
+                 session: Optional[Session] = None) -> None:
+        self.session = AioSession(session, verify_ssl=VERIFY_SSL)
+        self.token = token or Token(service_file=service_file,
+                                    scopes=SCOPES,
+                                    session=self.session.session)
+
+    async def _headers(self) -> Dict[str, str]:
+        if PUBSUB_EMULATOR_HOST:
+            return {}
+
+        token = await self.token.get()
+        return {
+            'Authorization': f'Bearer {token}'
+        }
+
+    # https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/create
+    async def create_subscription(self,
+                                  subscription: str,
+                                  topic: str,
+                                  *,
+                                  session: Optional[Session] = None,
+                                  **kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Create subscription.
+        """
+        url = f'{API_ROOT}/v1/{subscription}'
+        headers = await self._headers()
+        body: Dict[str, Any] = {
+            'topic': topic,
+            **kwargs
+        }
+        encoded = json.dumps(body).encode()
+        s = AioSession(session) if session else self.session
+        resp = await s.put(url, data=encoded, headers=headers)
+        result: Dict[str, Any] = await resp.json()
         return result
 
-    def __getitem__(self, index: int) -> int:
-        result: int = self._flow_control[index]
-        return result
+    # https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/delete
+    async def delete_subscription(self,
+                                  subscription: str,
+                                  *,
+                                  session: Optional[Session] = None
+                                  ) -> None:
+        """
+        Delete subscription.
+        """
+        url = f'{API_ROOT}/v1/{subscription}'
+        headers = await self._headers()
+        s = AioSession(session) if session else self.session
+        await s.delete(url, headers=headers)
 
-    def __getattr__(self, attr: str) -> Any:
-        return getattr(self._flow_control, attr)
+    # https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/pull
+    async def pull(self, subscription: str, max_messages: int,
+                   *, session: Optional[Session] = None
+                   ) -> List[SubscriberMessage]:
+        """
+        Pull messages from subscription
+        """
+        url = f'{API_ROOT}/v1/{subscription}:pull'
+        headers = await self._headers()
+        body = {
+            'maxMessages': max_messages,
+        }
+        encoded = json.dumps(body).encode()
+        s = AioSession(session) if session else self.session
+        resp = await s.post(url, data=encoded, headers=headers)
+        resp = await resp.json()
+        return [
+            SubscriberMessage.from_api_dict(m)
+            for m in resp['receivedMessages']
+        ]
 
-
-if BUILD_GCLOUD_REST:
-    from google.cloud import pubsub_v1 as pubsub
-
-    class SubscriberClient:
-        def __init__(self, **kwargs: Dict[str, Any]) -> None:
-            self._subscriber = pubsub.SubscriberClient(**kwargs)
-
-        def create_subscription(self,
-                                subscription: str,
-                                topic: str,
-                                **kwargs: Dict[str, Any]
-                                ) -> None:
-            """
-            Create subscription if it does not exist. Check out the official
-            [create_subscription docs](https://github.com/googleapis/google-cloud-python/blob/11c72ade8b282ae1917fba19e7f4e0fe7176d12b/pubsub/google/cloud/pubsub_v1/gapic/subscriber_client.py#L236)  # pylint: disable=line-too-long
-            for more details
-            """
-            try:
-                self._subscriber.create_subscription(
-                    subscription,
-                    topic,
-                    **kwargs
-                )
-            except exceptions.AlreadyExists:
-                pass
-
-        def subscribe(self,
-                      subscription: str,
-                      callback: Callable[[SubscriberMessage], Any],
-                      *,
-                      flow_control: Union[FlowControl, Tuple[int, ...]] = ()
-                      ) -> StreamingPullFuture:
-            """
-            Pass call to the google-cloud-pubsub SubscriberClient class.
-            This method will most likely be deprecated once gcloud-rest-pubsub
-            stop using google-cloud-pubsub under the hood. If this is
-            what you need we strongly recommend using official library.
-
-            """
-            sub_keepalive: StreamingPullFuture = (
-                self._subscriber.subscribe(
-                    subscription,
-                    self._wrap_callback(callback),
-                    flow_control=flow_control))
-
-            return sub_keepalive
-
-        @staticmethod
-        def _wrap_callback(callback: Callable[[SubscriberMessage], None]
-                           ) -> Callable[[Message], None]:
-            """
-            Make callback work with vanilla
-            google.cloud.pubsub_v1.subscriber.message.Message
-
-            """
-            def _callback_wrapper(message: Message) -> None:
-                callback(SubscriberMessage.from_google_cloud(message))
-
-            return _callback_wrapper
-
-else:
-    from google.cloud import pubsub
-    from aiohttp import ClientSession as Session
-
-    class SubscriberClient:  # type: ignore[no-redef]
-        def __init__(self, *,
-                     service_file: Optional[Union[str, IO[AnyStr]]] = None,
-                     token: Optional[Token] = None,
-                     session: Optional[Session] = None,
-                     **kwargs: Dict[str, Any]) -> None:
-            self._subscriber = pubsub.SubscriberClient(**kwargs)
-            self.session = AioSession(session, verify_ssl=VERIFY_SSL)
-            self.token = token or Token(service_file=service_file,
-                                        scopes=SCOPES,
-                                        session=self.session.session)
-
-        async def _headers(self) -> Dict[str, str]:
-            if PUBSUB_EMULATOR_HOST:
-                return {}
-
-            token = await self.token.get()
-            return {
-                'Authorization': f'Bearer {token}'
-            }
-
-        def create_subscription(self,
-                                subscription: str,
-                                topic: str,
-                                **kwargs: Dict[str, Any]
-                                ) -> None:
-            """
-            Create subscription if it does not exist. Check out the official
-            [create_subscription docs](https://github.com/googleapis/google-cloud-python/blob/11c72ade8b282ae1917fba19e7f4e0fe7176d12b/pubsub/google/cloud/pubsub_v1/gapic/subscriber_client.py#L236)  # pylint: disable=line-too-long
-            for more details
-            """
-            try:
-                self._subscriber.create_subscription(
-                    subscription,
-                    topic,
-                    **kwargs
-                )
-            except exceptions.AlreadyExists:
-                pass
-
-        # https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/pull
-        async def pull(self, subscription: str, max_messages: int,
-                       *, session: Optional[Session] = None
-                       ) -> List[SubscriberMessage]:
-            """
-            Pull messages from subscription
-            """
-            url = f'{API_ROOT}/v1/{subscription}:pull'
-            headers = await self._headers()
-            body = {
-                'maxMessages': max_messages,
-            }
-            encoded = json.dumps(body).encode()
-            s = AioSession(session) if session else self.session
-            resp = await s.post(url, data=encoded, headers=headers)
-            resp = await resp.json()
-            return [
-                SubscriberMessage.from_api_dict(m)
-                for m in resp['receivedMessages']
-            ]
-
-        # https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/acknowledge
-        async def acknowledge(self, subscription: str, ack_ids: List[str],
-                              *, session: Optional[Session] = None) -> None:
-            """
-            Acknowledge messages by ackIds
-            """
-            url = f'{API_ROOT}/v1/{subscription}:acknowledge'
-            headers = await self._headers()
-            body = {
-                'ackIds': ack_ids,
-            }
-            encoded = json.dumps(body).encode()
-            s = AioSession(session) if session else self.session
-            await s.post(url, data=encoded, headers=headers)
+    # https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/acknowledge
+    async def acknowledge(self, subscription: str, ack_ids: List[str],
+                          *, session: Optional[Session] = None) -> None:
+        """
+        Acknowledge messages by ackIds
+        """
+        url = f'{API_ROOT}/v1/{subscription}:acknowledge'
+        headers = await self._headers()
+        body = {
+            'ackIds': ack_ids,
+        }
+        encoded = json.dumps(body).encode()
+        s = AioSession(session) if session else self.session
+        await s.post(url, data=encoded, headers=headers)
 
 
-        # https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyAckDeadline
-        async def modify_ack_deadline(self, subscription: str,
-                                      ack_ids: List[str],
-                                      ack_deadline_seconds: int,
-                                      *, session: Optional[Session] = None
-                                      ) -> None:
-            """
-            Modify messages' ack deadline.
-            Set ack deadline to 0 to nack messages.
-            """
-            url = f'{API_ROOT}/v1/{subscription}:modifyAckDeadline'
-            headers = await self._headers()
-            body = {
-                'ackIds': ack_ids,
-                'ackDeadlineSeconds': ack_deadline_seconds,
-            }
-            s = AioSession(session) if session else self.session
-            await s.post(url, data=json.dumps(body).encode('utf-8'), headers=headers)
+    # https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyAckDeadline
+    async def modify_ack_deadline(self, subscription: str,
+                                  ack_ids: List[str],
+                                  ack_deadline_seconds: int,
+                                  *, session: Optional[Session] = None
+                                  ) -> None:
+        """
+        Modify messages' ack deadline.
+        Set ack deadline to 0 to nack messages.
+        """
+        url = f'{API_ROOT}/v1/{subscription}:modifyAckDeadline'
+        headers = await self._headers()
+        body = {
+            'ackIds': ack_ids,
+            'ackDeadlineSeconds': ack_deadline_seconds,
+        }
+        s = AioSession(session) if session else self.session
+        await s.post(url, data=json.dumps(body).encode('utf-8'),
+                     headers=headers)

--- a/pubsub/gcloud/aio/pubsub/subscriber_message.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_message.py
@@ -5,133 +5,58 @@ from typing import Any
 from typing import Awaitable
 from typing import Callable
 from typing import Dict
-from typing import List
-from typing import Optional
 
-from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
+def parse_publish_time(publish_time: str) -> datetime.datetime:
+    try:
+        return datetime.datetime.strptime(
+            publish_time, '%Y-%m-%dT%H:%M:%S.%f%z')
+    except ValueError:
+        return datetime.datetime.strptime(
+            publish_time, '%Y-%m-%dT%H:%M:%S%z')
 
-if BUILD_GCLOUD_REST:
-    from google.cloud.pubsub_v1.subscriber.message import Message
 
-    class SubscriberMessage:
-        def __init__(self, *args: List[Any],
-                     google_cloud_message: Message = None,
-                     **kwargs: Dict[str, Any]) -> None:
-            if google_cloud_message:
-                self._message = google_cloud_message
-                return
-            self._message = Message(*args, **kwargs)
+class SubscriberMessage:
+    def __init__(self, ack_id: str, message_id: str,
+                 publish_time: 'datetime.datetime',
+                 data: Dict[str, Any],
+                 attributes: Dict[str, Any]):
+        self.ack_id = ack_id
+        self.message_id = message_id
+        self.publish_time = publish_time
+        self.data = data
+        self.attributes = attributes
+        self._callback = self._default_callback()
 
-        @staticmethod
-        def from_google_cloud(message: Message) -> 'SubscriberMessage':
-            return SubscriberMessage(google_cloud_message=message)
+    @staticmethod
+    def from_api_dict(received_message: Dict[str, Any]
+                     ) -> 'SubscriberMessage':
+        ack_id = received_message['ackId']
+        message_id = received_message['message']['messageId']
+        data = json.loads(
+            base64.b64decode(received_message['message']['data']))
+        attributes = received_message['message']['attributes']
+        publish_time: datetime.datetime = parse_publish_time(
+            received_message['message']['publishTime'])
+        return SubscriberMessage(ack_id=ack_id, message_id=message_id,
+                                 publish_time=publish_time, data=data,
+                                 attributes=attributes)
 
-        @property
-        def google_cloud_message(self) -> Message:
-            return self._message
+    @staticmethod
+    def _default_callback(
+        ) -> Callable[['SubscriberMessage', bool], Awaitable[None]]:
+        async def f(message: 'SubscriberMessage', ack: bool) -> None:
+            raise NotImplementedError(
+                'Ack callback is not set for this message')
+        return f
 
-        @property
-        def message_id(self) -> str:  # indirects to a Google protobuff field
-            return str(self._message.message_id)
+    def add_ack_callback(
+            self,
+            callback: Callable[['SubscriberMessage', bool], Awaitable[None]]
+        ) -> None:
+        self._callback = callback
 
-        def __repr__(self) -> str:
-            return repr(self._message)
+    async def ack(self) -> None:
+        await self._callback(self, True)
 
-        @property
-        def attributes(self) -> Any:  # Google .ScalarMapContainer
-            return self._message.attributes
-
-        @property
-        def data(self) -> bytes:
-            return bytes(self._message.data)
-
-        @property
-        def publish_time(self) -> datetime.datetime:
-            published: datetime.datetime = self._message.publish_time
-            return published
-
-        @property
-        def ordering_key(self) -> str:
-            return str(self._message.ordering_key)
-
-        @property
-        def size(self) -> int:
-            return int(self._message.size)
-
-        @property
-        def ack_id(self) -> str:
-            return str(self._message.ack_id)
-
-        @property
-        def delivery_attempt(self) -> Optional[int]:
-            if self._message.delivery_attempt:
-                return int(self._message.delivery_attempt)
-            return None
-
-        def ack(self) -> None:
-            self._message.ack()
-
-        def drop(self) -> None:
-            self._message.drop()
-
-        def modify_ack_deadline(self, seconds: int) -> None:
-            self._message.modify_ack_deadline(seconds)
-
-        def nack(self) -> None:
-            self._message.nack()
-
-else:
-
-    def parse_publish_time(publish_time: str) -> datetime.datetime:
-        try:
-            return datetime.datetime.strptime(
-                publish_time, '%Y-%m-%dT%H:%M:%S.%f%z')
-        except ValueError:
-            return datetime.datetime.strptime(
-                publish_time, '%Y-%m-%dT%H:%M:%S%z')
-
-    class SubscriberMessage:  # type: ignore[no-redef]
-        def __init__(self, ack_id: str, message_id: str,
-                     publish_time: 'datetime.datetime',
-                     data: Dict[str, Any],
-                     attributes: Dict[str, Any]):
-            self.ack_id = ack_id
-            self.message_id = message_id
-            self.publish_time = publish_time
-            self.data = data
-            self.attributes = attributes
-            self._callback = self._default_callback()
-
-        @staticmethod
-        def from_api_dict(received_message: Dict[str, Any]
-                         ) -> 'SubscriberMessage':
-            ack_id = received_message['ackId']
-            message_id = received_message['message']['messageId']
-            data = json.loads(
-                base64.b64decode(received_message['message']['data']))
-            attributes = received_message['message']['attributes']
-            publish_time: datetime.datetime = parse_publish_time(
-                received_message['message']['publishTime'])
-            return SubscriberMessage(ack_id=ack_id, message_id=message_id,
-                                     publish_time=publish_time, data=data,
-                                     attributes=attributes)
-
-        @staticmethod
-        def _default_callback(
-            ) -> Callable[['SubscriberMessage', bool], Awaitable[None]]:
-            async def f(message: 'SubscriberMessage', ack: bool) -> None:
-                raise NotImplementedError(
-                    'Ack callback is not set for this message')
-            return f
-
-        def add_ack_callback(
-                self,
-                callback: Callable[['SubscriberMessage', bool], Awaitable[None]]
-            ) -> None:
-            self._callback = callback
-
-        async def ack(self) -> None:
-            await self._callback(self, True)
-
-        async def nack(self) -> None:
-            await self._callback(self, False)
+    async def nack(self) -> None:
+        await self._callback(self, False)

--- a/pubsub/gcloud/aio/pubsub/subscriber_message.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_message.py
@@ -1,75 +1,137 @@
+import base64
 import datetime
+import json
 from typing import Any
+from typing import Awaitable
+from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
 
-from google.cloud.pubsub_v1.subscriber.message import Message
+from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
 
+if BUILD_GCLOUD_REST:
+    from google.cloud.pubsub_v1.subscriber.message import Message
 
-class SubscriberMessage:
-    def __init__(self, *args: List[Any],
-                 google_cloud_message: Message = None,
-                 **kwargs: Dict[str, Any]) -> None:
-        if google_cloud_message:
-            self._message = google_cloud_message
-            return
-        self._message = Message(*args, **kwargs)
+    class SubscriberMessage:
+        def __init__(self, *args: List[Any],
+                     google_cloud_message: Message = None,
+                     **kwargs: Dict[str, Any]) -> None:
+            if google_cloud_message:
+                self._message = google_cloud_message
+                return
+            self._message = Message(*args, **kwargs)
 
-    @staticmethod
-    def from_google_cloud(message: Message) -> 'SubscriberMessage':
-        return SubscriberMessage(google_cloud_message=message)
+        @staticmethod
+        def from_google_cloud(message: Message) -> 'SubscriberMessage':
+            return SubscriberMessage(google_cloud_message=message)
 
-    @property
-    def google_cloud_message(self) -> Message:
-        return self._message
+        @property
+        def google_cloud_message(self) -> Message:
+            return self._message
 
-    @property
-    def message_id(self) -> str:  # indirects to a Google protobuff field
-        return str(self._message.message_id)
+        @property
+        def message_id(self) -> str:  # indirects to a Google protobuff field
+            return str(self._message.message_id)
 
-    def __repr__(self) -> str:
-        return repr(self._message)
+        def __repr__(self) -> str:
+            return repr(self._message)
 
-    @property
-    def attributes(self) -> Any:  # Google .ScalarMapContainer
-        return self._message.attributes
+        @property
+        def attributes(self) -> Any:  # Google .ScalarMapContainer
+            return self._message.attributes
 
-    @property
-    def data(self) -> bytes:
-        return bytes(self._message.data)
+        @property
+        def data(self) -> bytes:
+            return bytes(self._message.data)
 
-    @property
-    def publish_time(self) -> datetime.datetime:
-        published: datetime.datetime = self._message.publish_time
-        return published
+        @property
+        def publish_time(self) -> datetime.datetime:
+            published: datetime.datetime = self._message.publish_time
+            return published
 
-    @property
-    def ordering_key(self) -> str:
-        return str(self._message.ordering_key)
+        @property
+        def ordering_key(self) -> str:
+            return str(self._message.ordering_key)
 
-    @property
-    def size(self) -> int:
-        return int(self._message.size)
+        @property
+        def size(self) -> int:
+            return int(self._message.size)
 
-    @property
-    def ack_id(self) -> str:
-        return str(self._message.ack_id)
+        @property
+        def ack_id(self) -> str:
+            return str(self._message.ack_id)
 
-    @property
-    def delivery_attempt(self) -> Optional[int]:
-        if self._message.delivery_attempt:
-            return int(self._message.delivery_attempt)
-        return None
+        @property
+        def delivery_attempt(self) -> Optional[int]:
+            if self._message.delivery_attempt:
+                return int(self._message.delivery_attempt)
+            return None
 
-    def ack(self) -> None:
-        self._message.ack()
+        def ack(self) -> None:
+            self._message.ack()
 
-    def drop(self) -> None:
-        self._message.drop()
+        def drop(self) -> None:
+            self._message.drop()
 
-    def modify_ack_deadline(self, seconds: int) -> None:
-        self._message.modify_ack_deadline(seconds)
+        def modify_ack_deadline(self, seconds: int) -> None:
+            self._message.modify_ack_deadline(seconds)
 
-    def nack(self) -> None:
-        self._message.nack()
+        def nack(self) -> None:
+            self._message.nack()
+
+else:
+
+    def parse_publish_time(publish_time: str) -> datetime.datetime:
+        try:
+            return datetime.datetime.strptime(
+                publish_time, '%Y-%m-%dT%H:%M:%S.%f%z')
+        except ValueError:
+            return datetime.datetime.strptime(
+                publish_time, '%Y-%m-%dT%H:%M:%S%z')
+
+    class SubscriberMessage:  # type: ignore[no-redef]
+        def __init__(self, ack_id: str, message_id: str,
+                     publish_time: 'datetime.datetime',
+                     data: Dict[str, Any],
+                     attributes: Dict[str, Any]):
+            self.ack_id = ack_id
+            self.message_id = message_id
+            self.publish_time = publish_time
+            self.data = data
+            self.attributes = attributes
+            self._callback = self._default_callback()
+
+        @staticmethod
+        def from_api_dict(received_message: Dict[str, Any]
+                         ) -> 'SubscriberMessage':
+            ack_id = received_message['ackId']
+            message_id = received_message['message']['messageId']
+            data = json.loads(
+                base64.b64decode(received_message['message']['data']))
+            attributes = received_message['message']['attributes']
+            publish_time: datetime.datetime = parse_publish_time(
+                received_message['message']['publishTime'])
+            return SubscriberMessage(ack_id=ack_id, message_id=message_id,
+                                     publish_time=publish_time, data=data,
+                                     attributes=attributes)
+
+        @staticmethod
+        def _default_callback(
+            ) -> Callable[['SubscriberMessage', bool], Awaitable[None]]:
+            async def f(message: 'SubscriberMessage', ack: bool) -> None:
+                raise NotImplementedError(
+                    'Ack callback is not set for this message')
+            return f
+
+        def add_ack_callback(
+                self,
+                callback: Callable[['SubscriberMessage', bool], Awaitable[None]]
+            ) -> None:
+            self._callback = callback
+
+        async def ack(self) -> None:
+            await self._callback(self, True)
+
+        async def nack(self) -> None:
+            await self._callback(self, False)

--- a/pubsub/gcloud/aio/pubsub/subscriber_message.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_message.py
@@ -7,10 +7,10 @@ from typing import Dict
 def parse_publish_time(publish_time: str) -> datetime.datetime:
     try:
         return datetime.datetime.strptime(
-            publish_time, '%Y-%m-%dT%H:%M:%S.%f%z')
+            publish_time, '%Y-%m-%dT%H:%M:%S.%fZ')
     except ValueError:
         return datetime.datetime.strptime(
-            publish_time, '%Y-%m-%dT%H:%M:%S%z')
+            publish_time, '%Y-%m-%dT%H:%M:%SZ')
 
 
 class SubscriberMessage:

--- a/pubsub/gcloud/aio/pubsub/subscriber_message.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_message.py
@@ -2,6 +2,7 @@ import base64
 import datetime
 from typing import Any
 from typing import Dict
+from typing import Optional
 
 
 def parse_publish_time(publish_time: str) -> datetime.datetime:
@@ -17,7 +18,7 @@ class SubscriberMessage:
     def __init__(self, ack_id: str, message_id: str,
                  publish_time: 'datetime.datetime',
                  data: bytes,
-                 attributes: Dict[str, Any]):
+                 attributes: Optional[Dict[str, Any]]):
         self.ack_id = ack_id
         self.message_id = message_id
         self.publish_time = publish_time
@@ -30,7 +31,7 @@ class SubscriberMessage:
         ack_id = received_message['ackId']
         message_id = received_message['message']['messageId']
         data = base64.b64decode(received_message['message']['data'])
-        attributes = received_message['message']['attributes']
+        attributes = received_message['message'].get('attributes')
         publish_time: datetime.datetime = parse_publish_time(
             received_message['message']['publishTime'])
         return SubscriberMessage(ack_id=ack_id, message_id=message_id,

--- a/pubsub/gcloud/aio/pubsub/subscriber_message.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_message.py
@@ -6,6 +6,7 @@ from typing import Awaitable
 from typing import Callable
 from typing import Dict
 
+
 def parse_publish_time(publish_time: str) -> datetime.datetime:
     try:
         return datetime.datetime.strptime(
@@ -29,7 +30,7 @@ class SubscriberMessage:
 
     @staticmethod
     def from_api_dict(received_message: Dict[str, Any]
-                     ) -> 'SubscriberMessage':
+                      ) -> 'SubscriberMessage':
         ack_id = received_message['ackId']
         message_id = received_message['message']['messageId']
         data = json.loads(

--- a/pubsub/requirements.txt
+++ b/pubsub/requirements.txt
@@ -1,2 +1,1 @@
 gcloud-aio-auth >= 3.3.0, < 4.0.0
-google-cloud-pubsub >= 0.29.4, < 2.0.0

--- a/pubsub/tests/unit/subscription_test.py
+++ b/pubsub/tests/unit/subscription_test.py
@@ -25,7 +25,7 @@ def test_construct_subscriber_message_from_message_dict():
             'publishTime': '2020-01-01T00:00:01.000Z'
         }
     }
-    message = SubscriberMessage.from_api_dict(message_dict)
+    message = SubscriberMessage.from_repr(message_dict)
     assert message.ack_id == 'some_ack_id'
     assert message.attributes == {'attr_key': 'attr_value'}
     assert message.message_id == '123'

--- a/pubsub/tests/unit/subscription_test.py
+++ b/pubsub/tests/unit/subscription_test.py
@@ -31,4 +31,4 @@ def test_construct_subscriber_message_from_message_dict():
     assert message.message_id == '123'
     assert message.data == b'{"foo": "bar"}'
     assert message.publish_time == datetime.datetime(
-        2020, 1, 1, 0, 0, 1, tzinfo=datetime.timezone.utc)
+        2020, 1, 1, 0, 0, 1)

--- a/pubsub/tests/unit/subscription_test.py
+++ b/pubsub/tests/unit/subscription_test.py
@@ -29,6 +29,6 @@ def test_construct_subscriber_message_from_message_dict():
     assert message.ack_id == 'some_ack_id'
     assert message.attributes == {'attr_key': 'attr_value'}
     assert message.message_id == '123'
-    assert message.data == {'foo': 'bar'}
+    assert message.data == b'{"foo": "bar"}'
     assert message.publish_time == datetime.datetime(
         2020, 1, 1, 0, 0, 1, tzinfo=datetime.timezone.utc)


### PR DESCRIPTION
REST endpoints + grpc-free `SubscriberMessage`. 
`ack_callback` is here to let any message "producer" define how message can be acked by clients. There should be a name for this pattern, but I don't know it :(

- [x]  Manually tested