### PR TITLE
fix(datastore): Explicitly ask for Values when creating an Array

### DIFF
--- a/datastore/gcloud/aio/datastore/array.py
+++ b/datastore/gcloud/aio/datastore/array.py
@@ -11,7 +11,7 @@ from gcloud.aio.datastore import value
 
 # https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects/runQuery#ArrayValue
 class Array(Sequence):  # type: ignore[type-arg]
-    def __init__(self, items: List[Any]) -> None:
+    def __init__(self, items: List[value.Value]) -> None:
         super(Sequence, self).__init__()  # pylint: disable=bad-super-call
         self.items = items
 


### PR DESCRIPTION
Difficult to find a good name for that one.

I noticed that while looking at #242. Static checkers can help prevent this type of problem now.