### PR TITLE
feat(gcloud-aio): narrow pin for aiohttp + requirement chardet

### DIFF
--- a/auth/requirements.txt
+++ b/auth/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp>=3.7.3,<4.0.0
+aiohttp>=3.3.0,<4.0.0
 backoff>=1.0.0,<2.0.0
 chardet>=2.0,<4.0  # required by aiohttp 3.7.3
 cryptography>=2.0.0,<4.0.0

--- a/auth/requirements.txt
+++ b/auth/requirements.txt
@@ -1,5 +1,6 @@
-aiohttp>=3.3.0,<4.0.0
+aiohttp>=3.7.3,<4.0.0
 backoff>=1.0.0,<2.0.0
+chardet>=2.0,<4.0  # required by aiohttp 3.7.3
 cryptography>=2.0.0,<4.0.0
 future>=0.17.0,<0.18.3
 pyjwt>=1.5.3,<2.0.0


### PR DESCRIPTION
Okay, so a few apps in our stack are emitting: `aiohttp 3.7.3 has requirement chardet<4.0,>=2.0, but you have chardet 4.0.0.`

We believe that this is all tracked down to `aiohttp` included in this repo -- version `3.0.4` is the final version of chardet in the 3.x.x major version.

Note that this pin would need manual removal if a later version of aiohttp requires chardet >= 4.0.0; I'm not 100% sure this is the best way to do this, but I figured we can talk about it in this PR.