### PR TITLE
chore(pubsub): bump requirement for gcloud-aio-auth

### DIFF
--- a/pubsub/requirements.txt
+++ b/pubsub/requirements.txt
@@ -1,1 +1,1 @@
-gcloud-aio-auth >= 3.3.0, < 4.0.0
+gcloud-aio-auth >= 3.4.5, < 4.0.0


### PR DESCRIPTION
Now that gcloud-aio-auth==3.4.5 has the correct version pin for chardet, let's have pubsub pick it up so our downstream apps can import pubsub without further requirements conflicts.