### PR TITLE
fix(pubsub) Fix a bug in consumer's graceful shutdown

### DIFF
--- a/pubsub/gcloud/aio/pubsub/subscriber.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber.py
@@ -304,8 +304,8 @@ else:
             for task in done:
                 task.result()
             raise Exception('A subscriber worker shut down unexpectedly!')
-        except Exception:
-            log.exception('Subscriber exited')
+        except Exception as e:
+            log.info('Subscriber exited', exc_info=e)
             for task in producer_tasks:
                 task.cancel()
             await asyncio.wait(producer_tasks,

--- a/pubsub/gcloud/aio/pubsub/subscriber.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber.py
@@ -200,7 +200,7 @@ else:
                 message_queue.task_done()
         except asyncio.CancelledError:
             log.info('Consumer worker cancelled. Gracefully terminating...')
-            for _ in range(max_tasks - 1):
+            for _ in range(max(1, max_tasks - 1)):
                 await semaphore.acquire()
             await ack_queue.join()
             if nack_queue:

--- a/pubsub/gcloud/aio/pubsub/subscriber.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber.py
@@ -200,7 +200,7 @@ else:
                 message_queue.task_done()
         except asyncio.CancelledError:
             log.info('Consumer worker cancelled. Gracefully terminating...')
-            for _ in range(max_tasks):
+            for _ in range(max_tasks - 1):
                 await semaphore.acquire()
             await ack_queue.join()
             if nack_queue:


### PR DESCRIPTION
Two small changes:
1. Fix an off-by-one error. By the time we gracefully shutdown, consumer will most likely hold one lock in semaphore, so we should acquire one less. I'd imagine this isn't perfect since consumer is not guaranteed to have this lock. Worst case we will leave one task unfinished :( Let me know if you have better ideas
2. Change one log entry level from error to info, since it will be invoked on graceful shutdown and we don't want it to clutter the logs. All hard exception are logged before that anyway.