### PR TITLE
fix(pubsub) Fix a bug in consumer's graceful shutdown

### DIFF
--- a/pubsub/tests/unit/subscriber_test.py
+++ b/pubsub/tests/unit/subscriber_test.py
@@ -517,6 +517,8 @@ else:
         ack_queue.task_done()
         await asyncio.sleep(0)
         await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
         assert consumer_task.done()
 
     # ========

--- a/pubsub/tests/unit/subscriber_test.py
+++ b/pubsub/tests/unit/subscriber_test.py
@@ -360,8 +360,10 @@ else:
         mock2.ack_id = 'ack_id'
         mock3 = MagicMock()
         mock3.ack_id = 'ack_id'
+        mock4 = MagicMock()
+        mock4.ack_id = 'ack_id'
 
-        consumer_task = asyncio.ensure_future(
+        asyncio.ensure_future(
             consumer(
                 queue,
                 callback,
@@ -372,12 +374,9 @@ else:
                 MagicMock()
             )
         )
-        for m in [mock1, mock2, mock3]:
+        for m in [mock1, mock2, mock3, mock4]:
             await queue.put((m, 0.0))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        consumer_task.cancel()
+        await asyncio.sleep(0.1)
         mock1.assert_called_once()
         mock2.assert_called_once()
         mock3.assert_not_called()
@@ -438,8 +437,7 @@ else:
             )
         )
         await queue.put((message, 0.0))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.1)
         consumer_task.cancel()
         mock.assert_called_once()
         assert ack_queue.qsize() == 0
@@ -470,8 +468,7 @@ else:
             )
         )
         await queue.put((message, 0.0))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.1)
         consumer_task.cancel()
         mock.assert_called_once()
         assert ack_queue.qsize() == 0
@@ -504,21 +501,17 @@ else:
             )
         )
         await queue.put((message, 0.0))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.1)
         mock.assert_called_once()
         consumer_task.cancel()
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.1)
         assert not consumer_task.done()
         event.set()
         await asyncio.sleep(0)
         assert ack_queue.qsize() == 1
         await ack_queue.get()
         ack_queue.task_done()
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.1)
         assert consumer_task.done()
 
     # ========

--- a/pubsub/tests/unit/subscriber_test.py
+++ b/pubsub/tests/unit/subscriber_test.py
@@ -514,6 +514,30 @@ else:
         await asyncio.sleep(0.1)
         assert consumer_task.done()
 
+    @pytest.mark.asyncio
+    async def test_consumer_gracefull_shutdown_without_pending_tasks(
+        ack_deadline_cache
+    ):
+        queue = asyncio.Queue()
+        ack_queue = asyncio.Queue()
+        nack_queue = asyncio.Queue()
+
+        consumer_task = asyncio.ensure_future(
+            consumer(
+                queue,
+                lambda _x: None,
+                ack_queue,
+                ack_deadline_cache,
+                1,
+                nack_queue,
+                MagicMock()
+            )
+        )
+        await asyncio.sleep(0.1)
+        consumer_task.cancel()
+        await asyncio.sleep(0.1)
+        assert consumer_task.done()
+
     # ========
     # acker
     # ========


### PR DESCRIPTION
Well, this is a tricky bug. During graceful shutdown in consumer we can be sure that previous tasks were correctly scheduled, but not the last one. The last one is a total uncertainty: it could be  that it wasn't scheduled, or we could fail to attach a callback to it.

This is the best solution I could come up with: properly wait for previous tasks but just a little bit for the very last lock. 