### PR TITLE
Revert "chore(pubsub) Close subscriber session during shutdown"

### DIFF
--- a/pubsub/gcloud/aio/pubsub/subscriber.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber.py
@@ -324,5 +324,4 @@ else:
             for task in acker_tasks:
                 task.cancel()
             await asyncio.wait(acker_tasks, return_when=asyncio.ALL_COMPLETED)
-            await subscriber_client.session.close()
         raise asyncio.CancelledError('Subscriber shut down')


### PR DESCRIPTION
Reverts talkiq/gcloud-aio#282

Yes, so `SubscriberClient` is a divine artifact given to subscriber by the client, and we're not in a position to decide its fate