### PR TITLE
fix(pubsub) Increase long polling timeout to 30s

### DIFF
--- a/pubsub/gcloud/aio/pubsub/subscriber.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber.py
@@ -224,7 +224,9 @@ else:
                 new_messages = []
                 try:
                     new_messages = await subscriber_client.pull(
-                        subscription=subscription, max_messages=max_messages)
+                        subscription=subscription,
+                        max_messages=max_messages,
+                        timeout=30)
                 except (asyncio.TimeoutError, KeyError):
                     continue
 

--- a/pubsub/gcloud/aio/pubsub/subscriber.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber.py
@@ -226,6 +226,10 @@ else:
                     new_messages = await subscriber_client.pull(
                         subscription=subscription,
                         max_messages=max_messages,
+                        # it is important to have this value reasonably high
+                        # as long lived connections may be left hanging
+                        # on a server which will cause delay in message
+                        # delivery or even false deadlettering
                         timeout=30)
                 except (asyncio.TimeoutError, KeyError):
                     continue

--- a/pubsub/gcloud/aio/pubsub/subscriber.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber.py
@@ -229,7 +229,7 @@ else:
                         # it is important to have this value reasonably high
                         # as long lived connections may be left hanging
                         # on a server which will cause delay in message
-                        # delivery or even false deadlettering
+                        # delivery or even false deadlettering if it is enabled
                         timeout=30)
                 except (asyncio.TimeoutError, KeyError):
                     continue

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -63,6 +63,7 @@ class SubscriberClient:
                                   body: Optional[Dict[str, Any]] = None,
                                   *,
                                   session: Optional[Session] = None,
+                                  timeout: Optional[int] = None
                                   ) -> Dict[str, Any]:
         """
         Create subscription.
@@ -74,7 +75,11 @@ class SubscriberClient:
         payload.update({'topic': topic})
         encoded = json.dumps(payload).encode()
         s = AioSession(session) if session else self.session
-        resp = await s.put(url, data=encoded, headers=headers)
+        kwargs = {
+            'timeout': timeout,
+        }
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
+        resp = await s.put(url, data=encoded, headers=headers, **kwargs)
         result: Dict[str, Any] = await resp.json()
         return result
 
@@ -82,7 +87,8 @@ class SubscriberClient:
     async def delete_subscription(self,
                                   subscription: str,
                                   *,
-                                  session: Optional[Session] = None
+                                  session: Optional[Session] = None,
+                                  timeout: Optional[int] = None
                                   ) -> None:
         """
         Delete subscription.
@@ -90,11 +96,16 @@ class SubscriberClient:
         url = f'{API_ROOT}/v1/{subscription}'
         headers = await self._headers()
         s = AioSession(session) if session else self.session
-        await s.delete(url, headers=headers)
+        kwargs = {
+            'timeout': timeout,
+        }
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
+        await s.delete(url, headers=headers, **kwargs)
 
     # https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/pull
     async def pull(self, subscription: str, max_messages: int,
-                   *, session: Optional[Session] = None
+                   *, session: Optional[Session] = None,
+                   timeout: Optional[int] = None
                    ) -> List[SubscriberMessage]:
         """
         Pull messages from subscription
@@ -106,7 +117,11 @@ class SubscriberClient:
         }
         encoded = json.dumps(payload).encode()
         s = AioSession(session) if session else self.session
-        resp = await s.post(url, data=encoded, headers=headers)
+        kwargs = {
+            'timeout': timeout,
+        }
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
+        resp = await s.post(url, data=encoded, headers=headers, **kwargs)
         resp = await resp.json()
         return [
             SubscriberMessage.from_repr(m)
@@ -115,7 +130,8 @@ class SubscriberClient:
 
     # https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/acknowledge
     async def acknowledge(self, subscription: str, ack_ids: List[str],
-                          *, session: Optional[Session] = None) -> None:
+                          *, session: Optional[Session] = None,
+                          timeout: Optional[int] = None) -> None:
         """
         Acknowledge messages by ackIds
         """
@@ -126,13 +142,18 @@ class SubscriberClient:
         }
         encoded = json.dumps(payload).encode()
         s = AioSession(session) if session else self.session
-        await s.post(url, data=encoded, headers=headers)
+        kwargs = {
+            'timeout': timeout,
+        }
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
+        await s.post(url, data=encoded, headers=headers, **kwargs)
 
     # https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyAckDeadline
     async def modify_ack_deadline(self, subscription: str,
                                   ack_ids: List[str],
                                   ack_deadline_seconds: int,
-                                  *, session: Optional[Session] = None
+                                  *, session: Optional[Session] = None,
+                                  timeout: Optional[int] = None
                                   ) -> None:
         """
         Modify messages' ack deadline.
@@ -145,12 +166,17 @@ class SubscriberClient:
             'ackDeadlineSeconds': ack_deadline_seconds,
         }
         s = AioSession(session) if session else self.session
+        kwargs = {
+            'timeout': timeout,
+        }
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
         await s.post(url, data=json.dumps(payload).encode('utf-8'),
-                     headers=headers)
+                     headers=headers, **kwargs)
 
     # https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/get
     async def get_subscription(self, subscription: str,
-                               *, session: Optional[Session] = None
+                               *, session: Optional[Session] = None,
+                               timeout: Optional[int] = None
                                ) -> Dict[str, Any]:
         """
         Get Subscription
@@ -158,14 +184,19 @@ class SubscriberClient:
         url = f'{API_ROOT}/v1/{subscription}'
         headers = await self._headers()
         s = AioSession(session) if session else self.session
-        resp = await s.get(url, headers=headers)
+        kwargs = {
+            'timeout': timeout,
+        }
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
+        resp = await s.get(url, headers=headers, **kwargs)
         result: Dict[str, Any] = await resp.json()
         return result
 
     # https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/list
     async def list_subscriptions(self, project: str,
                                  query_params: Optional[Dict[str, str]] = None,
-                                 *, session: Optional[Session] = None
+                                 *, session: Optional[Session] = None,
+                                 timeout: Optional[int] = None
                                  ) -> Dict[str, Any]:
         """
         List subscriptions
@@ -173,6 +204,10 @@ class SubscriberClient:
         url = f'{API_ROOT}/v1/{project}/subscriptions'
         headers = await self._headers()
         s = AioSession(session) if session else self.session
-        resp = await s.get(url, headers=headers, params=query_params)
+        kwargs = {
+            'timeout': timeout,
+        }
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
+        resp = await s.get(url, headers=headers, params=query_params, **kwargs)
         result: Dict[str, Any] = await resp.json()
         return result

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -63,7 +63,7 @@ class SubscriberClient:
                                   body: Optional[Dict[str, Any]] = None,
                                   *,
                                   session: Optional[Session] = None,
-                                  timeout: Optional[int] = None
+                                  timeout: Optional[int] = 10
                                   ) -> Dict[str, Any]:
         """
         Create subscription.
@@ -75,11 +75,7 @@ class SubscriberClient:
         payload.update({'topic': topic})
         encoded = json.dumps(payload).encode()
         s = AioSession(session) if session else self.session
-        kwargs = {
-            'timeout': timeout,
-        }
-        kwargs = {k: v for k, v in kwargs.items() if v is not None}
-        resp = await s.put(url, data=encoded, headers=headers, **kwargs)
+        resp = await s.put(url, data=encoded, headers=headers, timeout=timeout)
         result: Dict[str, Any] = await resp.json()
         return result
 
@@ -88,7 +84,7 @@ class SubscriberClient:
                                   subscription: str,
                                   *,
                                   session: Optional[Session] = None,
-                                  timeout: Optional[int] = None
+                                  timeout: Optional[int] = 10
                                   ) -> None:
         """
         Delete subscription.
@@ -96,16 +92,12 @@ class SubscriberClient:
         url = f'{API_ROOT}/v1/{subscription}'
         headers = await self._headers()
         s = AioSession(session) if session else self.session
-        kwargs = {
-            'timeout': timeout,
-        }
-        kwargs = {k: v for k, v in kwargs.items() if v is not None}
-        await s.delete(url, headers=headers, **kwargs)
+        await s.delete(url, headers=headers, timeout=timeout)
 
     # https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/pull
     async def pull(self, subscription: str, max_messages: int,
                    *, session: Optional[Session] = None,
-                   timeout: Optional[int] = None
+                   timeout: Optional[int] = 30
                    ) -> List[SubscriberMessage]:
         """
         Pull messages from subscription
@@ -117,11 +109,8 @@ class SubscriberClient:
         }
         encoded = json.dumps(payload).encode()
         s = AioSession(session) if session else self.session
-        kwargs = {
-            'timeout': timeout,
-        }
-        kwargs = {k: v for k, v in kwargs.items() if v is not None}
-        resp = await s.post(url, data=encoded, headers=headers, **kwargs)
+        resp = await s.post(url, data=encoded, headers=headers,
+                            timeout=timeout)
         resp = await resp.json()
         return [
             SubscriberMessage.from_repr(m)
@@ -131,7 +120,7 @@ class SubscriberClient:
     # https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/acknowledge
     async def acknowledge(self, subscription: str, ack_ids: List[str],
                           *, session: Optional[Session] = None,
-                          timeout: Optional[int] = None) -> None:
+                          timeout: Optional[int] = 10) -> None:
         """
         Acknowledge messages by ackIds
         """
@@ -142,18 +131,14 @@ class SubscriberClient:
         }
         encoded = json.dumps(payload).encode()
         s = AioSession(session) if session else self.session
-        kwargs = {
-            'timeout': timeout,
-        }
-        kwargs = {k: v for k, v in kwargs.items() if v is not None}
-        await s.post(url, data=encoded, headers=headers, **kwargs)
+        await s.post(url, data=encoded, headers=headers, timeout=timeout)
 
     # https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyAckDeadline
     async def modify_ack_deadline(self, subscription: str,
                                   ack_ids: List[str],
                                   ack_deadline_seconds: int,
                                   *, session: Optional[Session] = None,
-                                  timeout: Optional[int] = None
+                                  timeout: Optional[int] = 10
                                   ) -> None:
         """
         Modify messages' ack deadline.
@@ -166,17 +151,13 @@ class SubscriberClient:
             'ackDeadlineSeconds': ack_deadline_seconds,
         }
         s = AioSession(session) if session else self.session
-        kwargs = {
-            'timeout': timeout,
-        }
-        kwargs = {k: v for k, v in kwargs.items() if v is not None}
         await s.post(url, data=json.dumps(payload).encode('utf-8'),
-                     headers=headers, **kwargs)
+                     headers=headers, timeout=timeout)
 
     # https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/get
     async def get_subscription(self, subscription: str,
                                *, session: Optional[Session] = None,
-                               timeout: Optional[int] = None
+                               timeout: Optional[int] = 10
                                ) -> Dict[str, Any]:
         """
         Get Subscription
@@ -184,11 +165,7 @@ class SubscriberClient:
         url = f'{API_ROOT}/v1/{subscription}'
         headers = await self._headers()
         s = AioSession(session) if session else self.session
-        kwargs = {
-            'timeout': timeout,
-        }
-        kwargs = {k: v for k, v in kwargs.items() if v is not None}
-        resp = await s.get(url, headers=headers, **kwargs)
+        resp = await s.get(url, headers=headers, timeout=timeout)
         result: Dict[str, Any] = await resp.json()
         return result
 
@@ -196,7 +173,7 @@ class SubscriberClient:
     async def list_subscriptions(self, project: str,
                                  query_params: Optional[Dict[str, str]] = None,
                                  *, session: Optional[Session] = None,
-                                 timeout: Optional[int] = None
+                                 timeout: Optional[int] = 10
                                  ) -> Dict[str, Any]:
         """
         List subscriptions
@@ -204,10 +181,7 @@ class SubscriberClient:
         url = f'{API_ROOT}/v1/{project}/subscriptions'
         headers = await self._headers()
         s = AioSession(session) if session else self.session
-        kwargs = {
-            'timeout': timeout,
-        }
-        kwargs = {k: v for k, v in kwargs.items() if v is not None}
-        resp = await s.get(url, headers=headers, params=query_params, **kwargs)
+        resp = await s.get(url, headers=headers, params=query_params,
+                           timeout=timeout)
         result: Dict[str, Any] = await resp.json()
         return result


### PR DESCRIPTION
So at the moment we use a default `10s` receive timeout for long-polling pull requests. It turned out it works horribly under low traffic.
What user sees: things not working
What monitoring shows: both `num_of_unacked_messages` and `oldest_unacked_message` would spike, then few messages would get into a deadletter topic.
What debugging showed: some messages simply never get processed by application
Mind that I'm talking about the queue which has several actively listening consumers.

What I think is happening. Producer workers would open long-polling connections, drop them after 10 seconds, then open a new set etc. When a message is finally published, pubsub server tries to evenly distribute them between open polling requests and a lot of them have no actual client connected. So after several such publishes a message gets into deadletter even though it was never delivered.

Now for the fix. I check a few libs to see what timeout they're using. Broadway uses `infinity`, spotify's sunsetting pubsub lib does `returnImmediately: True`, google libs strongly prefer `StreamingPull`. I also find [this obscure](https://tools.ietf.org/id/draft-loreto-http-bidirectional-07.html#timeouts) link which has an abbreviation as a domain name and simple html design which usually indicates quality HTTP documentation. It recommends 30 seconds.

I tested 30 seconds and it works like a charm. I couldn't lose a single message.

![image](https://user-images.githubusercontent.com/62574824/104782427-01ce9400-5739-11eb-9905-b8580b111323.png)
