### PR TITLE
fix(pubsub) account for missing data key in SubscriberMessage

### DIFF
--- a/pubsub/gcloud/aio/pubsub/subscriber_message.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_message.py
@@ -40,7 +40,7 @@ class SubscriberMessage:
                                  attributes=attributes)
 
     def to_repr(self) -> Dict[str, Any]:
-        r = {
+        r: Dict[str, Any] = {
             'ackId': self.ack_id,
             'message': {
                 'messageId': self.message_id,
@@ -48,7 +48,7 @@ class SubscriberMessage:
             }
         }
         if self.attributes:
-            r['message']['attributes'] = self.attributes  # type: ignore
+            r['message']['attributes'] = self.attributes
         if self.data:
-            r['message']['data'] = base64.b64encode(self.data)  # type: ignore
+            r['message']['data'] = base64.b64encode(self.data)
         return r

--- a/pubsub/gcloud/aio/pubsub/subscriber_message.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_message.py
@@ -47,8 +47,8 @@ class SubscriberMessage:
                 'publishTime': self.publish_time.strftime('%Y-%m-%dT%H:%M:%SZ')
             }
         }
-        if self.attributes:
+        if self.attributes is not None:
             r['message']['attributes'] = self.attributes
-        if self.data:
+        if self.data is not None:
             r['message']['data'] = base64.b64encode(self.data)
         return r

--- a/pubsub/tests/unit/subscription_test.py
+++ b/pubsub/tests/unit/subscription_test.py
@@ -32,3 +32,20 @@ def test_construct_subscriber_message_from_message_dict():
     assert message.data == b'{"foo": "bar"}'
     assert message.publish_time == datetime.datetime(
         2020, 1, 1, 0, 0, 1)
+
+
+def test_construct_subscriber_message_no_data_no_attrs():
+    message_dict = {
+        'ackId': 'some_ack_id',
+        'message': {
+            'messageId': '123',
+            'publishTime': '2020-01-01T00:00:01.000Z'
+        }
+    }
+    message = SubscriberMessage.from_repr(message_dict)
+    assert message.ack_id == 'some_ack_id'
+    assert message.attributes is None
+    assert message.message_id == '123'
+    assert message.data is None
+    assert message.publish_time == datetime.datetime(
+        2020, 1, 1, 0, 0, 1)


### PR DESCRIPTION
Just like `attributes` key, `data` can also be missing.