### PR TITLE
Shaun/pubsub/shutdown fixes

### DIFF
--- a/pubsub/gcloud/aio/pubsub/subscriber.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber.py
@@ -67,7 +67,6 @@ else:
                 message = await asyncio.wait_for(
                     queue.get(), timeout=time_budget)
                 result.append(message)
-                queue.task_done()
             except asyncio.TimeoutError:
                 break
             time_budget -= (time.perf_counter() - start)
@@ -82,7 +81,6 @@ else:
         while True:
             if not ack_ids:
                 ack_ids.append(await ack_queue.get())
-                ack_queue.task_done()
 
             ack_ids += await _budgeted_queue_get(ack_queue, ack_window)
 
@@ -93,9 +91,14 @@ else:
                     'acker is falling behind, dropping %d unacked messages',
                     len(ack_ids) - 2500)
                 ack_ids = ack_ids[-2500:]
+                for _ in range(len(ack_ids) - 2500):
+                    ack_queue.task_done()
+
             try:
                 await subscriber_client.acknowledge(subscription,
                                                     ack_ids=ack_ids)
+                for _ in ack_ids:
+                    ack_queue.task_done()
             except aiohttp.client_exceptions.ClientResponseError as e:
                 if e.status == 400:
                     log.error(
@@ -111,6 +114,8 @@ else:
                             log.warning('Ack failed for ack_id=%s',
                                         ack_id,
                                         exc_info=e)
+                        finally:
+                            ack_queue.task_done()
 
                     for ack_id in ack_ids:
                         asyncio.ensure_future(maybe_ack(ack_id))
@@ -121,6 +126,8 @@ else:
                 metrics_client.increment('pubsub.acker.batch.failed')
 
                 continue
+            except asyncio.CancelledError:  # pylint: disable=try-except-raise
+                raise
             except Exception as e:
                 log.warning(
                     'Ack request failed, better luck next batch', exc_info=e)
@@ -141,7 +148,6 @@ else:
         while True:
             if not ack_ids:
                 ack_ids.append(await nack_queue.get())
-                nack_queue.task_done()
 
             ack_ids += await _budgeted_queue_get(nack_queue, nack_window)
 
@@ -152,13 +158,15 @@ else:
                     'nacker is falling behind, dropping %d unacked messages',
                     len(ack_ids) - 2500)
                 ack_ids = ack_ids[-2500:]
+                for _ in range(len(ack_ids) - 2500):
+                    nack_queue.task_done()
             try:
                 await subscriber_client.modify_ack_deadline(
                     subscription,
                     ack_ids=ack_ids,
                     ack_deadline_seconds=0)
-            except asyncio.CancelledError:  # pylint: disable=try-except-raise
-                raise
+                for _ in ack_ids:
+                    nack_queue.task_done()
             except aiohttp.client_exceptions.ClientResponseError as e:
                 if e.status == 400:
                     log.error(
@@ -175,6 +183,8 @@ else:
                             log.warning('Nack failed for ack_id=%s',
                                         ack_id,
                                         exc_info=e)
+                        finally:
+                            nack_queue.task_done()
                     for ack_id in ack_ids:
                         asyncio.ensure_future(maybe_nack(ack_id))
                     ack_ids = []
@@ -184,6 +194,8 @@ else:
                 metrics_client.increment('pubsub.nacker.batch.failed')
 
                 continue
+            except asyncio.CancelledError:  # pylint: disable=try-except-raise
+                raise
             except Exception as e:
                 log.warning(
                     'Nack request failed, better luck next batch', exc_info=e)

--- a/pubsub/tests/unit/subscriber_test.py
+++ b/pubsub/tests/unit/subscriber_test.py
@@ -213,6 +213,7 @@ else:
         )
         await asyncio.sleep(0)
         await asyncio.sleep(0)
+        await asyncio.sleep(0)
         mock.assert_called_once()
         assert queue.qsize() == 0
         assert not producer_task.done()
@@ -238,6 +239,7 @@ else:
                 metrics_client=MagicMock()
             )
         )
+        await asyncio.sleep(0)
         await asyncio.sleep(0)
         await asyncio.sleep(0)
         mock.assert_called_once()
@@ -267,6 +269,9 @@ else:
         )
         await asyncio.sleep(0)
         await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
         mock.assert_called_once()
         assert queue.qsize() == 0
         assert producer_task.done()
@@ -286,6 +291,7 @@ else:
                     metrics_client=MagicMock()
                 )
             )
+            await asyncio.sleep(0)
             await asyncio.sleep(0)
             await asyncio.sleep(0)
             await asyncio.sleep(0)

--- a/pubsub/tests/unit/subscriber_test.py
+++ b/pubsub/tests/unit/subscriber_test.py
@@ -686,6 +686,30 @@ else:
                 logging.WARNING,
                 'Ack failed for ack_id=ack_id_2') in caplog.record_tuples
 
+    @pytest.mark.asyncio
+    async def test_acker_graceful_shutdown(subscriber_client):
+
+        mock = MagicMock()
+
+        async def f(*args, **kwargs):
+            mock(*args, **kwargs)
+
+        subscriber_client.acknowledge = f
+        queue = asyncio.Queue()
+        acker_task = asyncio.ensure_future(
+            acker(
+                'fake_subscription',
+                queue,
+                subscriber_client,
+                0.1,
+                MagicMock()
+            )
+        )
+        await queue.put('ack_id_1')
+        await asyncio.wait_for(queue.join(), 1.)
+        mock.assert_called_with('fake_subscription', ack_ids=['ack_id_1'])
+        acker_task.cancel()
+
     # ========
     # nacker
     # ========
@@ -839,6 +863,31 @@ else:
         assert ('gcloud.aio.pubsub.subscriber',
                 logging.WARNING,
                 'Nack failed for ack_id=ack_id_2') in caplog.record_tuples
+
+    @pytest.mark.asyncio
+    async def test_nacker_graceful_shutdown(subscriber_client):
+
+        mock = MagicMock()
+
+        async def f(*args, **kwargs):
+            mock(*args, **kwargs)
+
+        subscriber_client.modify_ack_deadline = f
+        queue = asyncio.Queue()
+        nacker_task = asyncio.ensure_future(
+            nacker(
+                'fake_subscription',
+                queue,
+                subscriber_client,
+                0.1,
+                MagicMock()
+            )
+        )
+        await queue.put('ack_id_1')
+        await asyncio.wait_for(queue.join(), 1.)
+        mock.assert_called_with('fake_subscription', ack_ids=['ack_id_1'],
+                                ack_deadline_seconds=0)
+        nacker_task.cancel()
 
     # =========
     # subscribe


### PR DESCRIPTION
Noticed in one of our apps that there were a number of redeliveries on shutdown. Tracked this down to at least 2 causes:

1. We prematurely mark an ack task as done, thereby joining on the corresponding queue early and failing to ack messages.
2. The long running pull request we make to pubsub can return messages after producer cancellation (discovered this by noticing that there were some messages with `delivery_attempt=2` that we did not detect having `delivery_attempt=1`)

Latest test on staging in realtime-nlp resulted in no redelivered messages after manually killing pods.