### PR TITLE
Add a function to get a streamed response

### DIFF
--- a/storage/gcloud/aio/storage/__init__.py
+++ b/storage/gcloud/aio/storage/__init__.py
@@ -5,6 +5,7 @@ from gcloud.aio.storage.blob import Blob
 from gcloud.aio.storage.bucket import Bucket
 from gcloud.aio.storage.storage import SCOPES
 from gcloud.aio.storage.storage import Storage
+from gcloud.aio.storage.storage import StreamResponse
 
 
 __all__ = ['__version__', 'Blob', 'Bucket', 'SCOPES', 'Storage',

--- a/storage/gcloud/aio/storage/__init__.py
+++ b/storage/gcloud/aio/storage/__init__.py
@@ -7,4 +7,5 @@ from gcloud.aio.storage.storage import SCOPES
 from gcloud.aio.storage.storage import Storage
 
 
-__all__ = ['__version__', 'Blob', 'Bucket', 'SCOPES', 'Storage']
+__all__ = ['__version__', 'Blob', 'Bucket', 'SCOPES', 'Storage',
+           'StreamResponse']

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -249,6 +249,23 @@ class Storage:
                               timeout: int = 10,
                               session: Optional[Session] = None
                               ) -> StreamResponse:
+        """Download a GCS object in a buffered stream. 
+
+        Args:
+            bucket (str): The bucket from which to dowonload.
+            object_name (str): The object within the bucket to download.
+            headers (Optional[Dict[str, Any]], optional): Custom header values
+                for the request, such as range. Defaults to None.
+            timeout (int, optional): Timeout, in seconds, for the request. Note
+                that with this function, this is the time to the beginning of
+                the response data (TTFB). Defaults to 10.
+            session (Optional[Session], optional): A specific session to
+                (re)use. Defaults to None.
+
+        Returns:
+            StreamResponse: A object encapsulating the stream, similar to
+            io.BufferedIOBase, but it only supports the read() function.
+        """
         return await self._download_stream(bucket, object_name,
                                            headers=headers, timeout=timeout,
                                            params={'alt': 'media'},

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -249,7 +249,7 @@ class Storage:
                               timeout: int = 10,
                               session: Optional[Session] = None
                               ) -> StreamResponse:
-        """Download a GCS object in a buffered stream. 
+        """Download a GCS object in a buffered stream.
 
         Args:
             bucket (str): The bucket from which to dowonload.

--- a/storage/tests/integration/download_stream_test.py
+++ b/storage/tests/integration/download_stream_test.py
@@ -1,0 +1,49 @@
+import io
+import os
+import random
+import string
+import uuid
+
+import pytest
+from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
+from gcloud.aio.storage import Storage
+
+# Selectively load libraries based on the package
+if BUILD_GCLOUD_REST:
+    from requests import Session
+else:
+    from aiohttp import ClientSession as Session
+
+# TODO: use hypothesis
+RANDOM_BINARY = os.urandom(2045)
+
+# Updated statement to make it compatible with python2
+rand_str_list = [random.choice(string.ascii_letters) for r in range(0, 1054)]
+RANDOM_STRING = ''.join(rand_str_list)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('uploaded_data,expected_data', [
+    (io.BytesIO(RANDOM_BINARY), RANDOM_BINARY),
+    (io.StringIO(RANDOM_STRING), RANDOM_STRING.encode('utf-8')),
+])
+async def test_download_stream(bucket_name, creds, uploaded_data,
+                               expected_data):
+    object_name = f'{uuid.uuid4().hex}/{uuid.uuid4().hex}'
+
+    async with Session() as session:
+        storage = Storage(service_file=creds, session=session)
+        res = await storage.upload(bucket_name, object_name, uploaded_data)
+
+        with io.BytesIO(b'') as downloaded_data:
+            download_stream = await storage.download_stream(
+                bucket_name, res['name'])
+            while True:
+                chunk = await download_stream.read(4096)
+                if not chunk:
+                    break
+                downloaded_data.write(chunk)
+
+            assert expected_data == downloaded_data.getvalue()
+
+        await storage.delete(bucket_name, res['name'])


### PR DESCRIPTION
Hi @TheKevJames & company,

I was taking a look at how I might get downloads from your library without downloading object contents into memory. I found some [documentation](https://docs.aiohttp.org/en/stable/client_quickstart.html#streaming-response-content) for aiohttp which recommended using the response.content attribute directly, instead of the response.read() method, for downloads of significant size. Since a lot of GCS objects are pretty big, I think this change is useful.

It doesn't modify the original `download` behavior, since it is a breaking change. Instead, this PR:

- adds a new method, `get_content`. This is just a clone of the download method, but with a `get_content` flag set when calling the private implementation
- changes the private implementation `_download` method to honor the `get_content` flag, returning response.content when that is set to True. When False (default), the original behavior is retained.
- changes the implementation of `download_to_filename` to now use the chunked writing from content, therefore using less memory while still being quite performant. A conservative buffer size of 4kB (typical small kernel page size) is used. This last change is not necessary to move this PR forward and I'm happy to back it out. It does illustrate how simple it is to use the `aiohttp.StreamReader` API, at least.

edit: I should add, I'm not a very opinionated programmer. If you'd prefer to just add a switch to the `download` method and go with that, I'm good. Might make it hard to discover, which is why I went with creating another method.