### PR TITLE
feat(storage): add ability to make patch request to stored objects (metadata)

### DIFF
--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -302,22 +302,6 @@ class Storage:
             return await self.upload(bucket, object_name, file_object,
                                      **kwargs)
 
-    async def _patch_metadata(
-            self, bucket: str, object_name: str, metadata: Dict[str, Any],
-            params: Dict[str, str], headers: Dict[str, str],
-            *, session: Optional[Session] = None,
-            timeout: int = 10) -> Dict[str, Any]:
-        # https://cloud.google.com/storage/docs/json_api/v1/objects/patch
-        url = f'{API_ROOT}/{bucket}/o/{object_name}'
-        headers.update(await self._headers())
-        headers['Content-Type'] = 'application/json'
-
-        s = AioSession(session) if session else self.session
-        resp = await s.patch(url, data=json.dumps(metadata).encode('utf-8'),
-                             headers=headers, params=params, timeout=timeout)
-        data: Dict[str, Any] = await resp.json(content_type=None)
-        return data
-
     async def set_temporary_hold(
             self, bucket: str, object_name: str, *, hold: bool = True,
             params: Optional[Dict[str, str]] = None,
@@ -525,6 +509,22 @@ class Storage:
 
             break
 
+        data: Dict[str, Any] = await resp.json(content_type=None)
+        return data
+
+    async def _patch_metadata(
+            self, bucket: str, object_name: str, metadata: Dict[str, Any],
+            params: Dict[str, str], headers: Dict[str, str],
+            *, session: Optional[Session] = None,
+            timeout: int = 10) -> Dict[str, Any]:
+        # https://cloud.google.com/storage/docs/json_api/v1/objects/patch
+        url = f'{API_ROOT}/{bucket}/o/{object_name}'
+        headers.update(await self._headers())
+        headers['Content-Type'] = 'application/json'
+
+        s = AioSession(session) if session else self.session
+        resp = await s.patch(url, data=json.dumps(metadata).encode('utf-8'),
+                             headers=headers, params=params, timeout=timeout)
         data: Dict[str, Any] = await resp.json(content_type=None)
         return data
 

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -302,37 +302,38 @@ class Storage:
             return await self.upload(bucket, object_name, file_object,
                                      **kwargs)
 
+    async def _patch_metadata(
+            self, bucket: str, object_name: str, metadata: Dict[str, Any],
+            *, params: Optional[Dict[str, str]] = None,
+            session: Optional[Session] = None,
+            timeout: int = 10) -> Dict[str, Any]:
+        url = f'{API_ROOT}/{bucket}/o/{object_name}'
+        s = AioSession(session) if session else self.session
+        headers = await self._headers()
+        headers.update({'Content-Type': 'application/json'})
+        resp = await s.patch(
+            url, data=json.dumps(metadata).encode('utf-8'),
+            headers=headers, params=params, timeout=timeout)
+        data: Dict[str, Any] = await resp.json(content_type=None)
+        return data
+
     async def set_temporary_hold(
             self, bucket: str, object_name: str, *, hold: bool = True,
             params: Optional[Dict[str, str]] = None,
             session: Optional[Session] = None, timeout: int = 10
     ) -> Dict[str, Any]:
-
-        async def _raise_for_status(resp) -> None:  # type: ignore
-            # TODO: remove after adding BaseSession.patch()
-            import aiohttp  # pylint: disable=import-outside-toplevel
-            if resp.status >= 400:
-                assert resp.reason is not None
-                # Google's error messages are useful, pass 'em through
-                body = await resp.text(errors='replace')
-                resp.release()
-                raise aiohttp.ClientResponseError(
-                    resp.request_info, resp.history,
-                    status=resp.status,
-                    message=f'{resp.reason}: {body}',
-                    headers=resp.headers)
-
-        url = f'{API_ROOT}/{bucket}/o/{object_name}'
-        s = AioSession(session) if session else self.session
-        headers = await self._headers()
-        headers.update({'Content-Type': 'application/json'})
-        metadata = json.dumps({'temporaryHold': hold}).encode('utf-8')
-        resp = await s.session.patch(  # TODO: add BaseSession.patch()
-            url, data=metadata, headers=headers, params=params,
-            timeout=timeout)
-        await _raise_for_status(resp)  # TODO: remove after BaseSession.patch()
-        data: Dict[str, Any] = await resp.json(content_type=None)
-        return data
+        """
+        Set a temporary hold on a storage blob.
+        https://cloud.google.com/storage/docs/json_api/v1/objects/patch
+        """
+        return await self._patch_metadata(
+            bucket=bucket,
+            object_name=object_name,
+            metadata={'temporaryHold': hold},
+            params=params,
+            session=session,
+            timeout=timeout,
+        )
 
     @staticmethod
     def _get_stream_len(stream: IO[AnyStr]) -> int:

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -302,19 +302,6 @@ class Storage:
             return await self.upload(bucket, object_name, file_object,
                                      **kwargs)
 
-    async def set_temporary_hold(
-            self, bucket: str, object_name: str, *, hold: bool = True,
-            params: Optional[Dict[str, str]] = None,
-            headers: Optional[Dict[str, str]] = None,
-            session: Optional[Session] = None, timeout: int = 10
-    ) -> Dict[str, Any]:
-        params = params or {}
-        headers = headers or {}
-        return await self._patch_metadata(
-            bucket=bucket, object_name=object_name,
-            metadata={'temporaryHold': hold},
-            params=params, headers=headers, session=session, timeout=timeout,)
-
     @staticmethod
     def _get_stream_len(stream: IO[AnyStr]) -> int:
         current = stream.tell()
@@ -512,13 +499,16 @@ class Storage:
         data: Dict[str, Any] = await resp.json(content_type=None)
         return data
 
-    async def _patch_metadata(
+    async def patch_metadata(
             self, bucket: str, object_name: str, metadata: Dict[str, Any],
-            params: Dict[str, str], headers: Dict[str, str],
-            *, session: Optional[Session] = None,
+            *, params: Optional[Dict[str, str]] = None,
+            headers: Optional[Dict[str, str]] = None,
+            session: Optional[Session] = None,
             timeout: int = 10) -> Dict[str, Any]:
         # https://cloud.google.com/storage/docs/json_api/v1/objects/patch
         url = f'{API_ROOT}/{bucket}/o/{object_name}'
+        params = params or {}
+        headers = headers or {}
         headers.update(await self._headers())
         headers['Content-Type'] = 'application/json'
 


### PR DESCRIPTION
Summary:
• adds a method `Storage.patch_metadata()` that accepts an arbitrary dictionary to patch stored object metadata

Related:
• https://switchcomm.atlassian.net/browse/VAE-2317
• ✅ https://github.com/talkiq/gcloud-aio/pull/311 — move Session.patch() to gcloud-(aio|rest)-auth

Testing:
• ✅ tested locally w `pip install -e ./storage`