### PR TITLE
feat(auth): add http PATCH to BaseSession, AioSession, and SyncSession

### DIFF
--- a/auth/gcloud/aio/auth/session.py
+++ b/auth/gcloud/aio/auth/session.py
@@ -47,6 +47,12 @@ class BaseSession:
         pass
 
     @abstractmethod
+    async def patch(self, url: str, headers: Dict[str, str],
+                    data: Optional[str], timeout: int,
+                    params: Optional[Dict[str, str]]) -> Response:
+        pass
+
+    @abstractmethod
     async def put(self, url: str, headers: Dict[str, str], data: IO[Any],
                   timeout: int) -> Response:
         pass
@@ -124,6 +130,15 @@ if not BUILD_GCLOUD_REST:
             await _raise_for_status(resp)
             return resp
 
+        async def patch(self, url: str, headers: Dict[str, str],
+                        data: Optional[str] = None, timeout: int = 10,
+                        params: Optional[Dict[str, str]] = None
+                        ) -> aiohttp.ClientResponse:
+            resp = await self.session.patch(url, data=data, headers=headers,
+                                            timeout=timeout, params=params)
+            await _raise_for_status(resp)
+            return resp
+
         async def put(self, url: str, headers: Dict[str, str], data: IO[Any],
                       timeout: int = 10) -> aiohttp.ClientResponse:
             resp = await self.session.put(url, data=data, headers=headers,
@@ -186,6 +201,15 @@ if BUILD_GCLOUD_REST:
             with self.google_api_lock:
                 resp = self.session.get(url, headers=headers, timeout=timeout,
                                         params=params)
+            resp.raise_for_status()
+            return resp
+
+        async def patch(self, url: str, headers: Dict[str, str],
+                        data: Optional[str] = None, timeout: int = 10,
+                        params: Optional[Dict[str, str]] = None) -> Response:
+            with self.google_api_lock:
+                resp = self.session.patch(url, data=data, headers=headers,
+                                          timeout=timeout, params=params)
             resp.raise_for_status()
             return resp
 


### PR DESCRIPTION
Add `patch` to `BaseSession`, `AioSession` and `SyncSession`.
• this is a pre-requisite to individually modifying metadata for Google Storage objects, but def belongs in the auth module, as it's probably general enough that we'll figure a need for it elsewhere.

Unblocks:
• https://github.com/talkiq/gcloud-aio/pull/310