### PR TITLE
Use non blocking aiofiles.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,6 +180,7 @@ jobs:
 
       # Physically update files to remove incompatible syntax
       - run: find . -type f -path '*requirements.txt' | xargs -L1 sed -Ei 's/aiohttp/# aiohttp/g'
+      - run: find . -type f -path '*requirements.txt' | xargs -L1 sed -Ei 's/aiofiles/# aiofiles/g'
       - run: find . -type f -path '*requirements.txt' | xargs -L1 sed -Ei 's/# requests/requests/g'
       - run: find . -type f | grep -v "session.py" | xargs -L1 sed -Ei 's/AioSession/SyncSession/g'
       - run: find . -type f | xargs -L1 sed -Ei 's/asyncio.ensure_future(.*)/\1/g'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
     -   id: reorder-python-imports
         args: [--py26-plus]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+    rev: v0.812
     hooks:
     -   &mypy
         id: mypy

--- a/storage/README.rst
+++ b/storage/README.rst
@@ -28,8 +28,8 @@ To upload a file, you might do something like the following:
     async with aiohttp.ClientSession() as session:
         client = Storage(session=session)
 
-        async with aiofiles.open(source, mode="r") as f:
-            output = await f.read()
+        async with aiofiles.open('/path/to/my/file', mode="r") as f:
+            contents = await f.read()
             status = await client.upload(
                 'my-bucket-name',
                 'path/to/gcs/folder',
@@ -59,8 +59,8 @@ more complicated operations:
         uploads = []
         for local_name, gcs_name in my_files.items():
             async with aiofiles.open(local_name, mode="r") as f:
-                output = await f.read()
-                uploads.append((gcs_name, output))
+                contents = await f.read()
+                uploads.append((gcs_name, contents))
 
         # Simultaneously upload all files
         await asyncio.gather(

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -26,8 +26,9 @@ if BUILD_GCLOUD_REST:
     from time import sleep
     from requests import HTTPError as ResponseError
     from requests import Session
+    from builtins import open as file_open
 else:
-    import aiofiles
+    from aiofiles import open as file_open  # type: ignore[no-redef]
     from asyncio import sleep  # type: ignore[misc]
     from aiohttp import ClientResponseError as ResponseError  # type: ignore[no-redef]  # pylint: disable=line-too-long
     from aiohttp import ClientSession as Session  # type: ignore[no-redef]
@@ -213,7 +214,10 @@ class Storage:
 
     async def download_to_filename(self, bucket: str, object_name: str,
                                    filename: str, **kwargs: Any) -> None:
-        async with aiofiles.open(filename, mode='wb+') as file_object:
+        async with file_open(  # type: ignore[attr-defined]
+            filename,
+            mode='wb+',
+        ) as file_object:
             await file_object.write(
                 await self.download(bucket, object_name, **kwargs)
             )
@@ -297,7 +301,10 @@ class Storage:
     async def upload_from_filename(self, bucket: str, object_name: str,
                                    filename: str,
                                    **kwargs: Any) -> Dict[str, Any]:
-        async with aiofiles.open(filename, 'rb') as file_object:
+        async with file_open(  # type: ignore[attr-defined]
+            filename,
+            mode='rb',
+        ) as file_object:
             contents = await file_object.read()
             return await self.upload(bucket, object_name, contents,
                                      **kwargs)

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -30,8 +30,7 @@ else:
     from asyncio import sleep  # type: ignore[misc]
     from aiohttp import ClientResponseError as ResponseError  # type: ignore[no-redef]  # pylint: disable=line-too-long
     from aiohttp import ClientSession as Session  # type: ignore[no-redef]
-    from aiofiles import open
-
+    from aiofiles import open  # pylint: disable=W0622
 
 API_ROOT = 'https://www.googleapis.com/storage/v1/b'
 API_ROOT_UPLOAD = 'https://www.googleapis.com/upload/storage/v1/b'
@@ -42,13 +41,11 @@ SCOPES = [
 
 MAX_CONTENT_LENGTH_SIMPLE_UPLOAD = 5 * 1024 * 1024  # 5 MB
 
-
 STORAGE_EMULATOR_HOST = os.environ.get('STORAGE_EMULATOR_HOST')
 if STORAGE_EMULATOR_HOST:
     API_ROOT = f'https://{STORAGE_EMULATOR_HOST}/storage/v1/b'
     API_ROOT_UPLOAD = f'https://{STORAGE_EMULATOR_HOST}/upload/storage/v1/b'
     VERIFY_SSL = False
-
 
 log = logging.getLogger(__name__)
 
@@ -217,8 +214,9 @@ class Storage:
     async def download_to_filename(self, bucket: str, object_name: str,
                                    filename: str, **kwargs: Any) -> None:
         async with open(filename, mode='wb+') as file_object:
-            await file_object.write(await self.download(bucket, object_name,
-                                                  **kwargs))
+            await file_object.write(
+                await self.download(bucket, object_name, **kwargs)
+            )
 
     async def download_metadata(self, bucket: str, object_name: str, *,
                                 headers: Optional[Dict[str, Any]] = None,

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -30,6 +30,7 @@ else:
     from asyncio import sleep  # type: ignore[misc]
     from aiohttp import ClientResponseError as ResponseError  # type: ignore[no-redef]  # pylint: disable=line-too-long
     from aiohttp import ClientSession as Session  # type: ignore[no-redef]
+    from aiofiles import open
 
 
 API_ROOT = 'https://www.googleapis.com/storage/v1/b'
@@ -215,8 +216,8 @@ class Storage:
 
     async def download_to_filename(self, bucket: str, object_name: str,
                                    filename: str, **kwargs: Any) -> None:
-        with open(filename, 'wb+') as file_object:
-            file_object.write(await self.download(bucket, object_name,
+        async with open(filename, mode='wb+') as file_object:
+            await file_object.write(await self.download(bucket, object_name,
                                                   **kwargs))
 
     async def download_metadata(self, bucket: str, object_name: str, *,
@@ -298,8 +299,9 @@ class Storage:
     async def upload_from_filename(self, bucket: str, object_name: str,
                                    filename: str,
                                    **kwargs: Any) -> Dict[str, Any]:
-        with open(filename, 'rb') as file_object:
-            return await self.upload(bucket, object_name, file_object,
+        async with open(filename, 'rb') as file_object:
+            contents = await file_object.read()
+            return await self.upload(bucket, object_name, contents,
                                      **kwargs)
 
     @staticmethod

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -27,10 +27,10 @@ if BUILD_GCLOUD_REST:
     from requests import HTTPError as ResponseError
     from requests import Session
 else:
+    import aiofiles
     from asyncio import sleep  # type: ignore[misc]
     from aiohttp import ClientResponseError as ResponseError  # type: ignore[no-redef]  # pylint: disable=line-too-long
     from aiohttp import ClientSession as Session  # type: ignore[no-redef]
-    from aiofiles import open  # pylint: disable=W0622
 
 API_ROOT = 'https://www.googleapis.com/storage/v1/b'
 API_ROOT_UPLOAD = 'https://www.googleapis.com/upload/storage/v1/b'
@@ -213,7 +213,7 @@ class Storage:
 
     async def download_to_filename(self, bucket: str, object_name: str,
                                    filename: str, **kwargs: Any) -> None:
-        async with open(filename, mode='wb+') as file_object:
+        async with aiofiles.open(filename, mode='wb+') as file_object:
             await file_object.write(
                 await self.download(bucket, object_name, **kwargs)
             )
@@ -297,7 +297,7 @@ class Storage:
     async def upload_from_filename(self, bucket: str, object_name: str,
                                    filename: str,
                                    **kwargs: Any) -> Dict[str, Any]:
-        async with open(filename, 'rb') as file_object:
+        async with aiofiles.open(filename, 'rb') as file_object:
             contents = await file_object.read()
             return await self.upload(bucket, object_name, contents,
                                      **kwargs)

--- a/storage/requirements.txt
+++ b/storage/requirements.txt
@@ -1,2 +1,2 @@
-gcloud-aio-auth>= 3.3.0,< 4.0.0
 aiofiles>=0.6.0,<1.0.0
+gcloud-aio-auth>= 3.3.0,< 4.0.0

--- a/storage/requirements.txt
+++ b/storage/requirements.txt
@@ -1,1 +1,2 @@
-gcloud-aio-auth >= 3.3.0, < 4.0.0
+gcloud-aio-auth>= 3.3.0,< 4.0.0
+aiofiles>=0.6.0,<1.0.0


### PR DESCRIPTION
## Features
- Adds `aiofiles` dependency to `aio.storage.storage` package
- Updates the doc references to builtin [open](https://docs.python.org/3/library/functions.html#open) to [aiofiles](https://github.com/Tinche/aiofiles)
- Bumps mypy due to https://github.com/python/mypy/issues/9739
- Improves `aio.storage.storage.Storage.download_to_filename` to use [aiofiles](https://github.com/Tinche/aiofiles) 
- Improves `aio.storage.storage.Storage.upload_from_filename` to use [aiofiles](https://github.com/Tinche/aiofiles)


@TheKevJames 

Moved from initial PR #309 