### PR TITLE
chore(release): bigquery 5.1.0 -> 5.2.0

### DIFF
--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as f:
 
 setuptools.setup(
     name='gcloud-aio-bigquery',
-    version='5.1.0',
+    version='5.2.0',
     description='Python Client for Google Cloud BigQuery',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
* Pull in #319 to pass through params to `Job.get_query_results`
* Pull in #234 to get the result of a query job via `Job.result`