### PR TITLE
feat(pubsub): Supporting context management protocol in SubscriberClient

### DIFF
--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -183,3 +183,12 @@ class SubscriberClient:
                            timeout=timeout)
         result: Dict[str, Any] = await resp.json()
         return result
+
+    async def close(self) -> None:
+        await self.session.close()
+
+    async def __aenter__(self) -> 'SubscriberClient':
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.close()


### PR DESCRIPTION
I noticed there was no context manager protocol implemented in `SubscriberClient`. I might misunderstand the class, but this will allow the use of `async with` without relying on the following idiom:

```python
async with aiohttp.ClientSession() as session:
    subscriber_client = SubscriberClient(session=session)
```
Instead, we will be able to do:

```python
async with SubscriberClient() as client:
    ....
```