### PR TITLE
Have Query from_repr support the 'kind' format generated by to_repr

### DIFF
--- a/datastore/gcloud/aio/datastore/query.py
+++ b/datastore/gcloud/aio/datastore/query.py
@@ -60,9 +60,9 @@ class Query(BaseQuery):
     def from_repr(cls, data: Dict[str, Any]) -> 'Query':
         kind = data['kind'] or ''  # Kind is required
         if not isinstance(kind, str):
-          # If 'kind' is not a str, then the only other acceptable format
-          # is the list of a single dict [{'name' : kind}] (see to_repr)
-          kind = kind[0].get('name') or ''
+            # If 'kind' is not a str, then the only other acceptable format
+            # is the list of a single dict [{'name' : kind}] (see to_repr)
+            kind = kind[0].get('name') or ''
         orders = [PropertyOrder.from_repr(o) for o in data.get('order', [])]
         start_cursor = data.get('startCursor') or ''
         end_cursor = data.get('endCursor') or ''

--- a/datastore/gcloud/aio/datastore/query.py
+++ b/datastore/gcloud/aio/datastore/query.py
@@ -59,6 +59,10 @@ class Query(BaseQuery):
     @classmethod
     def from_repr(cls, data: Dict[str, Any]) -> 'Query':
         kind = data['kind'] or ''  # Kind is required
+        if not isinstance(kind, str):
+          # If 'kind' is not a str, then the only other acceptable format
+          # is the list of a single dict [{'name' : kind}] (see to_repr)
+          kind = kind[0].get('name') or ''
         orders = [PropertyOrder.from_repr(o) for o in data.get('order', [])]
         start_cursor = data.get('startCursor') or ''
         end_cursor = data.get('endCursor') or ''

--- a/datastore/tests/unit/query_test.py
+++ b/datastore/tests/unit/query_test.py
@@ -109,6 +109,11 @@ class TestQuery:
         assert repr(query) == str(query.to_repr())
 
     @staticmethod
+    def test_from_to_repr(query):
+        new_query = Query.from_repr(query.to_repr())
+        assert new_query == query
+
+    @staticmethod
     @pytest.fixture(scope='session')
     def query(query_filter) -> Query:
         return Query('query_kind', query_filter)


### PR DESCRIPTION
Have Query.from_repr accept a list with a single dict in it as the format for the 'kind' key, the same as is produced by Query.to_repr.