### PR TITLE
chore(deps): bump dependency pylint to v2.8.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     -   id: name-tests-test
     -   id: requirements-txt-fixer
 -   repo: https://github.com/pycqa/pylint
-    rev: pylint-2.8.1
+    rev: v2.8.2
     hooks:
     -   id: pylint
         additional_dependencies:


### PR DESCRIPTION
This one had to be manual since pylint has changed its tagging strategy
in such a way that renovate cannot detect. Future updates should be
automated as per usual.