### PR TITLE
Do a buffered read when uploading local file instead of a full read.

### DIFF
--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -352,8 +352,7 @@ class Storage:
             filename,
             mode='rb',
         ) as file_object:
-            contents = await file_object.read()
-            return await self.upload(bucket, object_name, contents,
+            return await self.upload(bucket, object_name, file_object,
                                      **kwargs)
 
     @staticmethod


### PR DESCRIPTION
When uploading large files the current implementation uses a lot of memory without good reason, there is no need to read the complete file when upload can work with the file stream itself.