### PR TITLE
feat(storage): Add data to copy endpoint.

### DIFF
--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -148,7 +148,7 @@ class Storage:
 
     async def copy(self, bucket: str, object_name: str,
                    destination_bucket: str, *, new_name: Optional[str] = None,
-                   data: Optional[str] = None,
+                   metadata: Optional[str] = None,
                    params: Optional[Dict[str, str]] = None,
                    headers: Optional[Dict[str, str]] = None, timeout: int = 10,
                    session: Optional[Session] = None) -> Dict[str, Any]:
@@ -177,7 +177,7 @@ class Storage:
 
         # We may optionally supply metadata* to apply to the rewritten
         # object, which explains why `rewriteTo` is a POST endpoint; when no
-        # data is given, we have to send an empty body. Therefore
+        # metadata is given, we have to send an empty body. Therefore
         # the `Content-Length` and `Content-Type` indicate an empty body.
         #
         # * https://cloud.google.com/storage/docs/json_api/v1/objects#resource
@@ -187,8 +187,8 @@ class Storage:
             'Content-Length': '0',
             'Content-Type': '',
         }
-        if data:
-            headers_update['Content-Length'] = str(len(data))
+        if metadata:
+            headers_update['Content-Length'] = str(len(metadata))
             headers_update['Content-Type'] = 'application/json'
         headers.update(headers_update)
 
@@ -196,7 +196,7 @@ class Storage:
 
         s = AioSession(session) if session else self.session
         resp = await s.post(url, headers=headers, params=params,
-                            timeout=timeout, data=data)
+                            timeout=timeout, data=metadata)
 
         resp_data: Dict[str, Any] = await resp.json(content_type=None)
 

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -148,6 +148,7 @@ class Storage:
 
     async def copy(self, bucket: str, object_name: str,
                    destination_bucket: str, *, new_name: Optional[str] = None,
+                   data: Optional[str] = None,
                    params: Optional[Dict[str, str]] = None,
                    headers: Optional[Dict[str, str]] = None, timeout: int = 10,
                    session: Optional[Session] = None) -> Dict[str, Any]:
@@ -175,33 +176,37 @@ class Storage:
                f"/b/{destination_bucket}/o/{quote(new_name, safe='')}")
 
         # We may optionally supply metadata* to apply to the rewritten
-        # object, which explains why `rewriteTo` is a POST endpoint; however,
-        # we don't expose that here so we have to send an empty body. Therefore
+        # object, which explains why `rewriteTo` is a POST endpoint; when no
+        # data is given, we have to send an empty body. Therefore
         # the `Content-Length` and `Content-Type` indicate an empty body.
         #
         # * https://cloud.google.com/storage/docs/json_api/v1/objects#resource
         headers = headers or {}
         headers.update(await self._headers())
-        headers.update({
+        headers_update = {
             'Content-Length': '0',
             'Content-Type': '',
-        })
+        }
+        if data:
+            headers_update['Content-Length'] = str(len(data))
+            headers_update['Content-Type'] = 'application/json'
+        headers.update(headers_update)
 
         params = params or {}
 
         s = AioSession(session) if session else self.session
         resp = await s.post(url, headers=headers, params=params,
-                            timeout=timeout)
+                            timeout=timeout, data=data)
 
-        data: Dict[str, Any] = await resp.json(content_type=None)
+        resp_data: Dict[str, Any] = await resp.json(content_type=None)
 
-        while not data.get('done') and data.get('rewriteToken'):
-            params['rewriteToken'] = data['rewriteToken']
+        while not resp_data.get('done') and resp_data.get('rewriteToken'):
+            params['rewriteToken'] = resp_data['rewriteToken']
             resp = await s.post(url, headers=headers, params=params,
                                 timeout=timeout)
-            data = await resp.json(content_type=None)
+            resp_data = await resp.json(content_type=None)
 
-        return data
+        return resp_data
 
     async def delete(self, bucket: str, object_name: str, *, timeout: int = 10,
                      params: Optional[Dict[str, str]] = None,

--- a/storage/tests/integration/metadata_test.py
+++ b/storage/tests/integration/metadata_test.py
@@ -126,7 +126,7 @@ async def test_metadata_copy(bucket_name, creds):
 
         await storage.copy(bucket_name, object_name, bucket_name,
                            new_name=copied_object_name,
-                           data=json.dumps(original_metadata))
+                           metadata=json.dumps(original_metadata))
 
         data = await storage.download(bucket_name, copied_object_name)
         data_metadata = await storage.download_metadata(


### PR DESCRIPTION
Since gcloud supports a data body in its rewrite method, the copy
funcion can expose this to its public endpoint. This also enables the
enduser to set other metadata for the copied object.

https://github.com/talkiq/gcloud-aio/issues/362