### PR TITLE
feat(kms): do not convert decode() result to str

### DIFF
--- a/kms/README.rst
+++ b/kms/README.rst
@@ -26,7 +26,7 @@ We're still working on more complete documentation, but roughly you can do:
     kms = KMS('my-kms-project', 'my-keyring', 'my-key-name')
 
     # encrypt
-    plaintext = 'the-best-animal-is-the-aardvark'
+    plaintext = b'the-best-animal-is-the-aardvark'
     ciphertext = await kms.encrypt(encode(plaintext))
 
     # decrypt

--- a/kms/gcloud/aio/kms/utils.py
+++ b/kms/gcloud/aio/kms/utils.py
@@ -1,16 +1,19 @@
-# TODO: this file is copied from gcloud-aio-taskqueue
 import base64
 from typing import Union
 
 
-def decode(payload: str) -> str:
+def decode(payload: str) -> bytes:
     """
     https://en.wikipedia.org/wiki/Base64#URL_applications modified Base64
     for URL variants exist, where the + and / characters of standard
     Base64 are respectively replaced by - and _
+
+    Does not make any assumptions about encoding -- if you're encoding a bytes
+    payload then `foo == decode(encode(foo))`, but if `foo` is a string you'll
+    need to `.decode()` manually according to your expected encoding scheme.
     """
     variant = payload.replace('-', '+').replace('_', '/')
-    return base64.b64decode(variant).decode()
+    return base64.b64decode(variant)
 
 
 def encode(payload: Union[bytes, str]) -> str:


### PR DESCRIPTION
BREAKING CHANGE: avoid calling `.decode()` on the resulting payload of
`decode()` to account for non-utf-8 encodings and other user behaviour;
clients should know what data type they're expecting here and act
accordingly.