### PR TITLE
bug(auth): Prevent closing shared sessions from AIO/REST Sessions

### DIFF
--- a/auth/gcloud/aio/auth/session.py
+++ b/auth/gcloud/aio/auth/session.py
@@ -27,6 +27,7 @@ class BaseSession:
 
     def __init__(self, session: Optional[Session] = None, timeout: int = 10,
                  verify_ssl: bool = True) -> None:
+        self._shared_session = bool(session)
         self._session = session
         self._ssl = verify_ssl
         self._timeout = timeout
@@ -170,7 +171,7 @@ if not BUILD_GCLOUD_REST:
             return resp
 
         async def close(self) -> None:
-            if self._session:
+            if not self._shared_session and self._session:
                 await self._session.close()  # type: ignore[func-returns-value]
 
 
@@ -248,5 +249,5 @@ if BUILD_GCLOUD_REST:
             return resp
 
         async def close(self) -> None:
-            if self._session:
+            if not self._shared_session and self._session:
                 self._session.close()

--- a/auth/tests/unit/sessions_test.py
+++ b/auth/tests/unit/sessions_test.py
@@ -17,9 +17,6 @@ if BUILD_GCLOUD_REST:
         @property
         def closed(self) -> bool:
             return self._called
-
-    requests.Session = Session
-    # Required to be here to ensure inclusion after monkeypatch
 else:
     from aiohttp import ClientSession as Session
 

--- a/auth/tests/unit/sessions_test.py
+++ b/auth/tests/unit/sessions_test.py
@@ -1,22 +1,27 @@
 import pytest
-from aiohttp import ClientSession
+from gcloud.aio.auth.build_constants import BUILD_GCLOUD_REST
 from gcloud.aio.auth.session import AioSession
+
+if BUILD_GCLOUD_REST:
+    from requests import Session
+else:
+    from aiohttp import ClientSession as Session
 
 
 @pytest.mark.asyncio
 async def test_unmanaged_session():
-    async with ClientSession() as session:
-        aio_session = AioSession(session=session)
-        assert aio_session._shared_session  # pylint: disable=protected-access
-        await aio_session.close()
+    async with Session() as session:
+        gcloud_session = AioSession(session=session)
+        assert gcloud_session._shared_session  # pylint: disable=protected-access
+        await gcloud_session.close()
 
         assert not session.closed
 
 
 @pytest.mark.asyncio
 async def test_managed_session():
-    aio_session = AioSession()
-    internal_session = aio_session.session
-    assert not aio_session._shared_session  # pylint: disable=protected-access
-    await aio_session.close()
+    gcloud_session = AioSession()
+    internal_session = gcloud_session.session
+    assert not gcloud_session._shared_session  # pylint: disable=protected-access
+    await gcloud_session.close()
     assert internal_session.closed

--- a/auth/tests/unit/sessions_test.py
+++ b/auth/tests/unit/sessions_test.py
@@ -3,8 +3,21 @@ from gcloud.aio.auth.build_constants import BUILD_GCLOUD_REST
 from gcloud.aio.auth.session import AioSession
 
 if BUILD_GCLOUD_REST:
-    from unittest.mock import MagicMock as Session
     import requests
+
+    class Session(requests.Session):
+        def __init__(self, *args, **kwargs) -> None:
+            self._called = False
+            super(requests.Session, self).__init__(*args, **kwargs)
+
+        def close(self) -> None:
+            self._called = True
+            super(requests.Session, self).close()
+
+        @property
+        def closed(self) -> bool:
+            return self._called
+
     requests.Session = Session
 else:
     from aiohttp import ClientSession as Session
@@ -17,10 +30,7 @@ async def test_unmanaged_session():
         assert gcloud_session._shared_session  # pylint: disable=protected-access
         await gcloud_session.close()
 
-        if BUILD_GCLOUD_REST:
-            session.close.assert_not_called()
-        else:
-            assert not session.closed
+        assert not session.closed
 
 
 @pytest.mark.asyncio
@@ -30,7 +40,4 @@ async def test_managed_session():
     assert not gcloud_session._shared_session  # pylint: disable=protected-access
     await gcloud_session.close()
 
-    if BUILD_GCLOUD_REST:
-        gcloud_session.close.assert_called()  # pylint: disable=no-member
-    else:
-        assert internal_session.closed
+    assert internal_session.closed

--- a/auth/tests/unit/sessions_test.py
+++ b/auth/tests/unit/sessions_test.py
@@ -3,7 +3,9 @@ from gcloud.aio.auth.build_constants import BUILD_GCLOUD_REST
 from gcloud.aio.auth.session import AioSession
 
 if BUILD_GCLOUD_REST:
-    from requests import Session
+    from unittest.mock import MagicMock as Session
+    import requests
+    requests.Session = Session
 else:
     from aiohttp import ClientSession as Session
 
@@ -15,7 +17,10 @@ async def test_unmanaged_session():
         assert gcloud_session._shared_session  # pylint: disable=protected-access
         await gcloud_session.close()
 
-        assert not session.closed
+        if BUILD_GCLOUD_REST:
+            session.close.assert_not_called()
+        else:
+            assert not session.closed
 
 
 @pytest.mark.asyncio
@@ -24,4 +29,8 @@ async def test_managed_session():
     internal_session = gcloud_session.session
     assert not gcloud_session._shared_session  # pylint: disable=protected-access
     await gcloud_session.close()
-    assert internal_session.closed
+
+    if BUILD_GCLOUD_REST:
+        gcloud_session.close.assert_called()  # pylint: disable=no-member
+    else:
+        assert internal_session.closed

--- a/auth/tests/unit/sessions_test.py
+++ b/auth/tests/unit/sessions_test.py
@@ -1,0 +1,22 @@
+import pytest
+from aiohttp import ClientSession
+from gcloud.aio.auth.session import AioSession
+
+
+@pytest.mark.asyncio
+async def test_unmanaged_session():
+    async with ClientSession() as session:
+        aio_session = AioSession(session=session)
+        assert aio_session._shared_session  # pylint: disable=protected-access
+        await aio_session.close()
+
+        assert not session.closed
+
+
+@pytest.mark.asyncio
+async def test_managed_session():
+    aio_session = AioSession()
+    internal_session = aio_session.session
+    assert not aio_session._shared_session  # pylint: disable=protected-access
+    await aio_session.close()
+    assert internal_session.closed

--- a/auth/tests/unit/sessions_test.py
+++ b/auth/tests/unit/sessions_test.py
@@ -1,6 +1,5 @@
 import pytest
 from gcloud.aio.auth.build_constants import BUILD_GCLOUD_REST
-from gcloud.aio.auth.session import AioSession
 
 if BUILD_GCLOUD_REST:
     import requests
@@ -19,8 +18,11 @@ if BUILD_GCLOUD_REST:
             return self._called
 
     requests.Session = Session
+    # Required to be here to ensure inclusion after monkeypatch
+    from gcloud.aio.auth.session import AioSession
 else:
     from aiohttp import ClientSession as Session
+    from gcloud.aio.auth.session import AioSession
 
 
 @pytest.mark.asyncio

--- a/auth/tests/unit/sessions_test.py
+++ b/auth/tests/unit/sessions_test.py
@@ -17,6 +17,8 @@ if BUILD_GCLOUD_REST:
         @property
         def closed(self) -> bool:
             return self._called
+
+    requests.Session = Session
 else:
     from aiohttp import ClientSession as Session
 


### PR DESCRIPTION
Related to https://github.com/talkiq/gcloud-aio/pull/324.

This change resolves the context manager bug detailed in the linked PR.