### PR TITLE
fix(storage): Object name for patch_metadata

### DIFF
--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -606,7 +606,8 @@ class Storage:
             session: Optional[Session] = None,
             timeout: int = 10) -> Dict[str, Any]:
         # https://cloud.google.com/storage/docs/json_api/v1/objects/patch
-        url = f'{API_ROOT}/{bucket}/o/{object_name}'
+        encoded_object_name = quote(object_name, safe='')
+        url = f'{API_ROOT}/{bucket}/o/{encoded_object_name}'
         params = params or {}
         headers = headers or {}
         headers.update(await self._headers())


### PR DESCRIPTION
Object name encoding fix: for any other methods, object name encoding is perfomed, but not for the Storage().patch_metadata() method