### PR TITLE
add timeout parameter to blob download

### DIFF
--- a/storage/gcloud/aio/storage/blob.py
+++ b/storage/gcloud/aio/storage/blob.py
@@ -75,8 +75,13 @@ class Blob:
     def chunk_size(self) -> int:
         return self.size + (262144 - (self.size % 262144))
 
-    async def download(self, timeout: int = DEFAULT_TIMEOUT, session: Optional[Session] = None) -> Any:
-        return await self.bucket.storage.download(self.bucket.name, self.name, timeout=timeout,
+    async def download(self,
+                       timeout: int = DEFAULT_TIMEOUT,
+                       session: Optional[Session] = None
+                       ) -> Any:
+        return await self.bucket.storage.download(self.bucket.name,
+                                                  self.name,
+                                                  timeout=timeout,
                                                   session=session)
 
     async def upload(self, data: Any,

--- a/storage/gcloud/aio/storage/blob.py
+++ b/storage/gcloud/aio/storage/blob.py
@@ -16,9 +16,9 @@ from gcloud.aio.auth import Token  # pylint: disable=no-name-in-module
 from pyasn1.codec.der import decoder
 from pyasn1_modules import pem
 from pyasn1_modules.rfc5208 import PrivateKeyInfo
+from gcloud.aio.storage.constants import DEFAULT_TIMEOUT
 
 # Selectively load libraries based on the package
-from .storage import DEFAULT_TIMEOUT
 
 if BUILD_GCLOUD_REST:
     from requests import Session

--- a/storage/gcloud/aio/storage/blob.py
+++ b/storage/gcloud/aio/storage/blob.py
@@ -13,10 +13,10 @@ from urllib.parse import quote
 import rsa
 from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
 from gcloud.aio.auth import Token  # pylint: disable=no-name-in-module
+from gcloud.aio.storage.constants import DEFAULT_TIMEOUT
 from pyasn1.codec.der import decoder
 from pyasn1_modules import pem
 from pyasn1_modules.rfc5208 import PrivateKeyInfo
-from gcloud.aio.storage.constants import DEFAULT_TIMEOUT
 
 # Selectively load libraries based on the package
 

--- a/storage/gcloud/aio/storage/blob.py
+++ b/storage/gcloud/aio/storage/blob.py
@@ -18,6 +18,8 @@ from pyasn1_modules import pem
 from pyasn1_modules.rfc5208 import PrivateKeyInfo
 
 # Selectively load libraries based on the package
+from .storage import DEFAULT_TIMEOUT
+
 if BUILD_GCLOUD_REST:
     from requests import Session
 else:
@@ -73,8 +75,8 @@ class Blob:
     def chunk_size(self) -> int:
         return self.size + (262144 - (self.size % 262144))
 
-    async def download(self, session: Optional[Session] = None) -> Any:
-        return await self.bucket.storage.download(self.bucket.name, self.name,
+    async def download(self, timeout: int = DEFAULT_TIMEOUT, session: Optional[Session] = None) -> Any:
+        return await self.bucket.storage.download(self.bucket.name, self.name, timeout=timeout,
                                                   session=session)
 
     async def upload(self, data: Any,

--- a/storage/gcloud/aio/storage/constants.py
+++ b/storage/gcloud/aio/storage/constants.py
@@ -1,0 +1,1 @@
+DEFAULT_TIMEOUT = 10  # by default, timeout in 10 seconds on requests

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -42,6 +42,7 @@ SCOPES = [
 ]
 
 MAX_CONTENT_LENGTH_SIMPLE_UPLOAD = 5 * 1024 * 1024  # 5 MB
+DEFAULT_TIMEOUT = 10  # by default, timeout in 10 seconds on requests
 
 STORAGE_EMULATOR_HOST = os.environ.get('STORAGE_EMULATOR_HOST')
 if STORAGE_EMULATOR_HOST:
@@ -151,7 +152,7 @@ class Storage:
                    destination_bucket: str, *, new_name: Optional[str] = None,
                    metadata: Optional[Dict[str, Any]] = None,
                    params: Optional[Dict[str, str]] = None,
-                   headers: Optional[Dict[str, str]] = None, timeout: int = 10,
+                   headers: Optional[Dict[str, str]] = None, timeout: int = DEFAULT_TIMEOUT,
                    session: Optional[Session] = None) -> Dict[str, Any]:
 
         """
@@ -213,7 +214,7 @@ class Storage:
 
         return data
 
-    async def delete(self, bucket: str, object_name: str, *, timeout: int = 10,
+    async def delete(self, bucket: str, object_name: str, *, timeout: int = DEFAULT_TIMEOUT,
                      params: Optional[Dict[str, str]] = None,
                      headers: Optional[Dict[str, str]] = None,
                      session: Optional[Session] = None) -> str:
@@ -236,7 +237,7 @@ class Storage:
 
     async def download(self, bucket: str, object_name: str, *,
                        headers: Optional[Dict[str, Any]] = None,
-                       timeout: int = 10,
+                       timeout: int = DEFAULT_TIMEOUT,
                        session: Optional[Session] = None) -> bytes:
         return await self._download(bucket, object_name, headers=headers,
                                     timeout=timeout, params={'alt': 'media'},
@@ -255,7 +256,7 @@ class Storage:
     async def download_metadata(self, bucket: str, object_name: str, *,
                                 headers: Optional[Dict[str, Any]] = None,
                                 session: Optional[Session] = None,
-                                timeout: int = 10) -> Dict[str, Any]:
+                                timeout: int = DEFAULT_TIMEOUT) -> Dict[str, Any]:
         data = await self._download(bucket, object_name, headers=headers,
                                     timeout=timeout, session=session)
         metadata: Dict[str, Any] = json.loads(data.decode())
@@ -263,7 +264,7 @@ class Storage:
 
     async def download_stream(self, bucket: str, object_name: str, *,
                               headers: Optional[Dict[str, Any]] = None,
-                              timeout: int = 10,
+                              timeout: int = DEFAULT_TIMEOUT,
                               session: Optional[Session] = None
                               ) -> StreamResponse:
         """Download a GCS object in a buffered stream.
@@ -292,7 +293,7 @@ class Storage:
                            params: Optional[Dict[str, str]] = None,
                            headers: Optional[Dict[str, Any]] = None,
                            session: Optional[Session] = None,
-                           timeout: int = 10) -> Dict[str, Any]:
+                           timeout: int = DEFAULT_TIMEOUT) -> Dict[str, Any]:
         url = f'{API_ROOT}/{bucket}/o'
         headers = headers or {}
         headers.update(await self._headers())
@@ -430,7 +431,7 @@ class Storage:
     async def _download(self, bucket: str, object_name: str, *,
                         params: Optional[Dict[str, str]] = None,
                         headers: Optional[Dict[str, str]] = None,
-                        timeout: int = 10,
+                        timeout: int = DEFAULT_TIMEOUT,
                         session: Optional[Session] = None) -> bytes:
         # https://cloud.google.com/storage/docs/request-endpoints#encoding
         encoded_object_name = quote(object_name, safe='')
@@ -455,7 +456,7 @@ class Storage:
     async def _download_stream(self, bucket: str, object_name: str, *,
                                params: Optional[Dict[str, str]] = None,
                                headers: Optional[Dict[str, str]] = None,
-                               timeout: int = 10,
+                               timeout: int = DEFAULT_TIMEOUT,
                                session: Optional[Session] = None
                                ) -> StreamResponse:
         # https://cloud.google.com/storage/docs/request-endpoints#encoding
@@ -574,7 +575,7 @@ class Storage:
 
         s = AioSession(session) if session else self.session
         resp = await s.post(url, headers=post_headers, params=params,
-                            data=metadata_, timeout=10)
+                            data=metadata_, timeout=DEFAULT_TIMEOUT)
         session_uri: str = resp.headers['Location']
         return session_uri
 
@@ -604,7 +605,7 @@ class Storage:
             *, params: Optional[Dict[str, str]] = None,
             headers: Optional[Dict[str, str]] = None,
             session: Optional[Session] = None,
-            timeout: int = 10) -> Dict[str, Any]:
+            timeout: int = DEFAULT_TIMEOUT) -> Dict[str, Any]:
         # https://cloud.google.com/storage/docs/json_api/v1/objects/patch
         url = f'{API_ROOT}/{bucket}/o/{object_name}'
         params = params or {}
@@ -622,7 +623,7 @@ class Storage:
                                   params: Optional[Dict[str, str]] = None,
                                   headers: Optional[Dict[str, str]] = None,
                                   session: Optional[Session] = None,
-                                  timeout: int = 10) -> Dict[str, Any]:
+                                  timeout: int = DEFAULT_TIMEOUT) -> Dict[str, Any]:
         url = f'{API_ROOT}/{bucket}'
         headers = headers or {}
         headers.update(await self._headers())

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -153,7 +153,8 @@ class Storage:
                    destination_bucket: str, *, new_name: Optional[str] = None,
                    metadata: Optional[Dict[str, Any]] = None,
                    params: Optional[Dict[str, str]] = None,
-                   headers: Optional[Dict[str, str]] = None, timeout: int = DEFAULT_TIMEOUT,
+                   headers: Optional[Dict[str, str]] = None,
+                   timeout: int = DEFAULT_TIMEOUT,
                    session: Optional[Session] = None) -> Dict[str, Any]:
 
         """
@@ -215,7 +216,8 @@ class Storage:
 
         return data
 
-    async def delete(self, bucket: str, object_name: str, *, timeout: int = DEFAULT_TIMEOUT,
+    async def delete(self, bucket: str, object_name: str, *,
+                     timeout: int = DEFAULT_TIMEOUT,
                      params: Optional[Dict[str, str]] = None,
                      headers: Optional[Dict[str, str]] = None,
                      session: Optional[Session] = None) -> str:
@@ -257,7 +259,8 @@ class Storage:
     async def download_metadata(self, bucket: str, object_name: str, *,
                                 headers: Optional[Dict[str, Any]] = None,
                                 session: Optional[Session] = None,
-                                timeout: int = DEFAULT_TIMEOUT) -> Dict[str, Any]:
+                                timeout: int = DEFAULT_TIMEOUT
+                                ) -> Dict[str, Any]:
         data = await self._download(bucket, object_name, headers=headers,
                                     timeout=timeout, session=session)
         metadata: Dict[str, Any] = json.loads(data.decode())
@@ -624,7 +627,8 @@ class Storage:
                                   params: Optional[Dict[str, str]] = None,
                                   headers: Optional[Dict[str, str]] = None,
                                   session: Optional[Session] = None,
-                                  timeout: int = DEFAULT_TIMEOUT) -> Dict[str, Any]:
+                                  timeout: int = DEFAULT_TIMEOUT
+                                  ) -> Dict[str, Any]:
         url = f'{API_ROOT}/{bucket}'
         headers = headers or {}
         headers.update(await self._headers())

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -21,8 +21,10 @@ from gcloud.aio.auth import AioSession  # pylint: disable=no-name-in-module
 from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
 from gcloud.aio.auth import Token  # pylint: disable=no-name-in-module
 from gcloud.aio.storage.bucket import Bucket
+from gcloud.aio.storage.constants import DEFAULT_TIMEOUT
 
 # Selectively load libraries based on the package
+
 if BUILD_GCLOUD_REST:
     from time import sleep
     from requests import HTTPError as ResponseError
@@ -42,7 +44,6 @@ SCOPES = [
 ]
 
 MAX_CONTENT_LENGTH_SIMPLE_UPLOAD = 5 * 1024 * 1024  # 5 MB
-DEFAULT_TIMEOUT = 10  # by default, timeout in 10 seconds on requests
 
 STORAGE_EMULATOR_HOST = os.environ.get('STORAGE_EMULATOR_HOST')
 if STORAGE_EMULATOR_HOST:


### PR DESCRIPTION
Ended up almost breaking prod when switching to this due to the low default timeout, which is hidden when using Blob.download. Here is a PR to add this parameter.

Not sure what the 'no name storage' in your test suite is about.