### PR TITLE
chore(github): update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,6 @@
-*                   @TheKevJames
+*                   @talkiq/engineering-any @TheKevJames
+
+pyproject.toml      @TheKevJames
+poetry.lock         @TheKevJames
+
+/pubsub             @TheKevJames @shaundialpad


### PR DESCRIPTION
## Summary
As decided in our previous retro, update our CODEOWNERS file to include more explicit ownership on PRs. I've started by tossing in my own stuff (handling renovate PRs), but it would be great to get everyone to add themselves as appropriate to get us "caught up". Note I've also updated the PR template in `docs` to remind us to keep this up-to-date: if folks approve that change, I'll mirror it to this PR.

## Checklist
* [x] @TheKevJames
* [x] @allandialpad
* [ ] @caseydialpad
* [ ] @eddiedialpad
* [ ] @egalpin
* [x] @jonathan-johnston
* [x] @kylepad
* [x] @shaundialpad