### PR TITLE
fix(pubsub): gracefully handle worker cancellations

### DIFF
--- a/pubsub/gcloud/aio/pubsub/subscriber.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber.py
@@ -221,6 +221,11 @@ else:
             metrics_client.increment('pubsub.consumer.succeeded')
             metrics_client.histogram('pubsub.consumer.latency.runtime',
                                      time.perf_counter() - start)
+        except asyncio.CancelledError:
+            if nack_queue:
+                await nack_queue.put(message.ack_id)
+            log.warning('Application callback was cancelled')
+            metrics_client.increment('pubsub.consumer.cancelled')
         except Exception:
             if nack_queue:
                 await nack_queue.put(message.ack_id)


### PR DESCRIPTION
Graceful worker cancellations during subscriber shutdown should not be cause for alarm or logged at the error level. Additionally, it can be useful to track these separately, as cancellations and true worker errors are different issues.