### PR TITLE
chore(release): bump pubsub minor version

### DIFF
--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as f:
 
 setuptools.setup(
     name='gcloud-aio-pubsub',
-    version='4.4.1',
+    version='4.5.0',
     description='Python Client for Google Cloud Pub/Sub',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
It's been a long time since the last release but there have been more changes than was expected in the previous patch version bump. Fortunately no release was made on the patch version but one will be made on this minor version. The changes include:

* gracefully handle worker cancellations: https://github.com/talkiq/gcloud-aio/pull/401
* fixup some invalid tests: https://github.com/talkiq/gcloud-aio/pull/387
* no ack deadline cache refresh by default: https://github.com/talkiq/gcloud-aio/pull/370
* expose type hints: https://github.com/talkiq/gcloud-aio/pull/368
* add custom retry policy example: https://github.com/talkiq/gcloud-aio/commit/860c8e05de0c69e5f254357e267e785ab221f5e6#diff-92d64c121276956e129d509ac699180f8c32c6e03f6c49e75e8cc35f6be6096f
* fixup type hint in `PubsubMessage`: https://github.com/talkiq/gcloud-aio/commit/15ed76f63aa4d4e2e91286588aa1f34c5d2741b4#diff-92d64c121276956e129d509ac699180f8c32c6e03f6c49e75e8cc35f6be6096f