### PR TITLE
chore(ci): bump tester orb to 4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   linter: talkiq/linter@1
-  tester: talkiq/tester@3.0
+  tester: talkiq/tester@4.0
 
 jobs:
   nox:


### PR DESCRIPTION
A new version of the `talkiq/tester` orb has been released, which does not change `pipcheck` behaviour (the only job used by CI from this orb).

https://github.com/talkiq/circleci-orbs/pull/76