### PR TITLE
auth: allow to pass credentials as text

### DIFF
--- a/auth/gcloud/aio/auth/token.py
+++ b/auth/gcloud/aio/auth/token.py
@@ -56,7 +56,7 @@ class Type(enum.Enum):
     SERVICE_ACCOUNT = 'service_account'
 
 
-def get_service_data(service: ServiceFile) -> Dict[str, Any]:
+def get_service_data(service: ServiceFile) -> Dict[str, str]:
     # if a stream passed explicitly, read it
     if hasattr(service, 'read'):
         return json.loads(service.read())  # type: ignore

--- a/auth/tests/unit/token_test.py
+++ b/auth/tests/unit/token_test.py
@@ -1,5 +1,7 @@
 import io
+import os
 import json
+from pathlib import Path
 
 import gcloud.aio.auth.token as token
 import pytest
@@ -32,3 +34,73 @@ async def test_service_as_io():
     assert t.token_type == token.Type.SERVICE_ACCOUNT
     assert t.token_uri == 'https://oauth2.googleapis.com/token'
     assert await t.get_project() == 'random-project-123'
+
+
+@pytest.fixture
+def chdir(tmp_path):
+    old_dir = os.curdir
+    os.chdir(str(tmp_path))
+    try:
+        yield
+    finally:
+        os.chdir(old_dir)
+
+
+@pytest.fixture
+def clean_environ():
+    old_environ = os.environ.copy()
+    os.environ.clear()
+    try:
+        yield
+    finally:
+        os.environ.update(old_environ)
+
+
+@pytest.mark.parametrize('given, expected', [
+    ('{"name": "aragorn"}', {'name': 'aragorn'}),
+    (io.StringIO('{"name": "aragorn"}'), {'name': 'aragorn'}),
+    ('key.json', {'hello': 'world'}),
+    (Path('key.json'), {'hello': 'world'}),
+])
+def test_get_service_data__explicit(tmp_path: Path, chdir, given, expected):
+    (tmp_path / 'key.json').write_text('{"hello": "world"}')
+    assert token.get_service_data(given) == expected
+
+
+@pytest.mark.parametrize('given, expected', [
+    ('something', json.JSONDecodeError),
+    (io.StringIO('something'), json.JSONDecodeError),
+    (Path('something'), FileNotFoundError),
+])
+def test_get_service_data__explicit__raise(given, expected):
+    with pytest.raises(expected):
+        token.get_service_data(given)
+
+
+@pytest.mark.parametrize('given, expected', [
+    ({'GOOGLE_APPLICATION_CREDENTIALS': 'key.json'}, {'hello': 'world'}),
+    ({'GOOGLE_APPLICATION_CREDENTIALS': '{"name": "aragorn"}'}, {'name': 'aragorn'}),
+    ({'CLOUDSDK_CONFIG': '.'}, {'hi': 'mark'}),
+    ({'CLOUDSDK_CONFIG': '{"name": "aragorn"}'}, {'name': 'aragorn'}),
+])
+def test_get_service_data__explicit_env_var(
+    tmp_path: Path, chdir, clean_environ, given, expected,
+):
+    (tmp_path / 'key.json').write_text('{"hello": "world"}')
+    (tmp_path / 'application_default_credentials.json').write_text('{"hi": "mark"}')
+    os.environ.update(given)
+    assert token.get_service_data(None) == expected
+
+
+def test_get_service_data__explicit_env_var__raises(clean_environ):
+    os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = 'garbage'
+    with pytest.raises(json.JSONDecodeError):
+        token.get_service_data(None)
+
+
+SDK_CONFIG = Path.home() / '.config' / 'gcloud' / 'application_default_credentials.json'
+
+
+@pytest.mark.skipif(not SDK_CONFIG.exists(), reason='no default credentials installed')
+def test_get_service_data__implicit_sdk_config(clean_environ):
+    assert 'client_id' in token.get_service_data(None)


### PR DESCRIPTION
1. Allow passing credentials as a `pathlib.Path` object.
2. Allow passing credentials as text content instead of a path to a file.
3. Propagate exceptions for an invalid JSON if it is explicitly passed, not only for IO errors. And all types of exceptions, really, because why not.
4. Allow `CLOUDSDK_CONFIG` to be a path to the directory, not only to the file.
5. Cover it all with tests.
