### PR TITLE
Make StreamResponse a context manager

### DIFF
--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -111,6 +111,7 @@ class StreamResponse:
     """This class provides an abstraction between the slightly different
     recommended streaming implementations between requests and aiohttp.
     """
+
     def __init__(self, response: Any) -> None:
         self._response = response
         self._iter: Optional[Iterator[bytes]] = None
@@ -124,6 +125,12 @@ class StreamResponse:
         else:
             chunk = await self._response.content.read(size)
         return chunk
+
+    async def __aenter__(self):
+        return await self._response.__aenter__()
+
+    async def __aexit__(self, *exc_info):
+        return await self._response.__aexit__(*exc_info)
 
 
 class Storage:


### PR DESCRIPTION
If `aiohttp.ClientResponse` is read without releasing it, the connection is never released until the whole session is closed. This can be mitigated by reading the response inside a context manager.

```
#bad
resp = await session.get(url)
return await resp.content.read()

# good
async with session.get(url) as resp:
  return await resp.content.read()
```

The PR allows using `StreamResponse` as a context manager.