### PR TITLE
fix(bigquery): avoid nesting base session objects

### DIFF
--- a/auth/gcloud/aio/auth/session.py
+++ b/auth/gcloud/aio/auth/session.py
@@ -33,8 +33,8 @@ class BaseSession:
         self._timeout = timeout
 
     @abstractproperty
-    def session(self) -> Session:
-        pass
+    def session(self) -> Optional[Session]:
+        return self._session
 
     @abstractmethod
     async def post(self, url: str, headers: Dict[str, str],
@@ -114,7 +114,6 @@ if not BUILD_GCLOUD_REST:
                 timeout = aiohttp.ClientTimeout(self._timeout)
                 self._session = aiohttp.ClientSession(connector=connector,
                                                       timeout=timeout)
-            assert self._session is not None
             return self._session
 
         async def post(self, url: str, headers: Dict[str, str],
@@ -196,7 +195,6 @@ if BUILD_GCLOUD_REST:
             if not self._session:
                 self._session = Session()
                 self._session.verify = self._ssl
-            assert self._session is not None
             return self._session
 
         # N.B.: none of these will be `async` in compiled form, but adding the


### PR DESCRIPTION
@leanaha and I were digging into some issues in porting an app to `asyncio` and noticed an error stemming from `aiohttp.ClientTimeout` having an underlying timeout value of type `aiohttp.ClientTimeout` when using `gcloud-aio-bigquery`. This threw an exception within `aiohttp` code when it attempted to compare the timeout with an integer unsuccessfully (https://github.com/aio-libs/aiohttp/blob/v3.8.1/aiohttp/helpers.py#L648). Initially I thought this issue might exist somewhere in the `aiohttp` code itself, but after some static analysis of the source this didn't appear to be the case. To get more info I traced through the app and noticed that when using the BQ `Table` class to generate a `Job` without specifying a `session`, the resulting `Job` had a double-nested `AioSession` object such that you could only get to the `Session` object like `job.session.session.session`. Looking at the `gcloud-aio-bigquery` code I realized that the `Table` class was indeed passing a `AioSession` object to `Job` instead of the expected `Session`, causing the `Job` to wrap it like `AioSession(AioSession(Session()))`.

In fact, we already do this double-referencing in other modules here (non-exhaustive list) but we just missed them in our BQ module:
https://github.com/talkiq/gcloud-aio/blob/master/pubsub/gcloud/aio/pubsub/subscriber_client.py#L44
https://github.com/talkiq/gcloud-aio/blob/master/kms/gcloud/aio/kms/kms.py#L45
https://github.com/talkiq/gcloud-aio/blob/master/storage/gcloud/aio/storage/storage.py#L136

This changeset fixes this issue.
