### PR TITLE
Allow timeout in get_blob in storage

### DIFF
--- a/storage/gcloud/aio/storage/bucket.py
+++ b/storage/gcloud/aio/storage/bucket.py
@@ -32,7 +32,8 @@ class Bucket:
 
     async def get_blob(self, blob_name: str, timeout: int = DEFAULT_TIMEOUT,
                        session: Optional[Session] = None) -> Blob:
-        metadata = await self.storage.download_metadata(self.name, blob_name, timeout=timeout,
+        metadata = await self.storage.download_metadata(self.name, blob_name,
+                                                        timeout=timeout,
                                                         session=session)
 
         return Blob(self, blob_name, metadata)

--- a/storage/gcloud/aio/storage/bucket.py
+++ b/storage/gcloud/aio/storage/bucket.py
@@ -30,7 +30,7 @@ class Bucket:
         self.storage = storage
         self.name = name
 
-    async def get_blob(self, blob_name: str, timeout: int = DEFAULT_TIMEOUT
+    async def get_blob(self, blob_name: str, timeout: int = DEFAULT_TIMEOUT,
                        session: Optional[Session] = None) -> Blob:
         metadata = await self.storage.download_metadata(self.name, blob_name, timeout=timeout,
                                                         session=session)

--- a/storage/gcloud/aio/storage/bucket.py
+++ b/storage/gcloud/aio/storage/bucket.py
@@ -6,6 +6,7 @@ from typing import Optional
 from typing import TYPE_CHECKING
 
 from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
+from gcloud.aio.storage.constants import DEFAULT_TIMEOUT
 
 from .blob import Blob
 
@@ -29,9 +30,9 @@ class Bucket:
         self.storage = storage
         self.name = name
 
-    async def get_blob(self, blob_name: str,
+    async def get_blob(self, blob_name: str, timeout: int = DEFAULT_TIMEOUT
                        session: Optional[Session] = None) -> Blob:
-        metadata = await self.storage.download_metadata(self.name, blob_name,
+        metadata = await self.storage.download_metadata(self.name, blob_name, timeout=timeout,
                                                         session=session)
 
         return Blob(self, blob_name, metadata)


### PR DESCRIPTION
Just a minor feature that lets the user provide timeout to `get_blob`. 