### PR TITLE
fix(auth): coerce timeout to clienttimeout for clientsession

### DIFF
--- a/auth/gcloud/aio/auth/session.py
+++ b/auth/gcloud/aio/auth/session.py
@@ -111,13 +111,20 @@ if not BUILD_GCLOUD_REST:
 
     class AioSession(BaseSession):
         _session: aiohttp.ClientSession
+        _timeout: Timeout
 
         @property
         def session(self) -> aiohttp.ClientSession:
             if not self._session:
                 connector = aiohttp.TCPConnector(ssl=self._ssl)
+
+                if isinstance(self._timeout, aiohttp.ClientTimeout):
+                    timeout = self._timeout
+                else:
+                    timeout = aiohttp.ClientTimeout(total=self._timeout)
+
                 self._session = aiohttp.ClientSession(connector=connector,
-                                                      timeout=self._timeout)
+                                                      timeout=timeout)
             return self._session
 
         async def post(self, url: str, headers: Dict[str, str],


### PR DESCRIPTION
When sending requests, `aiohttp` intelligently converts timeout values from floats and ints into `ClientTimeout` but also accepts `ClientTimeout` (https://github.com/aio-libs/aiohttp/blob/v3.8.1/aiohttp/client.py#L440). Unfortunately, the `ClientSession` constructor is not so helpful and only accepts `ClientTimeout` values (https://github.com/aio-libs/aiohttp/blob/v3.8.1/aiohttp/client.py#L277).

Therefore when constructing the `ClientSession` object we must convert the `self._timeout` member variable to a `ClientTimeout` object before passing it in.