### PR TITLE
feat(datastore): add support for cursors on GQL queries

### DIFF
--- a/datastore/gcloud/aio/datastore/__init__.py
+++ b/datastore/gcloud/aio/datastore/__init__.py
@@ -23,6 +23,7 @@ from gcloud.aio.datastore.lat_lng import LatLng
 from gcloud.aio.datastore.mutation import MutationResult
 from gcloud.aio.datastore.projection import Projection
 from gcloud.aio.datastore.property_order import PropertyOrder
+from gcloud.aio.datastore.query import GQLCursor
 from gcloud.aio.datastore.query import GQLQuery
 from gcloud.aio.datastore.query import Query
 from gcloud.aio.datastore.query import QueryResultBatch
@@ -31,8 +32,8 @@ from gcloud.aio.datastore.value import Value
 
 __all__ = ['__version__', 'CompositeFilter', 'CompositeFilterOperator',
            'Consistency', 'Datastore', 'DatastoreOperation', 'Direction',
-           'Entity', 'EntityResult', 'Filter', 'GQLQuery', 'Key', 'LatLng',
-           'Mode', 'MoreResultsType', 'MutationResult', 'Operation',
-           'PathElement', 'Projection', 'PropertyFilter',
+           'Entity', 'EntityResult', 'Filter', 'GQLCursor', 'GQLQuery',
+           'Key', 'LatLng', 'Mode', 'MoreResultsType', 'MutationResult',
+           'Operation', 'PathElement', 'Projection', 'PropertyFilter',
            'PropertyFilterOperator', 'PropertyOrder', 'Query',
            'QueryResultBatch', 'ResultType', 'SCOPES', 'Value']

--- a/datastore/tests/unit/gql_query_test.py
+++ b/datastore/tests/unit/gql_query_test.py
@@ -1,0 +1,87 @@
+from typing import Any
+from typing import Dict
+from typing import List
+
+import pytest
+from gcloud.aio.datastore import GQLQuery
+from gcloud.aio.datastore.query import GQLCursor
+
+
+class TestGQLQuery:
+    @staticmethod
+    def test_from_repr(query):
+        data = {
+            'allowLiterals': query.allow_literals,
+            'queryString': query.query_string,
+            'namedBindings': {
+                'string_param': {
+                    'value': {
+                        'stringValue': 'foo'
+                    }
+                },
+                'cursor_param': {
+                    'cursor': 'startCursor'
+                }
+            },
+            'positionalBindings': [
+                {'value': {'integerValue': '123'}},
+                {'cursor': 'endCursor'}],
+        }
+
+        output_query = GQLQuery.from_repr(data)
+        assert output_query == query
+
+    @staticmethod
+    def test_to_repr(query):
+        data = {
+            'allowLiterals': query.allow_literals,
+            'queryString': query.query_string,
+            'namedBindings': {
+                'string_param': {
+                    'value': {
+                        'excludeFromIndexes': False,
+                        'stringValue': 'foo'
+                    }
+                },
+                'cursor_param': {
+                    'cursor': 'startCursor'
+                }
+            },
+            'positionalBindings': [
+                {'value': {'excludeFromIndexes': False, 'integerValue': 123}},
+                {'cursor': 'endCursor'}],
+        }
+
+        output_data = query.to_repr()
+
+        assert output_data == data
+
+    @staticmethod
+    def test_to_repr_and_back(query):
+        data = query.to_repr()
+
+        assert GQLQuery.from_repr(data) == query
+
+    @staticmethod
+    def test_repr_returns_to_repr_as_string(query):
+        assert repr(query) == str(query.to_repr())
+
+    @staticmethod
+    @pytest.fixture(scope='session')
+    def query(named_bindings, positional_bindings) -> GQLQuery:
+        return GQLQuery('query_string',
+                        named_bindings=named_bindings,
+                        positional_bindings=positional_bindings)
+
+    @staticmethod
+    @pytest.fixture(scope='session')
+    def named_bindings() -> Dict[str, Any]:
+        return {
+            'string_param': 'foo',
+            'cursor_param': GQLCursor('startCursor')
+        }
+
+    @staticmethod
+    @pytest.fixture(scope='session')
+    def positional_bindings() -> List[Any]:
+        return [123, GQLCursor('endCursor')]


### PR DESCRIPTION
According to the [GQL Reference](https://cloud.google.com/datastore/docs/reference/gql_reference#clauses), cursors are available on the `LIMIT` and `OFFSET` clauses of GQL queries.

This PR gives support for using cursors as binding parameters of GQL queries. A parameter on a GQL query can either be a value of different types (already implemented) or a cursor (implemented on this PR). Check the syntax [here](https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects/runQuery#gqlqueryparameter).

