### PR TITLE
fix: Subscriber shutdown exception handling fix

### DIFF
--- a/pubsub/gcloud/aio/pubsub/subscriber.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber.py
@@ -403,7 +403,7 @@ else:
             for task in done:
                 task.result()
             raise Exception('A subscriber worker shut down unexpectedly!')
-        except Exception as e:
+        except (asyncio.CancelledError, Exception) as e:
             log.info('Subscriber exited', exc_info=e)
             for task in producer_tasks:
                 task.cancel()


### PR DESCRIPTION
In python3.8 CancelledError was changed to be a subclass of BaseException

This makes sure to catch CancelledError so that it will trigger the shutdown behavior on the subscriber