### PR TITLE
Pass entity_result_type to EntityResult.from_repr and Entity.from_repr

### DIFF
--- a/datastore/gcloud/aio/datastore/entity.py
+++ b/datastore/gcloud/aio/datastore/entity.py
@@ -2,6 +2,7 @@ from typing import Any
 from typing import Dict
 from typing import Optional
 
+from gcloud.aio.datastore import ResultType
 from gcloud.aio.datastore.key import Key
 from gcloud.aio.datastore.value import Value
 
@@ -28,9 +29,13 @@ class Entity:
         return str(self.to_repr())
 
     @classmethod
-    def from_repr(cls, data: Dict[str, Any]) -> 'Entity':
+    def from_repr(cls,
+                  data: Dict[str, Any],
+                  entity_result_type: Optional[ResultType] = None
+                  ) -> 'Entity':
         # https://cloud.google.com/datastore/docs/reference/data/rest/v1/Entity
         # "for example, an entity in Value.entity_value may have no key"
+        del entity_result_type
         if 'key' in data:
             key: Optional[Key] = cls.key_kind.from_repr(data['key'])
         else:
@@ -66,10 +71,18 @@ class EntityResult:
         return str(self.to_repr())
 
     @classmethod
-    def from_repr(cls, data: Dict[str, Any]) -> 'EntityResult':
-        return cls(cls.entity_kind.from_repr(data['entity']),
-                   data.get('version', ''),
-                   data.get('cursor', ''))
+    def from_repr(cls, data: Dict[str, Any],
+                  entity_result_type: Optional[ResultType] = None
+                  ) -> 'EntityResult':
+
+        return cls(
+            cls.entity_kind.from_repr(
+                data['entity'],
+                entity_result_type=entity_result_type
+            ),
+            data.get('version', ''),
+            data.get('cursor', '')
+        )
 
     def to_repr(self) -> Dict[str, Any]:
         data: Dict[str, Any] = {

--- a/datastore/gcloud/aio/datastore/query.py
+++ b/datastore/gcloud/aio/datastore/query.py
@@ -207,8 +207,13 @@ class QueryResultBatch:
     def from_repr(cls, data: Dict[str, Any]) -> 'QueryResultBatch':
         end_cursor = data['endCursor']
         entity_result_type = ResultType(data['entityResultType'])
-        entity_results = [cls.entity_result_kind.from_repr(er)
-                          for er in data.get('entityResults', [])]
+        entity_results = [
+            cls.entity_result_kind.from_repr(
+                er,
+                entity_result_type=entity_result_type
+            )
+            for er in data.get('entityResults', [])
+        ]
         more_results = MoreResultsType(data['moreResults'])
         skipped_cursor = data.get('skippedCursor', '')
         skipped_results = data.get('skippedResults', 0)


### PR DESCRIPTION
This change modifies `EntityResult.from_repr` and `Entity.from_repr` to receive `entity_result_type` as a parameter. We are currently using it to add some extra validations. For example: if the `entity_result_type` is `FULL` we validate that all required props of our model are set. However, if it is a `PROJECTION` we can ignore missing values. 

This might be a more common use case, so it might be a good idea to upstream it to this library. 