### PR TITLE
feat(bigquery): convert responses to dicts

### DIFF
--- a/bigquery/gcloud/aio/bigquery/__init__.py
+++ b/bigquery/gcloud/aio/bigquery/__init__.py
@@ -8,7 +8,17 @@ from gcloud.aio.bigquery.bigquery import SourceFormat
 from gcloud.aio.bigquery.dataset import Dataset
 from gcloud.aio.bigquery.job import Job
 from gcloud.aio.bigquery.table import Table
+from gcloud.aio.bigquery.utils import from_query_response
 
 
-__all__ = ['__version__', 'Dataset', 'Disposition', 'Job', 'SCOPES',
-           'SchemaUpdateOption', 'SourceFormat', 'Table']
+__all__ = [
+    '__version__',
+    'Dataset',
+    'Disposition',
+    'Job',
+    'SCOPES',
+    'SchemaUpdateOption',
+    'SourceFormat',
+    'Table',
+    'from_query_response',
+]

--- a/bigquery/gcloud/aio/bigquery/__init__.py
+++ b/bigquery/gcloud/aio/bigquery/__init__.py
@@ -8,7 +8,7 @@ from gcloud.aio.bigquery.bigquery import SourceFormat
 from gcloud.aio.bigquery.dataset import Dataset
 from gcloud.aio.bigquery.job import Job
 from gcloud.aio.bigquery.table import Table
-from gcloud.aio.bigquery.utils import from_query_response
+from gcloud.aio.bigquery.utils import query_response_to_dict
 
 
 __all__ = [
@@ -20,5 +20,5 @@ __all__ = [
     'SchemaUpdateOption',
     'SourceFormat',
     'Table',
-    'from_query_response',
+    'query_response_to_dict',
 ]

--- a/bigquery/gcloud/aio/bigquery/utils.py
+++ b/bigquery/gcloud/aio/bigquery/utils.py
@@ -1,0 +1,83 @@
+import datetime
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+
+
+def flatten(x: Any) -> Any:
+    """
+    Flatten response objects into something we can actually work with.
+
+    The API returns data of the form:
+
+        {'f': [{'v': ...}]}
+
+    to indicate groupings of fields and their potential for having multiple
+    values. We want those to just be plain old objects.
+    """
+    if isinstance(x, dict):
+        # TODO: what if a user has stored a dictionary in their table and that
+        # dictionary is shaped the same way as Google's response format?
+        if 'f' in x:
+            print(x)
+            nested = [flatten(y['v']) for y in x['f']]
+            if len(nested) == 1:
+                # Nested data is always in a list form, even if it's a single
+                # value that cannot be REPEATED. Why? Who knows.
+                return nested[0]
+            return nested
+
+        if 'v' in x:
+            return flatten(x['v'])
+
+    if isinstance(x, list):
+        return [flatten(y) for y in x]
+
+    return x
+
+
+def parse(field: Dict[str, str], value: Any) -> Any:
+    """
+    Parse a given field back to a Python object.
+
+    This is often trivial: convert the value from a string to the type
+    specified in the field's schema. There's a couple caveats we've identified
+    so far, though:
+
+    * NULLABLE fields should be handled specially, eg. so as not to
+      accidentally convert them to the schema type.
+    * REPEATED fields are nested a biot differently than expected, so we need
+      to flatten *first*, then convert.
+    """
+    f: Callable[[Any], Any] = {  # type: ignore[assignment]
+        'BOOLEAN': lambda x: x == 'true',
+        'FLOAT': float,
+        'INTEGER': int,
+        'RECORD': list,
+        'STRING': str,
+        'TIMESTAMP': lambda x: datetime.datetime.fromtimestamp(float(x)),
+    }[field['type']]
+
+    if field['mode'] == 'NULLABLE' and value is None:
+        return value
+    if field['mode'] == 'REPEATED':
+        return [f(x) for x in flatten(value)]
+    return f(flatten(value))
+
+
+def from_query_response(response: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """
+    Convert a query response to a dictionary.
+
+    API responses for job queries are packed into a difficult-to-use format.
+    This method deserializes a response into a List of rows, with each row
+    being a dictionary of field names to the row's value.
+
+    This method also handles converting the values according to the schema
+    defined in the response (eg. into builtin python types).
+    """
+    fields = response['schema'].get('fields', [])
+    rows = [x['f'] for x in response.get('rows', [])]
+    return [{k['name']: parse(k, v) for k, v in zip(fields, row)}
+            for row in rows]

--- a/bigquery/gcloud/aio/bigquery/utils.py
+++ b/bigquery/gcloud/aio/bigquery/utils.py
@@ -102,7 +102,7 @@ def parse(field: Dict[str, Any], value: Any) -> Any:
     return f(flatten(value))
 
 
-def from_query_response(response: Dict[str, Any]) -> List[Dict[str, Any]]:
+def query_response_to_dict(response: Dict[str, Any]) -> List[Dict[str, Any]]:
     """
     Convert a query response to a dictionary.
 

--- a/bigquery/tests/unit/utils_test.py
+++ b/bigquery/tests/unit/utils_test.py
@@ -20,6 +20,9 @@ def test_flatten(data, expected):
 
 
 @pytest.mark.parametrize('field,value,expected', [
+    ({'type': 'BIGNUMERIC', 'mode': 'NULLABLE'}, '0.0', 0.0),
+    ({'type': 'BIGNUMERIC', 'mode': 'NULLABLE'}, '1.25', 1.25),
+
     ({'type': 'BOOLEAN', 'mode': 'NULLABLE'}, 'false', False),
     ({'type': 'BOOLEAN', 'mode': 'NULLABLE'}, 'true', True),
 
@@ -28,6 +31,9 @@ def test_flatten(data, expected):
 
     ({'type': 'INTEGER', 'mode': 'NULLABLE'}, '0', 0),
     ({'type': 'INTEGER', 'mode': 'NULLABLE'}, '1', 1),
+
+    ({'type': 'NUMERIC', 'mode': 'NULLABLE'}, '0.0', 0.0),
+    ({'type': 'NUMERIC', 'mode': 'NULLABLE'}, '1.25', 1.25),
 
     ({'type': 'RECORD', 'mode': 'NULLABLE', 'fields': [
         {'type': 'INTEGER', 'mode': 'REQUIRED'},

--- a/bigquery/tests/unit/utils_test.py
+++ b/bigquery/tests/unit/utils_test.py
@@ -1,0 +1,118 @@
+import datetime
+
+import pytest
+from gcloud.aio.bigquery.utils import flatten
+from gcloud.aio.bigquery.utils import from_query_response
+from gcloud.aio.bigquery.utils import parse
+
+
+@pytest.mark.parametrize('data,expected', [
+    ({'v': None}, None),
+    ({'v': 'foo'}, 'foo'),
+    ({'v': [{'v': 0}, {'v': 1}]}, [0, 1]),
+    ({'v': {'f': [{'v': 'foo'}]}}, 'foo'),
+    ({'v': {'f': [{'v': 'foo'}, {'v': 'bar'}]}}, ['foo', 'bar']),
+    ({'v': {'f': [{'v': {'f': [{'v': 0}, {'v': 1}]}},
+                  {'v': {'f': [{'v': 2}, {'v': 3}]}}]}}, [[0, 1], [2, 3]]),
+])
+def test_flatten(data, expected):
+    assert flatten(data) == expected
+    # extra nesting should never change the results
+    assert flatten({'f': [data]}) == expected
+
+
+@pytest.mark.parametrize('field,value,expected', [
+    ({'type': 'BOOLEAN', 'mode': 'NULLABLE'}, 'false', False),
+    ({'type': 'BOOLEAN', 'mode': 'NULLABLE'}, 'true', True),
+
+    ({'type': 'FLOAT', 'mode': 'NULLABLE'}, '0.0', 0.0),
+    ({'type': 'FLOAT', 'mode': 'NULLABLE'}, '1.25', 1.25),
+
+    ({'type': 'INTEGER', 'mode': 'NULLABLE'}, '0', 0),
+    ({'type': 'INTEGER', 'mode': 'NULLABLE'}, '1', 1),
+
+    ({'type': 'RECORD', 'mode': 'NULLABLE'}, [], []),
+    ({'type': 'RECORD', 'mode': 'NULLABLE'}, [1, 2], [1, 2]),
+
+    ({'type': 'STRING', 'mode': 'NULLABLE'}, '', ''),
+    ({'type': 'STRING', 'mode': 'NULLABLE'}, 'foo', 'foo'),
+
+    ({'type': 'TIMESTAMP', 'mode': 'NULLABLE'}, '0.0',
+     datetime.datetime(1970, 1, 1, 1)),
+    ({'type': 'TIMESTAMP', 'mode': 'NULLABLE'}, '1656511192.51',
+     datetime.datetime(2022, 6, 29, 14, 59, 52, 510000)),
+
+    ({'type': 'STRING', 'mode': 'REQUIRED'}, '', ''),
+    ({'type': 'STRING', 'mode': 'REQUIRED'}, 'foo', 'foo'),
+
+    ({'type': 'STRING', 'mode': 'REPEATED'},
+     {'v': [{'v': 'foo'}, {'v': 'bar'}]}, ['foo', 'bar']),
+
+])
+def test_parse(field, value, expected):
+    assert parse(field, value) == expected
+
+
+@pytest.mark.parametrize('kind', [
+    'BOOLEAN',
+    'FLOAT',
+    'INTEGER',
+    'RECORD',
+    'STRING',
+    'TIMESTAMP',
+])
+def test_parse_nullable(kind):
+    field = {'type': kind, 'mode': 'NULLABLE'}
+    # make sure we never convert to a falsey typed equivalent
+    # eg. for BOOLEAN, None != False
+    assert parse(field, None) is None
+
+
+def test_from_query_response():
+    fields = [
+        {'name': 'id', 'type': 'STRING', 'mode': 'NULLABLE'},
+        {'name': 'unixtime', 'type': 'INTEGER', 'mode': 'NULLABLE'},
+        {'name': 'isfakedata', 'type': 'BOOLEAN', 'mode': 'NULLABLE'},
+        {'name': 'nested', 'type': 'RECORD', 'mode': 'REPEATED', 'fields': [
+            {'name': 'nestedagain', 'type': 'RECORD', 'mode': 'REPEATED',
+             'fields': [
+                 {'name': 'item', 'type': 'STRING', 'mode': 'NULLABLE'},
+                 {'name': 'value', 'type': 'FLOAT', 'mode': 'NULLABLE'}]}]},
+        {'name': 'repeated', 'type': 'STRING', 'mode': 'REPEATED'},
+        {'name': 'PARTITIONTIME', 'type': 'TIMESTAMP', 'mode': 'NULLABLE'},
+    ]
+    rows = [
+        {'f': [
+            {'v': 'ident1'},
+            {'v': '1654122422181'},
+            {'v': 'true'},
+            {'v': [{'v': {'f': [{'v': {'f': [{'v': 'apples'},
+                                             {'v': '1.23'}]}},
+                                {'v': {'f': [{'v': 'oranges'},
+                                             {'v': '2.34'}]}}]}},
+                   {'v': {'f': [{'v': {'f': [{'v': 'aardvarks'},
+                                             {'v': '9000.1'}]}}]}}]},
+            {'v': [{'v': 'foo'}, {'v': 'bar'}]},
+            {'v': '1.6540416E9'}]},
+        {'f': [
+            {'v': 'ident2'},
+            {'v': '1654122422181'},
+            {'v': 'false'},
+            {'v': []},
+            {'v': [{'v': 'foo'}, {'v': 'bar'}]},
+            {'v': '1.6540416E9'}]},
+    ]
+
+    resp = {
+        'kind': 'bigquery#queryResponse',
+        'schema': {'fields': fields},
+        'jobReference': {'projectId': 'sample-project',
+                         'jobId': 'job_Tlpl-66ca7a8e365a28084c39ffc52d402671',
+                         'location': 'US'},
+        'rows': rows,
+        'totalRows': '2',
+        'totalBytesProcessed': '0',
+        'jobComplete': True,
+        'cacheHit': True,
+    }
+    print(from_query_response(resp))

--- a/bigquery/tests/unit/utils_test.py
+++ b/bigquery/tests/unit/utils_test.py
@@ -2,8 +2,8 @@ import datetime
 
 import pytest
 from gcloud.aio.bigquery.utils import flatten
-from gcloud.aio.bigquery.utils import from_query_response
 from gcloud.aio.bigquery.utils import parse
+from gcloud.aio.bigquery.utils import query_response_to_dict
 
 
 @pytest.mark.parametrize('data,expected', [
@@ -71,7 +71,7 @@ def test_parse_nullable(kind):
     assert parse(field, None) is None
 
 
-def test_from_query_response():
+def test_query_response_to_dict():
     fields = [
         {'name': 'id', 'type': 'STRING', 'mode': 'NULLABLE'},
         {'name': 'unixtime', 'type': 'INTEGER', 'mode': 'NULLABLE'},
@@ -170,6 +170,6 @@ def test_from_query_response():
         'jobComplete': True,
         'cacheHit': True,
     }
-    parsed = from_query_response(resp)
+    parsed = query_response_to_dict(resp)
     print(parsed)
     assert parsed == expected

--- a/bigquery/tests/unit/utils_test.py
+++ b/bigquery/tests/unit/utils_test.py
@@ -41,9 +41,10 @@ def test_flatten(data, expected):
     ({'type': 'STRING', 'mode': 'NULLABLE'}, 'foo', 'foo'),
 
     ({'type': 'TIMESTAMP', 'mode': 'NULLABLE'}, '0.0',
-     datetime.datetime(1970, 1, 1, 1)),
+     datetime.datetime(1970, 1, 1, 0, tzinfo=datetime.timezone.utc)),
     ({'type': 'TIMESTAMP', 'mode': 'NULLABLE'}, '1656511192.51',
-     datetime.datetime(2022, 6, 29, 14, 59, 52, 510000)),
+     datetime.datetime(2022, 6, 29, 13, 59, 52, 510000,
+                       tzinfo=datetime.timezone.utc)),
 
     ({'type': 'STRING', 'mode': 'REQUIRED'}, '', ''),
     ({'type': 'STRING', 'mode': 'REQUIRED'}, 'foo', 'foo'),
@@ -112,7 +113,8 @@ def test_query_response_to_dict():
     ]
     expected = [
         {
-            'PARTITIONTIME': datetime.datetime(2022, 6, 1, 1, 0),
+            'PARTITIONTIME': datetime.datetime(2022, 6, 1, 0, 0,
+                                               tzinfo=datetime.timezone.utc),
             'id': 'ident1',
             'isfakedata': True,
             'nested': [
@@ -145,7 +147,8 @@ def test_query_response_to_dict():
             'unixtime': 1654122422181,
         },
         {
-            'PARTITIONTIME': datetime.datetime(2022, 6, 1, 1, 0),
+            'PARTITIONTIME': datetime.datetime(2022, 6, 1, 0, 0,
+                                               tzinfo=datetime.timezone.utc),
             'id': 'ident2',
             'isfakedata': False,
             'nested': [],


### PR DESCRIPTION
Convenience method so client libs don't need to do the converting
themselves to get a slightly more useable dictionary format from their
BQ responses.