### PR TITLE
fix(ci): use nox image for everything

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,13 @@
 version: 2.1
 
 orbs:
-  linter: talkiq/linter@2
-  poetry: talkiq/poetry@3
+  linter: talkiq/linter@3
+  poetry: talkiq/poetry@4
 
 executors:
-  python-36:
+  nox:
     docker:
-      - image: python:3.6.15
-    resource_class: small
-
-  python-37:
-    docker:
-      - image: python:3.7.13
+      - image: thekevjames/nox:2022.8.7
     resource_class: small
 
   python-38:
@@ -63,9 +58,7 @@ jobs:
   #   * I have no idea why this fixed things, maybe a similar issue to
   #     https://github.com/python-poetry/poetry/issues/3410 ?
   poetry-run-deprecated-pythons:
-    docker:
-      - image: thekevjames/nox:2022.1.7
-    resource_class: small
+    executor: nox
     parameters:
       cmd:
         type: string
@@ -76,15 +69,20 @@ jobs:
     steps:
       - run: apt-get update -qy
       - run: apt-get install -qy python3.8-venv
-      - poetry/install
+      - poetry/install:
+          # TODO: figure out a better way for managing older envs like py27...
+          # ...or hopefully we can drop support before this affects us... more
+          # than it already does...
+          version: 1.1.9
       - checkout
       - run:
           command: poetry env use <<parameters.python_version>>
           working_directory: <<parameters.cwd>>
       - run:
-          command: |
-            poetry install --no-root
-            poetry run pip install .
+          command: poetry install --no-root
+          working_directory: <<parameters.cwd>>
+      - run:
+          command: poetry run pip install .
           working_directory: <<parameters.cwd>>
       - run:
           command: poetry run <<parameters.cmd>>
@@ -194,7 +192,8 @@ workflows:
       # build gcloud-rest-*
       - poetry/run:
           name: build-rest
-          cmd: ./bin/build-rest
+          commands:
+            - run: poetry run ./bin/build-rest
           post-steps:
             - store-rest
           filters:
@@ -203,27 +202,26 @@ workflows:
 
       # run linters
       - linter/pre-commit:
-          python_version: 3.8.6  # TODO: https://github.com/PyCQA/pylint/issues/3882
+          executor: python-38  # TODO: https://github.com/PyCQA/pylint/issues/3882
           filters:
             tags:
               only: /.*/
 
       # run tests
-      - poetry/run:
-          name: test-unit-/aio/<<matrix.cwd>>-<<matrix.executor>>
+      - poetry-run-deprecated-pythons:
+          name: test-unit-/aio/<<matrix.cwd>>-<<matrix.python_version>>
           cmd: pytest tests/unit
           matrix:
             alias: test-unit-aio
             parameters:
               cwd: [auth, bigquery, datastore, kms, pubsub, storage, taskqueue]
-              executor: [python-36, python-37, python-38, python-39]
+              python_version: ['3.6', '3.7', '3.8', '3.9']
           filters:
             tags:
               only: /.*/
-      - poetry/run:
-          name: test-integration-/aio/<<matrix.cwd>>
+      - poetry-run-deprecated-pythons:
+          name: test-integration-/aio/<<matrix.cwd>>-<<matrix.python_version>>
           cmd: pytest tests/integration
-          executor: python-39
           pre-steps:
             - run: echo 'export GOOGLE_APPLICATION_CREDENTIALS="/key.json"' >> $BASH_ENV
             - run: echo ${GOOGLE_SERVICE_PUBLIC} | base64 -d > "${GOOGLE_APPLICATION_CREDENTIALS}"
@@ -231,6 +229,7 @@ workflows:
             alias: test-integration-aio
             parameters:
               cwd: [auth, bigquery, datastore, pubsub, storage, taskqueue]
+              python_version: ['3.9']
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
Poetry can't be installed in python 3.6. Rather than making that a
special case, use the nox image for everything.
