### PR TITLE
chore(lint): enable mccabe complexity plugin with default settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,8 @@ repos:
         - git+https://github.com/bayesimpact/pylint_import_modules@016f79e4d2
         args:
         - --allowed-direct-imports="typing.*"
-        - --load-plugins=pylint_import_modules
+        - --load-plugins=pylint_import_modules,pylint.extensions.mccabe
+        - --max-complexity=10
         - --max-line-length=79
         - --max-args=10
         - --score=n
@@ -130,6 +131,8 @@ repos:
     rev: 3.9.2
     hooks:
     -   id: flake8
+        additional_dependencies:
+        - importlib-metadata<5
         args:
         - --ignore=E501,W503,F401,F811
 -   repo: local

--- a/auth/gcloud/aio/auth/session.py
+++ b/auth/gcloud/aio/auth/session.py
@@ -76,6 +76,7 @@ class BaseSession:
         pass
 
 
+# pylint: disable=too-complex
 if not BUILD_GCLOUD_REST:
     import aiohttp
 
@@ -187,7 +188,7 @@ if not BUILD_GCLOUD_REST:
             if not self._shared_session and self._session:
                 await self._session.close()
 
-
+# pylint: disable=too-complex
 if BUILD_GCLOUD_REST:
     class SyncSession(BaseSession):
         _google_api_lock = threading.RLock()

--- a/pubsub/gcloud/aio/pubsub/subscriber.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber.py
@@ -1,5 +1,6 @@
 from gcloud.aio.auth import BUILD_GCLOUD_REST
 
+# pylint: disable=too-complex
 if BUILD_GCLOUD_REST:
     pass
 else:

--- a/pubsub/tests/unit/subscriber_test.py
+++ b/pubsub/tests/unit/subscriber_test.py
@@ -1,6 +1,7 @@
 # pylint: disable=redefined-outer-name
 from gcloud.aio.auth import BUILD_GCLOUD_REST
 
+# pylint: disable=too-complex
 if BUILD_GCLOUD_REST:
     pass
 else:


### PR DESCRIPTION
Enable cyclomatic complexity plugin, which uses the McCabe Cyclomatic complexity to define how complex a function is. By default the maximum cyclomatic complexity is `10`.

[Cyclomatic complexity](https://en.wikipedia.org/wiki/Cyclomatic_complexity) is the number of linearly independent paths within it, or in layman's terms: how many paths can be taken "through the code". A cyclomatic complexity of `10` means there's 10 linearly independent paths to exit a function.

And a bonus: pin importlib<5.0 in order to fix a recent flake8 dependency issue.