### PR TITLE
fix(auth): Fix Token for stored credentials on Windows

### DIFF
--- a/auth/gcloud/aio/auth/token.py
+++ b/auth/gcloud/aio/auth/token.py
@@ -65,9 +65,13 @@ def get_service_data(
     service = service or os.environ.get('GOOGLE_APPLICATION_CREDENTIALS')
     if not service:
         cloudsdk_config = os.environ.get('CLOUDSDK_CONFIG')
-        sdkpath = (cloudsdk_config
-                   or os.path.join(os.path.expanduser('~'), '.config',
-                                   'gcloud'))
+        if cloudsdk_config is not None:
+            sdkpath = cloudsdk_config
+        elif os.name != 'nt':
+            sdkpath = os.path.join(os.path.expanduser('~'), '.config',
+                                   'gcloud')
+        else:
+            sdkpath = os.path.join(os.environ['APPDATA'], 'gcloud')
         service = os.path.join(sdkpath, 'application_default_credentials.json')
         set_explicitly = bool(cloudsdk_config)
     else:


### PR DESCRIPTION
Modifies `get_service_data` to be in sync with https://github.com/googleapis/google-auth-library-python/blob/73bc7e9e0e72b6c5057a13cdb4ac996b754ddb58/google/auth/_cloud_sdk.py#L47 I left out the "this should never happen but just in case" case, but happy to include that if desired.

Without this change, using any of the storage APIs on Windows while signed in via the Google Cloud CLI would fail because credentials were not found. With this change, this scenario now works.

Thank you!