### PR TITLE
Use aiohttp with contextmanager

### DIFF
--- a/pubsub/gcloud/aio/pubsub/publisher_client.py
+++ b/pubsub/gcloud/aio/pubsub/publisher_client.py
@@ -132,10 +132,9 @@ class PublisherClient:
         headers['Content-Length'] = str(len(payload))
 
         s = AioSession(session) if session else self.session
-        resp = await s.post(url, data=payload, headers=headers,
-                            timeout=timeout)
-        data: Dict[str, Any] = await resp.json()
-        return data
+        async with s.post(url, data=payload, headers=headers, timeout=timeout) as resp:
+            data: Dict[str, Any] = await resp.json()
+            return data
 
     async def close(self) -> None:
         await self.session.close()


### PR DESCRIPTION
I'm getting lots of errors like this in my logs: `Unclosed client session_client_session: <aiogoogle.sessions.aiohttp_session.AiohttpSession object at 0x7f1cb8188370>`

I believe this is because the aiohttp library is not used correctly. According to the docs, all get/post/.. request methods should always be called with a contextmanager. 

This is just a quick&dirty PR to demonstrate what I mean. Happy to provide a proper PR that changes this for all usages, if you agree with the change.