### PR TITLE
feat: load emulator hosts at runtime

### DIFF
--- a/bigquery/gcloud/aio/bigquery/bigquery.py
+++ b/bigquery/gcloud/aio/bigquery/bigquery.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 from enum import Enum
 from typing import Any
@@ -6,6 +7,7 @@ from typing import AnyStr
 from typing import Dict
 from typing import IO
 from typing import Optional
+from typing import Tuple
 from typing import Union
 
 from gcloud.aio.auth import AioSession  # pylint: disable=no-name-in-module
@@ -19,15 +21,23 @@ else:
     from aiohttp import ClientSession as Session  # type: ignore[assignment]
 
 
-API_ROOT = 'https://www.googleapis.com/bigquery/v2'
 SCOPES = [
     'https://www.googleapis.com/auth/bigquery.insertdata',
     'https://www.googleapis.com/auth/bigquery',
 ]
 
-BIGQUERY_EMULATOR_HOST = os.environ.get('BIGQUERY_EMULATOR_HOST')
-if BIGQUERY_EMULATOR_HOST:
-    API_ROOT = f'http://{BIGQUERY_EMULATOR_HOST}/bigquery/v2'
+log = logging.getLogger(__name__)
+
+
+def init_api_root(api_root: Optional[str]) -> Tuple[bool, str]:
+    if api_root:
+        return True, api_root
+
+    host = os.environ.get('BIGQUERY_EMULATOR_HOST')
+    if host:
+        return True, f'http://{host}/bigquery/v2'
+
+    return False, 'https://www.googleapis.com/bigquery/v2'
 
 
 class SourceFormat(Enum):
@@ -51,23 +61,30 @@ class SchemaUpdateOption(Enum):
 
 
 class BigqueryBase:
-    def __init__(self,
-                 project: Optional[str] = None,
-                 service_file: Optional[Union[str, IO[AnyStr]]] = None,
-                 session: Optional[Session] = None,
-                 token: Optional[Token] = None) -> None:
-        self._project = project
+    _project: Optional[str]
+    _api_root: str
+    _api_is_dev: bool
+
+    def __init__(
+            self, project: Optional[str] = None,
+            service_file: Optional[Union[str, IO[AnyStr]]] = None,
+            session: Optional[Session] = None, token: Optional[Token] = None,
+            api_root: Optional[str] = None,
+    ) -> None:
+        self._api_is_dev, self._api_root = init_api_root(api_root)
         self.session = AioSession(session)
         self.token = token or Token(
             service_file=service_file, scopes=SCOPES,
             session=self.session.session)  # type: ignore[arg-type]
 
+        self._project = project
+        if self._api_is_dev and not project:
+            self._project = (os.environ.get('BIGQUERY_PROJECT_ID')
+                             or os.environ.get('GOOGLE_CLOUD_PROJECT')
+                             or 'dev')
+
     async def project(self) -> str:
         if self._project:
-            return self._project
-
-        if BIGQUERY_EMULATOR_HOST:
-            self._project = str(os.environ.get('BIGQUERY_PROJECT_ID', 'dev'))
             return self._project
 
         self._project = await self.token.get_project()
@@ -77,7 +94,7 @@ class BigqueryBase:
         raise Exception('could not determine project, please set it manually')
 
     async def headers(self) -> Dict[str, str]:
-        if BIGQUERY_EMULATOR_HOST:
+        if self._api_is_dev:
             return {}
 
         token = await self.token.get()

--- a/bigquery/gcloud/aio/bigquery/dataset.py
+++ b/bigquery/gcloud/aio/bigquery/dataset.py
@@ -8,7 +8,6 @@ from typing import Union
 from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
 from gcloud.aio.auth import Token  # pylint: disable=no-name-in-module
 
-from .bigquery import API_ROOT
 from .bigquery import BigqueryBase
 
 # Selectively load libraries based on the package
@@ -19,14 +18,16 @@ else:
 
 
 class Dataset(BigqueryBase):
-    def __init__(self, dataset_name: Optional[str] = None,
-                 project: Optional[str] = None,
-                 service_file: Optional[Union[str, IO[AnyStr]]] = None,
-                 session: Optional[Session] = None,
-                 token: Optional[Token] = None) -> None:
+    def __init__(
+            self, dataset_name: Optional[str] = None,
+            project: Optional[str] = None,
+            service_file: Optional[Union[str, IO[AnyStr]]] = None,
+            session: Optional[Session] = None, token: Optional[Token] = None,
+            api_root: Optional[str] = None,
+    ) -> None:
         self.dataset_name = dataset_name
         super().__init__(project=project, service_file=service_file,
-                         session=session, token=token)
+                         session=session, token=token, api_root=api_root)
 
     # https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/list
     async def list_tables(
@@ -39,7 +40,7 @@ class Dataset(BigqueryBase):
             raise ValueError('could not determine dataset,'
                              ' please set it manually')
 
-        url = (f'{API_ROOT}/projects/{project}/datasets/'
+        url = (f'{self._api_root}/projects/{project}/datasets/'
                f'{self.dataset_name}/tables')
         return await self._get_url(url, session, timeout, params=params)
 
@@ -51,7 +52,7 @@ class Dataset(BigqueryBase):
         """List datasets in current project."""
         project = await self.project()
 
-        url = (f'{API_ROOT}/projects/{project}/datasets')
+        url = f'{self._api_root}/projects/{project}/datasets'
         return await self._get_url(url, session, timeout, params=params)
 
     # https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/get
@@ -64,7 +65,7 @@ class Dataset(BigqueryBase):
             raise ValueError('could not determine dataset,'
                              ' please set it manually')
 
-        url = (f'{API_ROOT}/projects/{project}/datasets/'
+        url = (f'{self._api_root}/projects/{project}/datasets/'
                f'{self.dataset_name}')
         return await self._get_url(url, session, timeout, params=params)
 
@@ -75,5 +76,5 @@ class Dataset(BigqueryBase):
         """Create datasets in current project."""
         project = await self.project()
 
-        url = (f'{API_ROOT}/projects/{project}/datasets')
+        url = f'{self._api_root}/projects/{project}/datasets'
         return await self._post_json(url, dataset, session, timeout)

--- a/bigquery/gcloud/aio/bigquery/job.py
+++ b/bigquery/gcloud/aio/bigquery/job.py
@@ -8,7 +8,6 @@ from typing import Union
 from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
 from gcloud.aio.auth import Token  # pylint: disable=no-name-in-module
 
-from .bigquery import API_ROOT
 from .bigquery import BigqueryBase
 from .bigquery import Disposition
 
@@ -20,14 +19,15 @@ else:
 
 
 class Job(BigqueryBase):
-    def __init__(self, job_id: Optional[str] = None,
-                 project: Optional[str] = None,
-                 service_file: Optional[Union[str, IO[AnyStr]]] = None,
-                 session: Optional[Session] = None,
-                 token: Optional[Token] = None) -> None:
+    def __init__(
+            self, job_id: Optional[str] = None, project: Optional[str] = None,
+            service_file: Optional[Union[str, IO[AnyStr]]] = None,
+            session: Optional[Session] = None, token: Optional[Token] = None,
+            api_root: Optional[str] = None,
+    ) -> None:
         self.job_id = job_id
         super().__init__(project=project, service_file=service_file,
-                         session=session, token=token)
+                         session=session, token=token, api_root=api_root)
 
     @staticmethod
     def _make_query_body(
@@ -59,7 +59,7 @@ class Job(BigqueryBase):
         """Get the specified job resource by job ID."""
 
         project = await self.project()
-        url = f'{API_ROOT}/projects/{project}/jobs/{self.job_id}'
+        url = f'{self._api_root}/projects/{project}/jobs/{self.job_id}'
 
         return await self._get_url(url, session, timeout)
 
@@ -71,7 +71,7 @@ class Job(BigqueryBase):
         """Get the specified jobQueryResults by job ID."""
 
         project = await self.project()
-        url = f'{API_ROOT}/projects/{project}/queries/{self.job_id}'
+        url = f'{self._api_root}/projects/{project}/queries/{self.job_id}'
 
         return await self._get_url(url, session, timeout, params=params)
 
@@ -81,7 +81,8 @@ class Job(BigqueryBase):
         """Cancel the specified job by job ID."""
 
         project = await self.project()
-        url = f'{API_ROOT}/projects/{project}/queries/{self.job_id}/cancel'
+        url = (f'{self._api_root}/projects/{project}/queries/{self.job_id}'
+               '/cancel')
 
         return await self._post_json(url, {}, session, timeout)
 
@@ -92,7 +93,7 @@ class Job(BigqueryBase):
         """Runs a query synchronously and returns query results if completes
         within a specified timeout."""
         project = await self.project()
-        url = f'{API_ROOT}/projects/{project}/queries'
+        url = f'{self._api_root}/projects/{project}/queries'
 
         return await self._post_json(url, query_request, session, timeout)
 
@@ -102,7 +103,7 @@ class Job(BigqueryBase):
                      timeout: int = 60) -> Dict[str, Any]:
         """Insert a new asynchronous job."""
         project = await self.project()
-        url = f'{API_ROOT}/projects/{project}/jobs'
+        url = f'{self._api_root}/projects/{project}/jobs'
 
         response = await self._post_json(url, job, session, timeout)
         if response['jobReference'].get('jobId'):
@@ -119,7 +120,7 @@ class Job(BigqueryBase):
             destination_table: Optional[Any] = None) -> Dict[str, Any]:
         """Create table as a result of the query"""
         project = await self.project()
-        url = f'{API_ROOT}/projects/{project}/jobs'
+        url = f'{self._api_root}/projects/{project}/jobs'
 
         body = self._make_query_body(query=query,
                                      write_disposition=write_disposition,

--- a/docs/aio.md
+++ b/docs/aio.md
@@ -1,3 +1,30 @@
+## Emulator Usage
+
+All of our API clients are integrated to make use of the official Google emulators, where those exist. As a general rule, this means you can set the `$FOO_EMULATOR_HOST` environment variable (where `$FOO` is the service being emulated, such as `PUBSUB_EMULATOR_HOST`) and your `gcloud` client will point to the emulator rather than the live APIs.
+
+Alternatively, you can provide the `api_root` option to any relevant constructor to have full control over the API being used. Note that while the environment variable expects just the hostname (to support the standard Google emulator usecase), if you assign this value manually via the contructor arg you must include the entire path.
+
+If you override the API value (either by constructor option or environment variable), tls verification and other such security measures will be disabled as needed. This feature is not intended for production use!
+
+Note also that this library only supports a single version of the Google APIs at a given time (generally the most recent version). If the API you point to does not conform to the correct version of the spec, we make no promises as to what might happen.
+
+For example:
+
+```python
+client = gcloud.aio.datastore.Datastore()
+assert client._api_root == 'https://datastore.googleapis.com/v1'
+
+# generally set via `gcloud emulators datastore env-init`
+os.environ['DATASTORE_EMULATOR_HOST'] = '127.0.0.1:8432'
+client = gcloud.aio.datastore.Datastore()
+assert client._api_root == 'http://127.0.0.1:8432/v1'
+
+client = gcloud.aio.datastore.Datastore(api_root='http://example.com/datastoreapi')
+assert client._api_root == 'http://example.com/datastoreapi'
+```
+
+Note that, in any case, these values will be loaded at the time the class instance is constructed.
+
 ## Session Management
 
 Since we use `aiohttp` under the hood, ensuring we properly close our `ClientSession` upon shutdown is important to avoid "unclosed connection" errors.

--- a/docs/gcloud.md
+++ b/docs/gcloud.md
@@ -2,7 +2,7 @@ These docs cover two projects: `gcloud-aio-*` and `gcloud-rest-*`. Both of them 
 
 For supported clients, see the modules in the sidebar.
 
-# Installation
+## Installation
 
 ```console
 $ pip install --upgrade gcloud-{aio,rest}-{client_name}

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -1,3 +1,30 @@
+## Emulator Usage
+
+All of our API clients are integrated to make use of the official Google emulators, where those exist. As a general rule, this means you can set the `$FOO_EMULATOR_HOST` environment variable (where `$FOO` is the service being emulated, such as `PUBSUB_EMULATOR_HOST`) and your `gcloud` client will point to the emulator rather than the live APIs.
+
+Alternatively, you can provide the `api_root` option to any relevant constructor to have full control over the API being used. Note that while the environment variable expects just the hostname (to support the standard Google emulator usecase), if you assign this value manually via the contructor arg you must include the entire path.
+
+If you override the API value (either by constructor option or environment variable), tls verification and other such security measures will be disabled as needed. This feature is not intended for production use!
+
+Note also that this library only supports a single version of the Google APIs at a given time (generally the most recent version). If the API you point to does not conform to the correct version of the spec, we make no promises as to what might happen.
+
+For example:
+
+```python
+client = gcloud.rest.datastore.Datastore()
+assert client._api_root == 'https://datastore.googleapis.com/v1'
+
+# generally set via `gcloud emulators datastore env-init`
+os.environ['DATASTORE_EMULATOR_HOST'] = '127.0.0.1:8432'
+client = gcloud.rest.datastore.Datastore()
+assert client._api_root == 'http://127.0.0.1:8432/v1'
+
+client = gcloud.rest.datastore.Datastore(api_root='http://example.com/datastoreapi')
+assert client._api_root == 'http://example.com/datastoreapi'
+```
+
+Note that, in any case, these values will be loaded at the time the class instance is constructed.
+
 ## Token Management
 
 By default, you should not need to care about managing a `gcloud.rest.auth.Token` instance. When you initialize a given client library, it will handle creating a token with the correct scopes.


### PR DESCRIPTION
Solves a couple related goals in a consistent way across all projects:

* allows users to provide an api host via code instead of only via env
  var
* load that value at time of constructing the client rather than import
  time

Thanks to @josipbudzaki in #542 and @adriangb in #539 for providing a
baseline approach.

Fixes #202.
