### PR TITLE
fix(circleci): bad interpolation when creating PYPI_TOKEN_*

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
           command: |
             suffix=$(if [ <<parameters.basedir>> = "/rest" ]; then echo "REST"; else echo "AIO"; fi)
             token=$(printenv | grep -i PYPI_TOKEN_GCLOUD_$(echo $suffix)_<<parameters.cwd>> | awk -F= '{ print $2 }')
-            echo 'export POETRY_PYPI_TOKEN_PYPI=${token}' >> "$BASH_ENV"
+            echo 'export POETRY_PYPI_TOKEN_PYPI=$token' >> "$BASH_ENV"
           working_directory: <<parameters.basedir>>/<<parameters.cwd>>
       - run:
           command: poetry build


### PR DESCRIPTION
`echo 'export POETRY_PYPI_TOKEN_PYPI="$token"' >> "$BASH_ENV"` interpolation doesn't work, cahnging this to `echo 'export POETRY_PYPI_TOKEN_PYPI=$token' >> "$BASH_ENV"` seems to do the trick.