### PR TITLE
fix: bad interpolation of token in BASH_ENV

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
           command: |
             suffix=$(if [ <<parameters.basedir>> = "/rest" ]; then echo "REST"; else echo "AIO"; fi)
             token=$(printenv | grep -i PYPI_TOKEN_GCLOUD_$(echo $suffix)_<<parameters.cwd>> | awk -F= '{ print $2 }')
-            echo 'export POETRY_PYPI_TOKEN_PYPI=$token' >> "$BASH_ENV"
+            echo "export POETRY_PYPI_TOKEN_PYPI=$token" >> "$BASH_ENV"
           working_directory: <<parameters.basedir>>/<<parameters.cwd>>
       - run:
           command: poetry build


### PR DESCRIPTION
Turns out that doing `echo '$asd'` with single quotes prints `asd`, whereas using `echo "$asd"` will interpolate the value of `asd` and thus print the value within the variable. We're currently using single quotes instead of double quotes, so we gotta make them single quotes double quotes for that sweet interpolation to work.