### PR TITLE
(storage) Adjustments to how signed urls are generated

### DIFF
--- a/storage/gcloud/aio/storage/blob.py
+++ b/storage/gcloud/aio/storage/blob.py
@@ -150,7 +150,8 @@ class Blob:
         headers = headers or {}
         headers['host'] = f'{self.bucket.name}.{HOST}'
 
-        ordered_headers = collections.OrderedDict(sorted(headers.items()))
+        ordered_headers = collections.OrderedDict(
+            sorted(headers.items(), key=lambda x: x[0].lower()))
         canonical_headers = ''.join(
             f'{str(k).lower()}:{str(v).lower()}\n'
             for k, v in ordered_headers.items()

--- a/storage/gcloud/aio/storage/blob.py
+++ b/storage/gcloud/aio/storage/blob.py
@@ -121,7 +121,7 @@ class Blob:
             )
 
         quoted_name = quote(self.name, safe=b'/~')
-        canonical_uri = f'/{quoted_name}'
+        canonical_uri = f'/{self.bucket.name}/{quoted_name}'
 
         datetime_now = datetime.datetime.utcnow()
         request_timestamp = datetime_now.strftime('%Y%m%dT%H%M%SZ')
@@ -148,7 +148,7 @@ class Blob:
         credential = f'{client_email}/{credential_scope}'
 
         headers = headers or {}
-        headers['host'] = f'{self.bucket.name}.{HOST}'
+        headers['host'] = HOST
 
         ordered_headers = collections.OrderedDict(
             sorted(headers.items(), key=lambda x: x[0].lower()))
@@ -217,6 +217,6 @@ class Blob:
         signature = binascii.hexlify(signed_blob).decode()
 
         return (
-            f'https://{self.bucket.name}.{HOST}{canonical_uri}?'
+            f'https://{HOST}{canonical_uri}?'
             f'{canonical_query_str}&X-Goog-Signature={signature}'
         )

--- a/storage/tests/integration/signed_url_test.py
+++ b/storage/tests/integration/signed_url_test.py
@@ -16,7 +16,7 @@ else:
 @pytest.mark.parametrize('data', ['test'])
 @pytest.mark.parametrize('headers', [
     {},
-    {'X-Goog-ACL': 'public-read', 'Content-Type': 'text/plain'}
+    {'X-Goog-ACL': 'public-read', 'Content-Type': 'text/plain'},
 ])
 async def test_gcs_signed_url(bucket_name, creds, data, headers):
     object_name = f'{uuid.uuid4().hex}/{uuid.uuid4().hex}.txt'

--- a/storage/tests/integration/signed_url_test.py
+++ b/storage/tests/integration/signed_url_test.py
@@ -14,7 +14,11 @@ else:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize('data', ['test'])
-async def test_gcs_signed_url(bucket_name, creds, data):
+@pytest.mark.parametrize('headers', [
+    {},
+    {'X-Goog-ACL': 'public-read', 'Content-Type': 'text/plain'}
+])
+async def test_gcs_signed_url(bucket_name, creds, data, headers):
     object_name = f'{uuid.uuid4().hex}/{uuid.uuid4().hex}.txt'
 
     async with Session() as session:
@@ -27,9 +31,9 @@ async def test_gcs_signed_url(bucket_name, creds, data):
         bucket = Bucket(storage, bucket_name)
         blob = await bucket.get_blob(object_name, session=session)
 
-        signed_url = await blob.get_signed_url(60)
+        signed_url = await blob.get_signed_url(60, headers=headers)
 
-        resp = await session.get(signed_url)
+        resp = await session.get(signed_url, headers=headers)
 
         try:
             downloaded_data: str = await resp.text()


### PR DESCRIPTION
- fix the sorting of headers to use the proper lowercase keys
- support domain-named buckets which can't be referenced as subdomains like normal buckets

If a publicly available domain-named bucket was created for testing, we could also test the domain-named buckets, in addition to the currently used `dialpad-oss-public-test` bucket.