### PR TITLE
Fix cancel job url

### DIFF
--- a/bigquery/gcloud/aio/bigquery/job.py
+++ b/bigquery/gcloud/aio/bigquery/job.py
@@ -90,7 +90,7 @@ class Job(BigqueryBase):
 
         project = await self.project()
         url = (
-            f'{self._api_root}/projects/{project}/queries/{self.job_id}'
+            f'{self._api_root}/projects/{project}/jobs/{self.job_id}'
             '/cancel'
         )
 


### PR DESCRIPTION
Hi,
I am just fixing the url to cancel bigquery jobs.

The [documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/cancel) says it should be `jobs` not `queries`. I seems to be just a typo because it points to the same documentation above in the code.