### PR TITLE
refactor: migrate to PEP 420 namespace packages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,7 +95,6 @@ repos:
         - backoff
         - types-cryptography
         - types-jwt
-        - types-pkg_resources
         - types-requests
         args:
         - --show-error-codes
@@ -109,7 +108,6 @@ repos:
         additional_dependencies:
         - aiohttp
         - gcloud-aio-auth
-        - types-pkg_resources
         - types-requests
         files: bigquery/
     -   <<: *mypy
@@ -117,7 +115,6 @@ repos:
         additional_dependencies:
         - aiohttp
         - gcloud-aio-auth
-        - types-pkg_resources
         - types-requests
         files: datastore/
     -   <<: *mypy
@@ -125,7 +122,6 @@ repos:
         additional_dependencies:
         - aiohttp
         - gcloud-aio-auth
-        - types-pkg_resources
         - types-requests
         files: kms/
     -   <<: *mypy
@@ -134,7 +130,6 @@ repos:
         - aiohttp
         - gcloud-aio-auth
         - prometheus-client
-        - types-pkg_resources
         - types-requests
         files: pubsub/
     -   <<: *mypy
@@ -144,7 +139,6 @@ repos:
         - gcloud-aio-auth
         - rsa
         - types-aiofiles
-        - types-pkg_resources
         - types-requests
         files: storage/
     -   <<: *mypy
@@ -152,7 +146,6 @@ repos:
         additional_dependencies:
         - aiohttp
         - gcloud-aio-auth
-        - types-pkg_resources
         - types-requests
         files: taskqueue/
 -   repo: https://github.com/asottile/yesqa

--- a/auth/gcloud/__init__.py
+++ b/auth/gcloud/__init__.py
@@ -1,9 +1,0 @@
-"""
-.. include:: ../../docs/gcloud.md
-"""
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/auth/gcloud/aio/__init__.py
+++ b/auth/gcloud/aio/__init__.py
@@ -1,9 +1,0 @@
-"""
-.. include:: ../../../docs/aio.md
-"""
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/auth/gcloud/aio/auth/__init__.py
+++ b/auth/gcloud/aio/auth/__init__.py
@@ -41,16 +41,17 @@ Additionally, the `Token` constructor accepts the following optional arguments:
 
 [service-account]: https://console.cloud.google.com/iam-admin/serviceaccounts
 """
-from pkg_resources import get_distribution
+import importlib.metadata
 
-__version__ = get_distribution('gcloud-aio-auth').version
+from .build_constants import BUILD_GCLOUD_REST
+from .iam import IamClient
+from .session import AioSession
+from .token import Token
+from .utils import decode
+from .utils import encode
 
-from gcloud.aio.auth.build_constants import BUILD_GCLOUD_REST
-from gcloud.aio.auth.iam import IamClient
-from gcloud.aio.auth.session import AioSession
-from gcloud.aio.auth.token import Token
-from gcloud.aio.auth.utils import decode, encode
 
+__version__ = importlib.metadata.version('gcloud-aio-auth')
 __all__ = [
     'AioSession',
     'BUILD_GCLOUD_REST',

--- a/auth/poetry.lock
+++ b/auth/poetry.lock
@@ -690,22 +690,6 @@ pytest = ">=5.0"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
-name = "setuptools"
-version = "66.1.1"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "setuptools-66.1.1-py3-none-any.whl", hash = "sha256:6f590d76b713d5de4e49fe4fbca24474469f53c83632d5d0fd056f7ff7e8112b"},
-    {file = "setuptools-66.1.1.tar.gz", hash = "sha256:ac4008d396bc9cd983ea483cb7139c0240a07bbc74ffb6232fceffedc6cf03a8"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -806,4 +790,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.8, < 4.0"
-content-hash = "5e1ce654faef82ba2f0061706dd4b521d1762a1e398f522647ff5d9d2f57b595"
+content-hash = "a536435ce4647d00591067b77e12c3b20741b4b464b70adc62e53177146e3f68"

--- a/auth/poetry.rest.lock
+++ b/auth/poetry.rest.lock
@@ -400,22 +400,6 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
-name = "setuptools"
-version = "66.1.1"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "setuptools-66.1.1-py3-none-any.whl", hash = "sha256:6f590d76b713d5de4e49fe4fbca24474469f53c83632d5d0fd056f7ff7e8112b"},
-    {file = "setuptools-66.1.1.tar.gz", hash = "sha256:ac4008d396bc9cd983ea483cb7139c0240a07bbc74ffb6232fceffedc6cf03a8"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -446,4 +430,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.8, < 4.0"
-content-hash = "2c322855c9ac9d0586b0b921d5e0647838c926f015b47b1f89616dcce4a872fe"
+content-hash = "894c917835083fb881e9936e226785bb1c066c582126c245a9796ebd6f6ad873"

--- a/auth/pyproject.rest.toml
+++ b/auth/pyproject.rest.toml
@@ -27,7 +27,6 @@ chardet = ">= 2.0, < 6.0"
 cryptography = ">= 2.0.0, < 42.0.0"
 pyjwt = ">= 1.5.3, < 3.0.0"
 requests = ">= 2.2.1, < 3.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"  # TODO: upgrade to PEP 420 namespace packages
 
 [tool.poetry.dev-dependencies]
 pytest = ">= 4.0.0, < 8.0.0"

--- a/auth/pyproject.toml
+++ b/auth/pyproject.toml
@@ -27,7 +27,6 @@ chardet = ">= 2.0, < 6.0"
 cryptography = ">= 2.0.0, < 42.0.0"
 pyjwt = ">= 1.5.3, < 3.0.0"
 # requests = ">= 2.2.1, < 3.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"  # TODO: upgrade to PEP 420 namespace packages
 
 [tool.poetry.dev-dependencies]
 pytest = ">= 4.0.0, < 8.0.0"

--- a/bigquery/gcloud/__init__.py
+++ b/bigquery/gcloud/__init__.py
@@ -1,9 +1,0 @@
-"""
-.. include:: ../../docs/gcloud.md
-"""
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/bigquery/gcloud/aio/__init__.py
+++ b/bigquery/gcloud/aio/__init__.py
@@ -1,9 +1,0 @@
-"""
-.. include:: ../../../docs/aio.md
-"""
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/bigquery/gcloud/aio/bigquery/__init__.py
+++ b/bigquery/gcloud/aio/bigquery/__init__.py
@@ -22,19 +22,19 @@ the address of your emulator should be enough to do the trick.
 [smoke-test]:
 https://github.com/talkiq/gcloud-aio/blob/master/bigquery/tests/integration/smoke_test.py
 """
-from pkg_resources import get_distribution
-__version__ = get_distribution('gcloud-aio-bigquery').version
+import importlib.metadata
 
-from gcloud.aio.bigquery.bigquery import Disposition
-from gcloud.aio.bigquery.bigquery import SCOPES
-from gcloud.aio.bigquery.bigquery import SchemaUpdateOption
-from gcloud.aio.bigquery.bigquery import SourceFormat
-from gcloud.aio.bigquery.dataset import Dataset
-from gcloud.aio.bigquery.job import Job
-from gcloud.aio.bigquery.table import Table
-from gcloud.aio.bigquery.utils import query_response_to_dict
+from .bigquery import Disposition
+from .bigquery import SchemaUpdateOption
+from .bigquery import SCOPES
+from .bigquery import SourceFormat
+from .dataset import Dataset
+from .job import Job
+from .table import Table
+from .utils import query_response_to_dict
 
 
+__version__ = importlib.metadata.version('gcloud-aio-bigquery')
 __all__ = [
     'Dataset',
     'Disposition',

--- a/bigquery/poetry.lock
+++ b/bigquery/poetry.lock
@@ -499,7 +499,6 @@ backoff = ">= 1.0.0, < 3.0.0"
 chardet = ">= 2.0, < 6.0"
 cryptography = ">= 2.0.0, < 42.0.0"
 pyjwt = ">= 1.5.3, < 3.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"
 
 [package.source]
 type = "directory"
@@ -510,13 +509,12 @@ name = "gcloud-aio-datastore"
 version = "7.4.0"
 description = "Python Client for Google Cloud Datastore"
 optional = false
-python-versions = ">= 3.7, < 4.0"
+python-versions = ">= 3.8, < 4.0"
 files = []
 develop = false
 
 [package.dependencies]
 gcloud-aio-auth = ">= 3.1.0, < 5.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"
 
 [package.source]
 type = "directory"
@@ -527,7 +525,7 @@ name = "gcloud-aio-storage"
 version = "8.3.0"
 description = "Python Client for Google Cloud Storage"
 optional = false
-python-versions = ">= 3.7, < 4.0"
+python-versions = ">= 3.8, < 4.0"
 files = []
 develop = false
 
@@ -536,7 +534,6 @@ aiofiles = ">= 0.6.0, < 24.0.0"
 gcloud-aio-auth = ">= 3.6.0, < 5.0.0"
 pyasn1-modules = ">= 0.2.1, < 0.3.0"
 rsa = ">= 3.1.4, < 5.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"
 
 [package.source]
 type = "directory"
@@ -798,22 +795,6 @@ files = [
 pyasn1 = ">=0.1.3"
 
 [[package]]
-name = "setuptools"
-version = "66.1.1"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "setuptools-66.1.1-py3-none-any.whl", hash = "sha256:6f590d76b713d5de4e49fe4fbca24474469f53c83632d5d0fd056f7ff7e8112b"},
-    {file = "setuptools-66.1.1.tar.gz", hash = "sha256:ac4008d396bc9cd983ea483cb7139c0240a07bbc74ffb6232fceffedc6cf03a8"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -914,4 +895,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.8, < 4.0"
-content-hash = "02f749ce1aaaf4c351fa646e3f40d2b2edd6ea40a431f30aad5fedc0a646b90d"
+content-hash = "d56aeb37235d0edc6ac19ef8002f7cd1a989f8de2b114e685b9ee59e465ce687"

--- a/bigquery/poetry.rest.lock
+++ b/bigquery/poetry.rest.lock
@@ -278,7 +278,6 @@ chardet = ">= 2.0, < 6.0"
 cryptography = ">= 2.0.0, < 42.0.0"
 pyjwt = ">= 1.5.3, < 3.0.0"
 requests = ">= 2.2.1, < 3.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"
 
 [package.source]
 type = "directory"
@@ -295,7 +294,6 @@ develop = false
 
 [package.dependencies]
 gcloud-rest-auth = ">= 3.1.0, < 5.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"
 
 [package.source]
 type = "directory"
@@ -314,7 +312,6 @@ develop = false
 gcloud-rest-auth = ">= 3.6.0, < 5.0.0"
 pyasn1-modules = ">= 0.2.1, < 0.3.0"
 rsa = ">= 3.1.4, < 5.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"
 
 [package.source]
 type = "directory"
@@ -496,22 +493,6 @@ files = [
 pyasn1 = ">=0.1.3"
 
 [[package]]
-name = "setuptools"
-version = "66.1.1"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "setuptools-66.1.1-py3-none-any.whl", hash = "sha256:6f590d76b713d5de4e49fe4fbca24474469f53c83632d5d0fd056f7ff7e8112b"},
-    {file = "setuptools-66.1.1.tar.gz", hash = "sha256:ac4008d396bc9cd983ea483cb7139c0240a07bbc74ffb6232fceffedc6cf03a8"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -542,4 +523,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.8, < 4.0"
-content-hash = "6e6d2b6ee6c52aff39eb63c5ab502137fc13512af43f12e0f0ba0b99eb3634d1"
+content-hash = "724f205ad482559b90a7581a5f2caa082cc61280cff97bd71ca97510f60e2869"

--- a/bigquery/pyproject.rest.toml
+++ b/bigquery/pyproject.rest.toml
@@ -22,7 +22,6 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">= 3.8, < 4.0"
 gcloud-rest-auth = ">= 3.1.0, < 5.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"  # TODO: upgrade to PEP 420 namespace packages
 
 [tool.poetry.dev-dependencies]
 gcloud-rest-auth = { path = "../auth" }

--- a/bigquery/pyproject.toml
+++ b/bigquery/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">= 3.8, < 4.0"
 gcloud-aio-auth = ">= 3.1.0, < 5.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"  # TODO: upgrade to PEP 420 namespace packages
 
 [tool.poetry.dev-dependencies]
 gcloud-aio-auth = { path = "../auth" }

--- a/datastore/gcloud/__init__.py
+++ b/datastore/gcloud/__init__.py
@@ -1,9 +1,0 @@
-"""
-.. include:: ../../docs/gcloud.md
-"""
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/datastore/gcloud/aio/__init__.py
+++ b/datastore/gcloud/aio/__init__.py
@@ -1,9 +1,0 @@
-"""
-.. include:: ../../../docs/aio.md
-"""
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/datastore/gcloud/aio/datastore/__init__.py
+++ b/datastore/gcloud/aio/datastore/__init__.py
@@ -175,41 +175,41 @@ class MyGQLQuery(gcloud.aio.datastore.GQLQuery):
     value_kind = MyValue
 ```
 """
-from pkg_resources import get_distribution
-__version__ = get_distribution('gcloud-aio-datastore').version
+import importlib.metadata
 
-from gcloud.aio.datastore.constants import CompositeFilterOperator
-from gcloud.aio.datastore.constants import Consistency
-from gcloud.aio.datastore.constants import Direction
-from gcloud.aio.datastore.constants import Mode
-from gcloud.aio.datastore.constants import MoreResultsType
-from gcloud.aio.datastore.constants import Operation
-from gcloud.aio.datastore.constants import PropertyFilterOperator
-from gcloud.aio.datastore.constants import ResultType
-from gcloud.aio.datastore.datastore import Datastore
-from gcloud.aio.datastore.datastore import SCOPES
-from gcloud.aio.datastore.datastore_operation import DatastoreOperation
-from gcloud.aio.datastore.entity import Entity
-from gcloud.aio.datastore.entity import EntityResult
-from gcloud.aio.datastore.filter import CompositeFilter
-from gcloud.aio.datastore.filter import Filter
-from gcloud.aio.datastore.filter import PropertyFilter
-from gcloud.aio.datastore.key import Key
-from gcloud.aio.datastore.key import PathElement
-from gcloud.aio.datastore.lat_lng import LatLng
-from gcloud.aio.datastore.mutation import MutationResult
-from gcloud.aio.datastore.projection import Projection
-from gcloud.aio.datastore.property_order import PropertyOrder
-from gcloud.aio.datastore.transaction_options import ReadOnly
-from gcloud.aio.datastore.transaction_options import ReadWrite
-from gcloud.aio.datastore.transaction_options import TransactionOptions
-from gcloud.aio.datastore.query import GQLCursor
-from gcloud.aio.datastore.query import GQLQuery
-from gcloud.aio.datastore.query import Query
-from gcloud.aio.datastore.query import QueryResultBatch
-from gcloud.aio.datastore.value import Value
+from .constants import CompositeFilterOperator
+from .constants import Consistency
+from .constants import Direction
+from .constants import Mode
+from .constants import MoreResultsType
+from .constants import Operation
+from .constants import PropertyFilterOperator
+from .constants import ResultType
+from .datastore import Datastore
+from .datastore import SCOPES
+from .datastore_operation import DatastoreOperation
+from .entity import Entity
+from .entity import EntityResult
+from .filter import CompositeFilter
+from .filter import Filter
+from .filter import PropertyFilter
+from .key import Key
+from .key import PathElement
+from .lat_lng import LatLng
+from .mutation import MutationResult
+from .projection import Projection
+from .property_order import PropertyOrder
+from .query import GQLCursor
+from .query import GQLQuery
+from .query import Query
+from .query import QueryResultBatch
+from .transaction_options import ReadOnly
+from .transaction_options import ReadWrite
+from .transaction_options import TransactionOptions
+from .value import Value
 
 
+__version__ = importlib.metadata.version('gcloud-aio-datastore')
 __all__ = [
     'CompositeFilter',
     'CompositeFilterOperator',

--- a/datastore/gcloud/aio/datastore/array.py
+++ b/datastore/gcloud/aio/datastore/array.py
@@ -3,7 +3,7 @@ from typing import Any
 from typing import Dict
 from typing import List
 
-from gcloud.aio.datastore import value
+from . import value
 
 
 # https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects/runQuery#ArrayValue

--- a/datastore/gcloud/aio/datastore/constants.py
+++ b/datastore/gcloud/aio/datastore/constants.py
@@ -1,7 +1,7 @@
 import enum
 from datetime import datetime as dt
 
-from gcloud.aio.datastore.lat_lng import LatLng
+from .lat_lng import LatLng
 
 
 class CompositeFilterOperator(enum.Enum):

--- a/datastore/gcloud/aio/datastore/datastore.py
+++ b/datastore/gcloud/aio/datastore/datastore.py
@@ -13,17 +13,18 @@ from typing import Union
 from gcloud.aio.auth import AioSession  # pylint: disable=no-name-in-module
 from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
 from gcloud.aio.auth import Token  # pylint: disable=no-name-in-module
-from gcloud.aio.datastore.constants import Consistency
-from gcloud.aio.datastore.constants import Mode
-from gcloud.aio.datastore.constants import Operation
-from gcloud.aio.datastore.datastore_operation import DatastoreOperation
-from gcloud.aio.datastore.entity import EntityResult
-from gcloud.aio.datastore.key import Key
-from gcloud.aio.datastore.mutation import MutationResult
-from gcloud.aio.datastore.query import BaseQuery
-from gcloud.aio.datastore.query import QueryResultBatch
-from gcloud.aio.datastore.transaction_options import TransactionOptions
-from gcloud.aio.datastore.value import Value
+
+from .constants import Consistency
+from .constants import Mode
+from .constants import Operation
+from .datastore_operation import DatastoreOperation
+from .entity import EntityResult
+from .key import Key
+from .mutation import MutationResult
+from .query import BaseQuery
+from .query import QueryResultBatch
+from .transaction_options import TransactionOptions
+from .value import Value
 
 # Selectively load libraries based on the package
 if BUILD_GCLOUD_REST:

--- a/datastore/gcloud/aio/datastore/entity.py
+++ b/datastore/gcloud/aio/datastore/entity.py
@@ -2,8 +2,8 @@ from typing import Any
 from typing import Dict
 from typing import Optional
 
-from gcloud.aio.datastore.key import Key
-from gcloud.aio.datastore.value import Value
+from .key import Key
+from .value import Value
 
 
 class Entity:

--- a/datastore/gcloud/aio/datastore/filter.py
+++ b/datastore/gcloud/aio/datastore/filter.py
@@ -2,9 +2,9 @@ from typing import Any
 from typing import Dict
 from typing import List
 
-from gcloud.aio.datastore.constants import CompositeFilterOperator
-from gcloud.aio.datastore.constants import PropertyFilterOperator
-from gcloud.aio.datastore.value import Value
+from .constants import CompositeFilterOperator
+from .constants import PropertyFilterOperator
+from .value import Value
 
 
 class BaseFilter:

--- a/datastore/gcloud/aio/datastore/mutation.py
+++ b/datastore/gcloud/aio/datastore/mutation.py
@@ -2,7 +2,7 @@ from typing import Any
 from typing import Dict
 from typing import Optional
 
-from gcloud.aio.datastore.key import Key
+from .key import Key
 
 
 # https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects/commit#Mutation

--- a/datastore/gcloud/aio/datastore/property_order.py
+++ b/datastore/gcloud/aio/datastore/property_order.py
@@ -1,7 +1,7 @@
 from typing import Any
 from typing import Dict
 
-from gcloud.aio.datastore.constants import Direction
+from .constants import Direction
 
 
 # https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects/runQuery#PropertyOrder

--- a/datastore/gcloud/aio/datastore/query.py
+++ b/datastore/gcloud/aio/datastore/query.py
@@ -3,13 +3,13 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-from gcloud.aio.datastore.constants import MoreResultsType
-from gcloud.aio.datastore.constants import ResultType
-from gcloud.aio.datastore.entity import EntityResult
-from gcloud.aio.datastore.filter import Filter
-from gcloud.aio.datastore.projection import Projection
-from gcloud.aio.datastore.property_order import PropertyOrder
-from gcloud.aio.datastore.value import Value
+from .constants import MoreResultsType
+from .constants import ResultType
+from .entity import EntityResult
+from .filter import Filter
+from .projection import Projection
+from .property_order import PropertyOrder
+from .value import Value
 
 
 class BaseQuery:

--- a/datastore/gcloud/aio/datastore/value.py
+++ b/datastore/gcloud/aio/datastore/value.py
@@ -3,9 +3,9 @@ from datetime import datetime
 from typing import Any
 from typing import Dict
 
-from gcloud.aio.datastore.constants import TypeName
-from gcloud.aio.datastore.constants import TYPES
-from gcloud.aio.datastore.key import Key
+from .constants import TypeName
+from .constants import TYPES
+from .key import Key
 
 
 # https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects/runQuery#value
@@ -97,8 +97,8 @@ class Value:  # pylint:disable=useless-object-inheritance
     @classmethod
     def _get_supported_types(cls) -> Dict[Any, TypeName]:
         # pylint: disable=import-outside-toplevel,cyclic-import
-        from gcloud.aio.datastore import array
-        from gcloud.aio.datastore import entity
+        from . import array
+        from . import entity
 
         supported_types = TYPES
         supported_types.update({

--- a/datastore/poetry.lock
+++ b/datastore/poetry.lock
@@ -499,7 +499,6 @@ backoff = ">= 1.0.0, < 3.0.0"
 chardet = ">= 2.0, < 6.0"
 cryptography = ">= 2.0.0, < 42.0.0"
 pyjwt = ">= 1.5.3, < 3.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"
 
 [package.source]
 type = "directory"
@@ -510,7 +509,7 @@ name = "gcloud-aio-storage"
 version = "8.3.0"
 description = "Python Client for Google Cloud Storage"
 optional = false
-python-versions = ">= 3.7, < 4.0"
+python-versions = ">= 3.8, < 4.0"
 files = []
 develop = false
 
@@ -519,7 +518,6 @@ aiofiles = ">= 0.6.0, < 24.0.0"
 gcloud-aio-auth = ">= 3.6.0, < 5.0.0"
 pyasn1-modules = ">= 0.2.1, < 0.3.0"
 rsa = ">= 3.1.4, < 5.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"
 
 [package.source]
 type = "directory"
@@ -781,22 +779,6 @@ files = [
 pyasn1 = ">=0.1.3"
 
 [[package]]
-name = "setuptools"
-version = "66.1.1"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "setuptools-66.1.1-py3-none-any.whl", hash = "sha256:6f590d76b713d5de4e49fe4fbca24474469f53c83632d5d0fd056f7ff7e8112b"},
-    {file = "setuptools-66.1.1.tar.gz", hash = "sha256:ac4008d396bc9cd983ea483cb7139c0240a07bbc74ffb6232fceffedc6cf03a8"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -897,4 +879,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.8, < 4.0"
-content-hash = "c128f0ddf2369adfd26a65b40ec975af4297b9effcd46fb493c65e283aae395d"
+content-hash = "13601470d84f07b8ba04bdc8cad4fea1090dc891cb0d8441b21be6a14ec17278"

--- a/datastore/poetry.rest.lock
+++ b/datastore/poetry.rest.lock
@@ -278,7 +278,6 @@ chardet = ">= 2.0, < 6.0"
 cryptography = ">= 2.0.0, < 42.0.0"
 pyjwt = ">= 1.5.3, < 3.0.0"
 requests = ">= 2.2.1, < 3.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"
 
 [package.source]
 type = "directory"
@@ -297,7 +296,6 @@ develop = false
 gcloud-rest-auth = ">= 3.6.0, < 5.0.0"
 pyasn1-modules = ">= 0.2.1, < 0.3.0"
 rsa = ">= 3.1.4, < 5.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"
 
 [package.source]
 type = "directory"
@@ -479,22 +477,6 @@ files = [
 pyasn1 = ">=0.1.3"
 
 [[package]]
-name = "setuptools"
-version = "66.1.1"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "setuptools-66.1.1-py3-none-any.whl", hash = "sha256:6f590d76b713d5de4e49fe4fbca24474469f53c83632d5d0fd056f7ff7e8112b"},
-    {file = "setuptools-66.1.1.tar.gz", hash = "sha256:ac4008d396bc9cd983ea483cb7139c0240a07bbc74ffb6232fceffedc6cf03a8"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -525,4 +507,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.8, < 4.0"
-content-hash = "2b2cb3db940c6b135e23d8c51dc2a90568c684b7a844bebff7442b6db5306665"
+content-hash = "0cf8115e7977a3f26907ff783c5ee1f315f1b90b0b2422d7870742579ad36fdd"

--- a/datastore/pyproject.rest.toml
+++ b/datastore/pyproject.rest.toml
@@ -22,7 +22,6 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">= 3.8, < 4.0"
 gcloud-rest-auth = ">= 3.1.0, < 5.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"  # TODO: upgrade to PEP 420 namespace packages
 
 [tool.poetry.dev-dependencies]
 # aiohttp = ">= 3.3.0, < 4.0.0"

--- a/datastore/pyproject.toml
+++ b/datastore/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">= 3.8, < 4.0"
 gcloud-aio-auth = ">= 3.1.0, < 5.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"  # TODO: upgrade to PEP 420 namespace packages
 
 [tool.poetry.dev-dependencies]
 aiohttp = ">= 3.3.0, < 4.0.0"

--- a/kms/gcloud/__init__.py
+++ b/kms/gcloud/__init__.py
@@ -1,9 +1,0 @@
-"""
-.. include:: ../../docs/gcloud.md
-"""
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/kms/gcloud/aio/__init__.py
+++ b/kms/gcloud/aio/__init__.py
@@ -1,9 +1,0 @@
-"""
-.. include:: ../../../docs/aio.md
-"""
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/kms/gcloud/aio/kms/__init__.py
+++ b/kms/gcloud/aio/kms/__init__.py
@@ -38,13 +38,13 @@ For testing purposes, you may want to use `gcloud-aio-kms` along with a local
 emulator. Setting the `$KMS_EMULATOR_HOST` environment variable to the address
 of your emulator should be enough to do the trick.
 """
-from pkg_resources import get_distribution
-__version__ = get_distribution('gcloud-aio-kms').version
+import importlib.metadata
 
-from gcloud.aio.kms.kms import KMS
-from gcloud.aio.kms.kms import SCOPES
-from gcloud.aio.kms.utils import decode
-from gcloud.aio.kms.utils import encode
+from .kms import KMS
+from .kms import SCOPES
+from .utils import decode
+from .utils import encode
 
 
+__version__ = importlib.metadata.version('gcloud-aio-kms')
 __all__ = ['__version__', 'decode', 'encode', 'KMS', 'SCOPES']

--- a/kms/poetry.lock
+++ b/kms/poetry.lock
@@ -488,7 +488,6 @@ backoff = ">= 1.0.0, < 3.0.0"
 chardet = ">= 2.0, < 6.0"
 cryptography = ">= 2.0.0, < 42.0.0"
 pyjwt = ">= 1.5.3, < 3.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"
 
 [package.source]
 type = "directory"
@@ -676,22 +675,6 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
-name = "setuptools"
-version = "66.1.1"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "setuptools-66.1.1-py3-none-any.whl", hash = "sha256:6f590d76b713d5de4e49fe4fbca24474469f53c83632d5d0fd056f7ff7e8112b"},
-    {file = "setuptools-66.1.1.tar.gz", hash = "sha256:ac4008d396bc9cd983ea483cb7139c0240a07bbc74ffb6232fceffedc6cf03a8"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -792,4 +775,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.8, < 4.0"
-content-hash = "cd391e50937d6606f6a5a21b09d39e27503d2fda5cab4348ac45d91471de5fe5"
+content-hash = "c48e5da36d7c6617dc9340022d571876a297ed692a148346895f91c1dc94fec9"

--- a/kms/poetry.rest.lock
+++ b/kms/poetry.rest.lock
@@ -278,7 +278,6 @@ chardet = ">= 2.0, < 6.0"
 cryptography = ">= 2.0.0, < 42.0.0"
 pyjwt = ">= 1.5.3, < 3.0.0"
 requests = ">= 2.2.1, < 3.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"
 
 [package.source]
 type = "directory"
@@ -404,22 +403,6 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
-name = "setuptools"
-version = "66.1.1"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "setuptools-66.1.1-py3-none-any.whl", hash = "sha256:6f590d76b713d5de4e49fe4fbca24474469f53c83632d5d0fd056f7ff7e8112b"},
-    {file = "setuptools-66.1.1.tar.gz", hash = "sha256:ac4008d396bc9cd983ea483cb7139c0240a07bbc74ffb6232fceffedc6cf03a8"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -450,4 +433,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.8, < 4.0"
-content-hash = "25aadf09a7297571ab461eb613984ba11b43e3809d317bb7e0297be9dc4d6ea9"
+content-hash = "176a26cdbb4e2baba02608724447c62b86737218104e34d16af8cc6c7ed7c9cf"

--- a/kms/pyproject.rest.toml
+++ b/kms/pyproject.rest.toml
@@ -22,7 +22,6 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">= 3.8, < 4.0"
 gcloud-rest-auth = ">= 3.1.0, < 5.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"  # TODO: upgrade to PEP 420 namespace packages
 
 [tool.poetry.dev-dependencies]
 gcloud-rest-auth = { path = "../auth" }

--- a/kms/pyproject.toml
+++ b/kms/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">= 3.8, < 4.0"
 gcloud-aio-auth = ">= 3.1.0, < 5.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"  # TODO: upgrade to PEP 420 namespace packages
 
 [tool.poetry.dev-dependencies]
 gcloud-aio-auth = { path = "../auth" }

--- a/pubsub/gcloud/__init__.py
+++ b/pubsub/gcloud/__init__.py
@@ -1,9 +1,0 @@
-"""
-.. include:: ../../docs/gcloud.md
-"""
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/pubsub/gcloud/aio/__init__.py
+++ b/pubsub/gcloud/aio/__init__.py
@@ -1,9 +1,0 @@
-"""
-.. include:: ../../../docs/aio.md
-"""
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/pubsub/gcloud/aio/pubsub/__init__.py
+++ b/pubsub/gcloud/aio/pubsub/__init__.py
@@ -229,15 +229,17 @@ https://github.com/TheKevJames/tools/tree/master/docker-gcloud-pubsub-emulator
 [endpoint]:
 https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/pull#request-body
 """
-from pkg_resources import get_distribution
-__version__ = get_distribution('gcloud-aio-pubsub').version
+import importlib.metadata
 
 from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
-from gcloud.aio.pubsub.publisher_client import PublisherClient
-from gcloud.aio.pubsub.subscriber_client import SubscriberClient
-from gcloud.aio.pubsub.subscriber_message import SubscriberMessage
-from gcloud.aio.pubsub.utils import PubsubMessage
 
+from .publisher_client import PublisherClient
+from .subscriber_client import SubscriberClient
+from .subscriber_message import SubscriberMessage
+from .utils import PubsubMessage
+
+
+__version__ = importlib.metadata.version('gcloud-aio-pubsub')
 __all__ = [
     'PublisherClient',
     'PubsubMessage',
@@ -247,5 +249,5 @@ __all__ = [
 ]
 
 if not BUILD_GCLOUD_REST:
-    from gcloud.aio.pubsub.subscriber import subscribe
+    from .subscriber import subscribe
     __all__.append('subscribe')

--- a/pubsub/gcloud/aio/pubsub/publisher_client.py
+++ b/pubsub/gcloud/aio/pubsub/publisher_client.py
@@ -13,7 +13,8 @@ from typing import Union
 from gcloud.aio.auth import AioSession  # pylint: disable=no-name-in-module
 from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
 from gcloud.aio.auth import Token  # pylint: disable=no-name-in-module
-from gcloud.aio.pubsub.utils import PubsubMessage
+
+from .utils import PubsubMessage
 
 # Selectively load libraries based on the package
 if BUILD_GCLOUD_REST:

--- a/pubsub/gcloud/aio/pubsub/subscriber.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber.py
@@ -17,10 +17,10 @@ else:
     from typing import TYPE_CHECKING
     from typing import TypeVar
 
-    from gcloud.aio.pubsub import metrics
-    from gcloud.aio.pubsub.subscriber_client import SubscriberClient
-    from gcloud.aio.pubsub.subscriber_message import SubscriberMessage
-    from gcloud.aio.pubsub.metrics_agent import MetricsAgent
+    from . import metrics
+    from .subscriber_client import SubscriberClient
+    from .subscriber_message import SubscriberMessage
+    from .metrics_agent import MetricsAgent
 
     log = logging.getLogger(__name__)
 

--- a/pubsub/poetry.lock
+++ b/pubsub/poetry.lock
@@ -488,7 +488,6 @@ backoff = ">= 1.0.0, < 3.0.0"
 chardet = ">= 2.0, < 6.0"
 cryptography = ">= 2.0.0, < 42.0.0"
 pyjwt = ">= 1.5.3, < 3.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"
 
 [package.source]
 type = "directory"
@@ -725,22 +724,6 @@ pytest = ">=5.0"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
-name = "setuptools"
-version = "66.1.1"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "setuptools-66.1.1-py3-none-any.whl", hash = "sha256:6f590d76b713d5de4e49fe4fbca24474469f53c83632d5d0fd056f7ff7e8112b"},
-    {file = "setuptools-66.1.1.tar.gz", hash = "sha256:ac4008d396bc9cd983ea483cb7139c0240a07bbc74ffb6232fceffedc6cf03a8"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -841,4 +824,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.8, < 4.0"
-content-hash = "039c7ab9bcede04607b2ec0a2a770261911a132b8af147aa2657b878f9a7cac9"
+content-hash = "2be60d1bacea23b1e14fa0b5c9685c3bd2f27db080b97aa09c36d3b4bcb2faf8"

--- a/pubsub/poetry.rest.lock
+++ b/pubsub/poetry.rest.lock
@@ -278,7 +278,6 @@ chardet = ">= 2.0, < 6.0"
 cryptography = ">= 2.0.0, < 42.0.0"
 pyjwt = ">= 1.5.3, < 3.0.0"
 requests = ">= 2.2.1, < 3.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"
 
 [package.source]
 type = "directory"
@@ -421,22 +420,6 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
-name = "setuptools"
-version = "66.1.1"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "setuptools-66.1.1-py3-none-any.whl", hash = "sha256:6f590d76b713d5de4e49fe4fbca24474469f53c83632d5d0fd056f7ff7e8112b"},
-    {file = "setuptools-66.1.1.tar.gz", hash = "sha256:ac4008d396bc9cd983ea483cb7139c0240a07bbc74ffb6232fceffedc6cf03a8"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -467,4 +450,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.8, < 4.0"
-content-hash = "687b7053ee09acb4c0fe0bd037b7b2d90c8be98adc006061abbb52cf8f18863d"
+content-hash = "4a3273ac0aca6debd8c6c0170f7aca3f18dc1a10639c2bb141aa7d22a2531986"

--- a/pubsub/pyproject.rest.toml
+++ b/pubsub/pyproject.rest.toml
@@ -23,7 +23,6 @@ classifiers = [
 python = ">= 3.8, < 4.0"
 gcloud-rest-auth = ">= 3.3.0, < 5.0.0"
 # prometheus-client = ">= 0.13.1, < 1.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"  # TODO: upgrade to PEP 420 namespace packages
 
 [tool.poetry.dev-dependencies]
 # aiohttp = ">= 3.3.0, < 4.0.0"

--- a/pubsub/pyproject.toml
+++ b/pubsub/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 python = ">= 3.8, < 4.0"
 gcloud-aio-auth = ">= 3.3.0, < 5.0.0"
 prometheus-client = ">= 0.13.1, < 1.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"  # TODO: upgrade to PEP 420 namespace packages
 
 [tool.poetry.dev-dependencies]
 aiohttp = ">= 3.3.0, < 4.0.0"

--- a/storage/gcloud/__init__.py
+++ b/storage/gcloud/__init__.py
@@ -1,9 +1,0 @@
-"""
-.. include:: ../../docs/gcloud.md
-"""
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/storage/gcloud/aio/__init__.py
+++ b/storage/gcloud/aio/__init__.py
@@ -1,9 +1,0 @@
-"""
-.. include:: ../../../docs/aio.md
-"""
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/storage/gcloud/aio/storage/__init__.py
+++ b/storage/gcloud/aio/storage/__init__.py
@@ -146,16 +146,16 @@ class StorageWithBackoff(gcloud.aio.storage.Storage):
 [smoke-test]:
 https://github.com/talkiq/gcloud-aio/blob/master/storage/tests/integration/smoke_test.py
 """
-from pkg_resources import get_distribution
-__version__ = get_distribution('gcloud-aio-storage').version
+import importlib.metadata
 
-from gcloud.aio.storage.blob import Blob
-from gcloud.aio.storage.bucket import Bucket
-from gcloud.aio.storage.storage import SCOPES
-from gcloud.aio.storage.storage import Storage
-from gcloud.aio.storage.storage import StreamResponse
+from .blob import Blob
+from .bucket import Bucket
+from .storage import SCOPES
+from .storage import Storage
+from .storage import StreamResponse
 
 
+__version__ = importlib.metadata.version('gcloud-aio-storage')
 __all__ = [
     'Blob',
     'Bucket',

--- a/storage/gcloud/aio/storage/blob.py
+++ b/storage/gcloud/aio/storage/blob.py
@@ -13,10 +13,11 @@ from urllib.parse import quote
 import rsa
 from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
 from gcloud.aio.auth import Token  # pylint: disable=no-name-in-module
-from gcloud.aio.storage.constants import DEFAULT_TIMEOUT
 from pyasn1.codec.der import decoder
 from pyasn1_modules import pem
 from pyasn1_modules.rfc5208 import PrivateKeyInfo
+
+from .constants import DEFAULT_TIMEOUT
 
 # Selectively load libraries based on the package
 if BUILD_GCLOUD_REST:

--- a/storage/gcloud/aio/storage/bucket.py
+++ b/storage/gcloud/aio/storage/bucket.py
@@ -6,9 +6,9 @@ from typing import Optional
 from typing import TYPE_CHECKING
 
 from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
-from gcloud.aio.storage.constants import DEFAULT_TIMEOUT
 
 from .blob import Blob
+from .constants import DEFAULT_TIMEOUT
 
 # Selectively load libraries based on the package
 if BUILD_GCLOUD_REST:

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -19,8 +19,9 @@ from urllib.parse import quote
 from gcloud.aio.auth import AioSession  # pylint: disable=no-name-in-module
 from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
 from gcloud.aio.auth import Token  # pylint: disable=no-name-in-module
-from gcloud.aio.storage.bucket import Bucket
-from gcloud.aio.storage.constants import DEFAULT_TIMEOUT
+
+from .bucket import Bucket
+from .constants import DEFAULT_TIMEOUT
 
 # Selectively load libraries based on the package
 if BUILD_GCLOUD_REST:

--- a/storage/poetry.lock
+++ b/storage/poetry.lock
@@ -499,7 +499,6 @@ backoff = ">= 1.0.0, < 3.0.0"
 chardet = ">= 2.0, < 6.0"
 cryptography = ">= 2.0.0, < 42.0.0"
 pyjwt = ">= 1.5.3, < 3.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"
 
 [package.source]
 type = "directory"
@@ -761,22 +760,6 @@ files = [
 pyasn1 = ">=0.1.3"
 
 [[package]]
-name = "setuptools"
-version = "66.1.1"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "setuptools-66.1.1-py3-none-any.whl", hash = "sha256:6f590d76b713d5de4e49fe4fbca24474469f53c83632d5d0fd056f7ff7e8112b"},
-    {file = "setuptools-66.1.1.tar.gz", hash = "sha256:ac4008d396bc9cd983ea483cb7139c0240a07bbc74ffb6232fceffedc6cf03a8"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -877,4 +860,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.8, < 4.0"
-content-hash = "60bfd91beed9657f382550f24c250f0c861c14db75d6b5efc6897270f5126cf7"
+content-hash = "233d10806d42f91fbf225d1e6ee78b7e3a14b29104a5f7b4d7edd27de516dee2"

--- a/storage/poetry.rest.lock
+++ b/storage/poetry.rest.lock
@@ -278,7 +278,6 @@ chardet = ">= 2.0, < 6.0"
 cryptography = ">= 2.0.0, < 42.0.0"
 pyjwt = ">= 1.5.3, < 3.0.0"
 requests = ">= 2.2.1, < 3.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"
 
 [package.source]
 type = "directory"
@@ -460,22 +459,6 @@ files = [
 pyasn1 = ">=0.1.3"
 
 [[package]]
-name = "setuptools"
-version = "66.1.1"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "setuptools-66.1.1-py3-none-any.whl", hash = "sha256:6f590d76b713d5de4e49fe4fbca24474469f53c83632d5d0fd056f7ff7e8112b"},
-    {file = "setuptools-66.1.1.tar.gz", hash = "sha256:ac4008d396bc9cd983ea483cb7139c0240a07bbc74ffb6232fceffedc6cf03a8"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -506,4 +489,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.8, < 4.0"
-content-hash = "e55897ae69423e2757a1dbbebf9845cd4a05dd89aa8df652cb5d38b95da875b8"
+content-hash = "17ffb5b1abf09028277369db86c43d7028e62c49ee5b47430bca3abb1aa2cdd1"

--- a/storage/pyproject.rest.toml
+++ b/storage/pyproject.rest.toml
@@ -25,7 +25,6 @@ python = ">= 3.8, < 4.0"
 gcloud-rest-auth = ">= 3.6.0, < 5.0.0"
 pyasn1-modules = ">= 0.2.1, < 0.3.0"
 rsa = ">= 3.1.4, < 5.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"  # TODO: upgrade to PEP 420 namespace packages
 
 [tool.poetry.dev-dependencies]
 gcloud-rest-auth = { path = "../auth" }

--- a/storage/pyproject.toml
+++ b/storage/pyproject.toml
@@ -25,7 +25,6 @@ aiofiles = ">= 0.6.0, < 24.0.0"
 gcloud-aio-auth = ">= 3.6.0, < 5.0.0"
 pyasn1-modules = ">= 0.2.1, < 0.3.0"
 rsa = ">= 3.1.4, < 5.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"  # TODO: upgrade to PEP 420 namespace packages
 
 [tool.poetry.dev-dependencies]
 gcloud-aio-auth = { path = "../auth" }

--- a/taskqueue/gcloud/__init__.py
+++ b/taskqueue/gcloud/__init__.py
@@ -1,9 +1,0 @@
-"""
-.. include:: ../../docs/gcloud.md
-"""
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/taskqueue/gcloud/aio/__init__.py
+++ b/taskqueue/gcloud/aio/__init__.py
@@ -1,9 +1,0 @@
-"""
-.. include:: ../../../docs/aio.md
-"""
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/taskqueue/gcloud/aio/taskqueue/__init__.py
+++ b/taskqueue/gcloud/aio/taskqueue/__init__.py
@@ -22,13 +22,13 @@ the address of your emulator should be enough to do the trick.
 [smoke-tests]:
 https://github.com/talkiq/gcloud-aio/tree/master/taskqueue/tests/integration
 """
-from pkg_resources import get_distribution
-__version__ = get_distribution('gcloud-aio-taskqueue').version
+import importlib.metadata
 
-from gcloud.aio.taskqueue.queue import PushQueue
-from gcloud.aio.taskqueue.queue import SCOPES
+from .queue import PushQueue
+from .queue import SCOPES
 
 
+__version__ = importlib.metadata.version('gcloud-aio-taskqueue')
 __all__ = [
     'PushQueue',
     'SCOPES',

--- a/taskqueue/poetry.lock
+++ b/taskqueue/poetry.lock
@@ -488,7 +488,6 @@ backoff = ">= 1.0.0, < 3.0.0"
 chardet = ">= 2.0, < 6.0"
 cryptography = ">= 2.0.0, < 42.0.0"
 pyjwt = ">= 1.5.3, < 3.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"
 
 [package.source]
 type = "directory"
@@ -711,22 +710,6 @@ pytest = ">=5.0"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
-name = "setuptools"
-version = "66.1.1"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "setuptools-66.1.1-py3-none-any.whl", hash = "sha256:6f590d76b713d5de4e49fe4fbca24474469f53c83632d5d0fd056f7ff7e8112b"},
-    {file = "setuptools-66.1.1.tar.gz", hash = "sha256:ac4008d396bc9cd983ea483cb7139c0240a07bbc74ffb6232fceffedc6cf03a8"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -827,4 +810,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.8, < 4.0"
-content-hash = "37db23f67207b41073225dee1408691990dcd2eb7ad296c0076a5ee53d94d432"
+content-hash = "3843877e643a9bb8ed77708b2229d948b24f7dd83f976056f993a772d91800b1"

--- a/taskqueue/poetry.rest.lock
+++ b/taskqueue/poetry.rest.lock
@@ -278,7 +278,6 @@ chardet = ">= 2.0, < 6.0"
 cryptography = ">= 2.0.0, < 42.0.0"
 pyjwt = ">= 1.5.3, < 3.0.0"
 requests = ">= 2.2.1, < 3.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"
 
 [package.source]
 type = "directory"
@@ -421,22 +420,6 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
-name = "setuptools"
-version = "66.1.1"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "setuptools-66.1.1-py3-none-any.whl", hash = "sha256:6f590d76b713d5de4e49fe4fbca24474469f53c83632d5d0fd056f7ff7e8112b"},
-    {file = "setuptools-66.1.1.tar.gz", hash = "sha256:ac4008d396bc9cd983ea483cb7139c0240a07bbc74ffb6232fceffedc6cf03a8"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -467,4 +450,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.8, < 4.0"
-content-hash = "e0df300a6f7b8e1d802463ec42599fad69bb8d62ed0f27f1415c31543681880b"
+content-hash = "57727b26e737de120793f99c511d36fabe9322b76aa438dbab2107c194b3de43"

--- a/taskqueue/pyproject.rest.toml
+++ b/taskqueue/pyproject.rest.toml
@@ -22,7 +22,6 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">= 3.8, < 4.0"
 gcloud-rest-auth = ">= 3.1.0, < 5.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"  # TODO: upgrade to PEP 420 namespace packages
 
 [tool.poetry.dev-dependencies]
 # aiohttp = ">= 3.3.0, < 4.0.0"

--- a/taskqueue/pyproject.toml
+++ b/taskqueue/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">= 3.8, < 4.0"
 gcloud-aio-auth = ">= 3.1.0, < 5.0.0"
-setuptools = ">= 66.0.0, < 67.0.0"  # TODO: upgrade to PEP 420 namespace packages
 
 [tool.poetry.dev-dependencies]
 aiohttp = ">= 3.3.0, < 4.0.0"


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant issues / branches / other PRs / blockers / etc.
--->
Finally upgrade to PEP420 namespace packages and remove pkg_resources. Uses
importlib-metadata as a py37 backport stepping-stone.
