### PR TITLE
fix(auth): reset token acquisition future after failure

### DIFF
--- a/auth/gcloud/aio/auth/token.py
+++ b/auth/gcloud/aio/auth/token.py
@@ -195,7 +195,7 @@ class Token:
         return self.access_token
 
     async def ensure_token(self) -> None:
-        if self.acquiring and not self.acquiring.cancelled():
+        if self.acquiring and not self.acquiring.done():
             await self.acquiring
             return
 


### PR DESCRIPTION
## Summary

If `self.acquire_access_token()` fails for any reason other than task
cancellation, we currently never detect it and will repeatedly raise
the exception upon waiting for the token.

See https://github.com/talkiq/gcloud-aio/pull/500 for further details of
where this issue was first surfaced but only partially fixed.

