### PR TITLE
chore(release): bump auth version

### DIFF
--- a/auth/pyproject.toml
+++ b/auth/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcloud-aio-auth"
-version = "4.2.2"
+version = "4.2.3"
 description = "Python Client for Google Cloud Auth"
 readme = "README.rst"
 


### PR DESCRIPTION
## Summary
Bumping auth to include patch: https://github.com/talkiq/gcloud-aio/pull/628