### PR TITLE
Accept the official format for `STORAGE_EMULATOR_HOST` env var

### DIFF
--- a/storage/gcloud/aio/storage/__init__.py
+++ b/storage/gcloud/aio/storage/__init__.py
@@ -107,7 +107,7 @@ For example, using [fsouza/fake-gcs-server][fake-gcs-server], you can do:
 
 ```shell
 docker run -d -p 4443:4443 -v $PWD/my-sample-data:/data fsouza/fake-gcs-server
-export STORAGE_EMULATOR_HOST='0.0.0.0:4443'
+export STORAGE_EMULATOR_HOST='http://0.0.0.0:4443'
 ```
 
 Any `gcloud-aio-storage` requests made with that environment variable set will

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -5,6 +5,7 @@ import json
 import logging
 import mimetypes
 import os
+import warnings
 from typing import Any
 from typing import AnyStr
 from typing import Dict
@@ -51,6 +52,10 @@ def init_api_root(api_root: Optional[str]) -> Tuple[bool, str]:
 
     host = os.environ.get('STORAGE_EMULATOR_HOST')
     if host:
+        if not host.startswith('http'):
+            warnings.warn('STORAGE_EMULATOR_HOST must include http:// prefix',
+                          DeprecationWarning)
+            host = f'http://{host}'
         return True, host
 
     return False, 'https://www.googleapis.com'

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -51,7 +51,7 @@ def init_api_root(api_root: Optional[str]) -> Tuple[bool, str]:
 
     host = os.environ.get('STORAGE_EMULATOR_HOST')
     if host:
-        return True, f'http://{host}'
+        return True, host
 
     return False, 'https://www.googleapis.com'
 


### PR DESCRIPTION
## Summary
In order for this library to be compatible with the official python Google Cloud Storage library, it needs to accept the same value for configuring the `STORAGE_EMULATOR_HOST` environment variable. This will allow users to rely on both libraries in a single project.

Fixes: https://github.com/talkiq/gcloud-aio/issues/631