### PR TITLE
Unpins `cryptography` in order to expedite CVE patches

### DIFF
--- a/auth/pyproject.rest.toml
+++ b/auth/pyproject.rest.toml
@@ -24,7 +24,7 @@ python = ">= 3.7, < 4.0"
 # aiohttp = ">= 3.3.0, < 4.0.0"
 backoff = ">= 1.0.0, < 3.0.0"
 chardet = ">= 2.0, < 6.0"
-cryptography = ">= 2.0.0, < 42.0.0"
+cryptography = ">=42.0.1"
 pyjwt = ">= 1.5.3, < 3.0.0"
 requests = ">= 2.2.1, < 3.0.0"
 setuptools = ">= 66.0.0, < 67.0.0"  # TODO: upgrade to PEP 420 namespace packages

--- a/auth/pyproject.toml
+++ b/auth/pyproject.toml
@@ -24,7 +24,7 @@ python = ">= 3.7, < 4.0"
 aiohttp = ">= 3.3.0, < 4.0.0"
 backoff = ">= 1.0.0, < 3.0.0"
 chardet = ">= 2.0, < 6.0"
-cryptography = ">= 2.0.0, < 42.0.0"
+cryptography = ">=42.0.1"
 pyjwt = ">= 1.5.3, < 3.0.0"
 # requests = ">= 2.2.1, < 3.0.0"
 setuptools = ">= 66.0.0, < 67.0.0"  # TODO: upgrade to PEP 420 namespace packages


### PR DESCRIPTION
## Summary

There have been a couple of `cryptography` CVEs (the most recent being
CVE-2023-38325), which often requires upgrading to a new _major_ version of
`cryptography` due to their somewhat quirky versioning scheme.  Having an
upstream dependency like `gcloud-aio-*` that pins an upper version of a
security-critical library like `cryptography` is very inconvenient, and often
requires users to manually install a newer version or wait to patch a CVE.

I'm proposing that we make an exception to the typical requirements style of the
`gcloud-aio` packages (to pin an upper major version) to expedite these kinds of
things.  Anecdotally, I can't recall ever seeing breaking changes in a major
version bump of `cryptography`, especially at its current state of maturity.
