### PR TITLE
perf(auth): avoid unnecessary token refresh on get_project()

### DIFF
--- a/auth/gcloud/aio/auth/token.py
+++ b/auth/gcloud/aio/auth/token.py
@@ -183,6 +183,8 @@ class BaseToken:
             or os.environ.get('GCLOUD_PROJECT')
             or os.environ.get('APPLICATION_ID')
         )
+        if project:
+            return project
 
         if self.token_type == Type.GCE_METADATA:
             await self.ensure_token()
@@ -191,16 +193,15 @@ class BaseToken:
                 headers=GCE_METADATA_HEADERS,
             )
 
-            if not project:
-                try:
-                    project = await resp.text()
-                except (AttributeError, TypeError):
-                    project = str(resp.text)
+            try:
+                return await resp.text()
+            except (AttributeError, TypeError):
+                return str(resp.text)
 
-        elif self.token_type == Type.SERVICE_ACCOUNT:
-            project = project or self.service_data.get('project_id')
+        if self.token_type == Type.SERVICE_ACCOUNT:
+            return self.service_data.get('project_id')
 
-        return project
+        return None
 
     async def get(self) -> Optional[str]:
         await self.ensure_token()


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant issues / branches / other PRs / blockers / etc.
--->
Perf optimization: for GCE_METADATA tokens, there's no hit the token refresh
endpoint when we're only looking to call `get_project()` and have the value set
locally.
