### PR TITLE
fix(auth): correctly set ssl flag for aio

### DIFF
--- a/auth/gcloud/aio/auth/session.py
+++ b/auth/gcloud/aio/auth/session.py
@@ -139,10 +139,19 @@ if not BUILD_GCLOUD_REST:
         _session: aiohttp.ClientSession  # type: ignore[assignment]
         _timeout: Timeout  # type: ignore[assignment]
 
+        # N.B. `aiohttp.TCPConnector` SSL config is not true / false / CA
+        # bundle path like `requests`, but `None` / false / object instead:
+        # * `None` for default SSL check
+        # * `False` to skip SSL certificate validation
+        # * `aiohttp.Fingerprint` for fingerprint validation
+        # * `ssl.SSLContext` for custom SSL certificate validation
+        #
+        # https://docs.aiohttp.org/en/v3.9.1/client_reference.html#aiohttp.TCPConnector
         @property
         def session(self) -> aiohttp.ClientSession:  # type: ignore[override]
             if not self._session:
-                connector = aiohttp.TCPConnector(ssl=self._ssl)
+                connector = aiohttp.TCPConnector(
+                    ssl=None if self._ssl else False)
 
                 if isinstance(self._timeout, aiohttp.ClientTimeout):
                     timeout = self._timeout

--- a/auth/pyproject.rest.toml
+++ b/auth/pyproject.rest.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcloud-rest-auth"
-version = "5.1.1"
+version = "5.1.2"
 description = "Python Client for Google Cloud Auth"
 readme = "README.rst"
 

--- a/auth/pyproject.toml
+++ b/auth/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcloud-aio-auth"
-version = "5.1.1"
+version = "5.1.2"
 description = "Python Client for Google Cloud Auth"
 readme = "README.rst"
 


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant issues / branches / other PRs / blockers / etc.
--->

* Pull in perf change: https://github.com/talkiq/gcloud-aio/pull/653
* Fix `ssl` flag for `gcloud-aio-auth`
* Fix flaky BQ integration tests with `backoff`
