### PR TITLE
feat(auth): add support for service account impersonation

### DIFF
--- a/auth/gcloud/aio/auth/__init__.py
+++ b/auth/gcloud/aio/auth/__init__.py
@@ -63,6 +63,15 @@ The ``Token`` constructor accepts the following optional arguments:
   ``Token.close()`` method to ensure the session is cleaned up appropriately.
 * ``scopes``: an optional list of GCP `scopes`_ for which to generate our
   token. Only valid (and required!) for `service account`_ authentication.
+* ``target_principal``: The service account to generate the access token for.
+  The **roles/iam.serviceAccounts.getAccessToken** role on that service account
+  is required.
+* ``delegates``: The sequence of service accounts in a delegation chain.
+  This field is required for delegated requests.
+  Each service account must be granted the **roles/iam.serviceAccountTokenCreator**
+  role on its next service account in the chain. The last service account in
+  the chain must be granted the **roles/iam.serviceAccountTokenCreator** role
+  on the service account that is specified in the ``target_principal``.
 
 CLI
 ---

--- a/auth/gcloud/aio/auth/token.py
+++ b/auth/gcloud/aio/auth/token.py
@@ -59,6 +59,10 @@ GCE_ENDPOINT_ID_TOKEN = (
     f'{GCE_METADATA_BASE}/instance/service-accounts'
     '/default/identity?audience={audience}'
 )
+GCLOUD_ENDPOINT_GENERATE_ACCESS_TOKEN = (
+    'https://iamcredentials.googleapis.com'
+    '/v1/projects/-/serviceAccounts/{service_account}:generateAccessToken'
+)
 GCLOUD_ENDPOINT_GENERATE_ID_TOKEN = (
     'https://iamcredentials.googleapis.com'
     '/v1/projects/-/serviceAccounts/{service_account}:generateIdToken'
@@ -254,15 +258,20 @@ class Token(BaseToken):
         self, service_file: Optional[Union[str, IO[AnyStr]]] = None,
         session: Optional[Session] = None,
         scopes: Optional[List[str]] = None,
+        target_principal: Optional[str] = None,
+        delegates: Optional[List[str]] = None,
     ) -> None:
         super().__init__(service_file=service_file, session=session)
 
         self.scopes = ' '.join(scopes or [])
-        if self.token_type == Type.SERVICE_ACCOUNT and not self.scopes:
+        if (self.token_type == Type.SERVICE_ACCOUNT
+                or target_principal) and not self.scopes:
             raise Exception(
                 'scopes must be provided when token type is '
-                'service account',
+                'service account or using target_principal',
             )
+        self.target_principal = target_principal
+        self.delegates = delegates
 
     async def _refresh_authorized_user(self, timeout: int) -> TokenResponse:
         payload = urlencode({
@@ -326,6 +335,25 @@ class Token(BaseToken):
             resp = await self._refresh_service_account(timeout=timeout)
         else:
             raise Exception(f'unsupported token type {self.token_type}')
+
+        # impersonate the target principal with optional delegates
+        if self.target_principal:
+            headers = {
+                'Authorization': f'Bearer {resp.value}',
+            }
+            payload = json.dumps({
+                'lifetime': f'{self.default_token_ttl}s',
+                'scope': self.scopes.split(' '),
+                'delegates': self.delegates,
+            })
+
+            impersonation_resp = await self.session.post(
+                GCLOUD_ENDPOINT_GENERATE_ACCESS_TOKEN.format(
+                    service_account=self.target_principal),
+                data=payload, headers=headers, timeout=timeout)
+
+            impersonation_content = await impersonation_resp.json()
+            resp.value = str(impersonation_content['accessToken'])
 
         return resp
 

--- a/bigquery/gcloud/aio/bigquery/bigquery.py
+++ b/bigquery/gcloud/aio/bigquery/bigquery.py
@@ -6,6 +6,7 @@ from typing import Any
 from typing import AnyStr
 from typing import Dict
 from typing import IO
+from typing import List
 from typing import Optional
 from typing import Tuple
 from typing import Union
@@ -70,12 +71,16 @@ class BigqueryBase:
             service_file: Optional[Union[str, IO[AnyStr]]] = None,
             session: Optional[Session] = None, token: Optional[Token] = None,
             api_root: Optional[str] = None,
+            target_principal: Optional[str] = None,
+            delegates: Optional[List[str]] = None,
     ) -> None:
         self._api_is_dev, self._api_root = init_api_root(api_root)
         self.session = AioSession(session)
         self.token = token or Token(
             service_file=service_file, scopes=SCOPES,
             session=self.session.session,  # type: ignore[arg-type]
+            target_principal=target_principal,
+            delegates=delegates,
         )
 
         self._project = project

--- a/datastore/gcloud/aio/datastore/datastore.py
+++ b/datastore/gcloud/aio/datastore/datastore.py
@@ -72,6 +72,8 @@ class Datastore:
             service_file: Optional[Union[str, IO[AnyStr]]] = None,
             namespace: str = '', session: Optional[Session] = None,
             token: Optional[Token] = None, api_root: Optional[str] = None,
+            target_principal: Optional[str] = None,
+            delegates: Optional[List[str]] = None,
     ) -> None:
         self._api_is_dev, self._api_root = init_api_root(api_root)
         self.namespace = namespace
@@ -79,6 +81,8 @@ class Datastore:
         self.token = token or Token(
             service_file=service_file, scopes=SCOPES,
             session=self.session.session,  # type: ignore[arg-type]
+            target_principal=target_principal,
+            delegates=delegates,
         )
 
         self._project = project

--- a/kms/gcloud/aio/kms/kms.py
+++ b/kms/gcloud/aio/kms/kms.py
@@ -7,6 +7,7 @@ from typing import Any
 from typing import AnyStr
 from typing import Dict
 from typing import IO
+from typing import List
 from typing import Optional
 from typing import Tuple
 from typing import Union
@@ -47,6 +48,8 @@ class KMS:
             service_file: Optional[Union[str, IO[AnyStr]]] = None,
             location: str = 'global', session: Optional[Session] = None,
             token: Optional[Token] = None, api_root: Optional[str] = None,
+            target_principal: Optional[str] = None,
+            delegates: Optional[List[str]] = None,
     ) -> None:
         self._api_is_dev, self._api_root = init_api_root(api_root)
         self._api_root = (
@@ -59,6 +62,8 @@ class KMS:
             service_file=service_file,
             session=self.session.session,  # type: ignore[arg-type]
             scopes=SCOPES,
+            target_principal=target_principal,
+            delegates=delegates,
         )
 
     async def headers(self) -> Dict[str, str]:

--- a/pubsub/gcloud/aio/pubsub/publisher_client.py
+++ b/pubsub/gcloud/aio/pubsub/publisher_client.py
@@ -50,6 +50,8 @@ class PublisherClient:
             self, *, service_file: Optional[Union[str, IO[AnyStr]]] = None,
             session: Optional[Session] = None, token: Optional[Token] = None,
             api_root: Optional[str] = None,
+            target_principal: Optional[str] = None,
+            delegates: Optional[List[str]] = None,
     ) -> None:
         self._api_is_dev, self._api_root = init_api_root(api_root)
 
@@ -57,6 +59,8 @@ class PublisherClient:
         self.token = token or Token(
             service_file=service_file, scopes=SCOPES,
             session=self.session.session,  # type: ignore[arg-type]
+            target_principal=target_principal,
+            delegates=delegates,
         )
 
     @staticmethod

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -45,6 +45,8 @@ class SubscriberClient:
             self, *, service_file: Optional[Union[str, IO[AnyStr]]] = None,
             token: Optional[Token] = None, session: Optional[Session] = None,
             api_root: Optional[str] = None,
+            target_principal: Optional[str] = None,
+            delegates: Optional[List[str]] = None,
     ) -> None:
         self._api_is_dev, self._api_root = init_api_root(api_root)
 
@@ -52,6 +54,8 @@ class SubscriberClient:
         self.token = token or Token(
             service_file=service_file, scopes=SCOPES,
             session=self.session.session,  # type: ignore[arg-type]
+            target_principal=target_principal,
+            delegates=delegates,
         )
 
     @staticmethod

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -159,6 +159,8 @@ class Storage:
             self, *, service_file: Optional[Union[str, IO[AnyStr]]] = None,
             token: Optional[Token] = None, session: Optional[Session] = None,
             api_root: Optional[str] = None,
+            target_principal: Optional[str] = None,
+            delegates: Optional[List[str]] = None,
     ) -> None:
         self._api_is_dev, self._api_root = init_api_root(api_root)
         self._api_root_read = f'{self._api_root}/storage/v1/b'
@@ -168,6 +170,8 @@ class Storage:
         self.token = token or Token(
             service_file=service_file, scopes=SCOPES,
             session=self.session.session,  # type: ignore[arg-type]
+            target_principal=target_principal,
+            delegates=delegates,
         )
 
     async def _headers(self) -> Dict[str, str]:

--- a/taskqueue/gcloud/aio/taskqueue/queue.py
+++ b/taskqueue/gcloud/aio/taskqueue/queue.py
@@ -8,6 +8,7 @@ from typing import Any
 from typing import AnyStr
 from typing import Dict
 from typing import IO
+from typing import List
 from typing import Optional
 from typing import Tuple
 from typing import Union
@@ -50,6 +51,8 @@ class PushQueue:
             service_file: Optional[Union[str, IO[AnyStr]]] = None,
             session: Optional[Session] = None, token: Optional[Token] = None,
             api_root: Optional[str] = None,
+            target_principal: Optional[str] = None,
+            delegates: Optional[List[str]] = None,
     ) -> None:
         self._api_is_dev, self._api_root = init_api_root(api_root)
         self._queue_path = (
@@ -60,6 +63,8 @@ class PushQueue:
         self.token = token or Token(
             service_file=service_file, scopes=SCOPES,
             session=self.session.session,  # type: ignore[arg-type]
+            target_principal=target_principal,
+            delegates=delegates,
         )
 
     async def headers(self) -> Dict[str, str]:


### PR DESCRIPTION
## Summary

Added the arguments `target_principal` and `delegates` which optionally define an impersonation chain for the given target principal to the Token class and related clients.

The request to generate the impersonated access token is made via the IAM credentials API method [projects.serviceAccounts.generateAccessToken](https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken).

Test skeletons have been added. Those tests are currently skipped as
they require additional setup of the testing environment with additional
service accounts which are to be impersonated:

- `sa_a` to be impersonated by the base service account
- `sa_b` to be impersonated by `sa_a` via delegation

closes #421 
