### PR TITLE
fix(storage): Restore option to sign blob urls by using the signBlob endpoint of the IAM API

### DIFF
--- a/storage/gcloud/aio/storage/blob.py
+++ b/storage/gcloud/aio/storage/blob.py
@@ -145,16 +145,17 @@ class Blob:
         datestamp = datetime_now.strftime('%Y%m%d')
 
         token = token or self.bucket.storage.token
-        # Try to sign locally by default, if available
-        signature_method = _SignatureMethod.PEM
+        credential_scope = f'{datestamp}/auto/storage/goog4_request'
+        # Try to sign locally if available
         client_email = token.service_data.get('client_email')
         private_key = token.service_data.get('private_key')
         if not client_email or not private_key:
             # Cannot sign locally, so we'll have to use Google's IAM API
             signature_method = _SignatureMethod.IAM_API
-
-        credential_scope = f'{datestamp}/auto/storage/goog4_request'
-        credential = f'{client_email}/{credential_scope}'
+            credential = f'{service_account_email}/{credential_scope}'
+        else:
+            signature_method = _SignatureMethod.PEM
+            credential = f'{client_email}/{credential_scope}'
 
         headers = headers or {}
         headers['host'] = HOST

--- a/storage/gcloud/aio/storage/blob.py
+++ b/storage/gcloud/aio/storage/blob.py
@@ -250,4 +250,5 @@ class Blob:
         signed_resp = await iam_client.sign_blob(
             str_to_sign, service_account_email=service_account_email, session=session,
         )
+        print(signed_resp)
         return decode(signed_resp['signedBlob'])

--- a/storage/gcloud/aio/storage/blob.py
+++ b/storage/gcloud/aio/storage/blob.py
@@ -4,6 +4,7 @@ import datetime
 import enum
 import hashlib
 import io
+import typing
 from typing import Any
 from typing import Dict
 from typing import Optional
@@ -149,7 +150,7 @@ class Blob:
         credential_scope = f'{datestamp}/auto/storage/goog4_request'
         # Try to sign locally if available
         client_email = token.service_data.get('client_email')
-        private_key = token.service_data.get('private_key')
+        private_key = typing.cast(str, token.service_data.get('private_key'))
         if not client_email or not private_key:
             # Cannot sign locally, so we'll have to use Google's IAM API
             signature_method = _SignatureMethod.IAM_API

--- a/storage/gcloud/aio/storage/blob.py
+++ b/storage/gcloud/aio/storage/blob.py
@@ -212,7 +212,8 @@ class Blob:
             signed_blob = await self.get_iam_api_signature(
                 str_to_sign,
                 iam_client,
-                service_account_email, session
+                service_account_email,
+                session,
             )
 
         signature = binascii.hexlify(signed_blob).decode()
@@ -223,7 +224,7 @@ class Blob:
         )
 
     @staticmethod
-    def get_pem_signature(str_to_sign, private_key):
+    def get_pem_signature(str_to_sign: str, private_key: str) -> bytes:
         # N.B. see the ``PemKind`` enum
         marker_id, key_bytes = pem.readPemBlocksFromFile(
             io.StringIO(private_key), PKCS1_MARKER, PKCS8_MARKER,
@@ -256,7 +257,9 @@ class Blob:
 
     @staticmethod
     async def get_iam_api_signature(
-            str_to_sign, iam_client, service_account_email, session):
+            str_to_sign: str, iam_client: IamClient,
+            service_account_email: Optional[str], session: Optional[Session],
+    ) -> bytes:
         signed_resp = await iam_client.sign_blob(
             str_to_sign,
             service_account_email=service_account_email,

--- a/storage/gcloud/aio/storage/blob.py
+++ b/storage/gcloud/aio/storage/blob.py
@@ -4,7 +4,6 @@ import datetime
 import enum
 import hashlib
 import io
-import typing
 from typing import Any
 from typing import Dict
 from typing import Optional
@@ -150,7 +149,7 @@ class Blob:
         credential_scope = f'{datestamp}/auto/storage/goog4_request'
         # Try to sign locally if available
         client_email = token.service_data.get('client_email')
-        private_key = typing.cast(str, token.service_data.get('private_key'))
+        private_key = token.service_data.get('private_key')
         if not client_email or not private_key:
             # Cannot sign locally, so we'll have to use Google's IAM API
             signature_method = _SignatureMethod.IAM_API
@@ -201,7 +200,8 @@ class Blob:
             credential_scope, canonical_req_hash,
         ])
 
-        if signature_method == _SignatureMethod.PEM:
+        if (signature_method == _SignatureMethod.PEM and private_key
+                and isinstance(private_key, str)):
             signed_blob = self.get_pem_signature(str_to_sign, private_key)
         else:
             try:

--- a/storage/gcloud/aio/storage/blob.py
+++ b/storage/gcloud/aio/storage/blob.py
@@ -250,4 +250,4 @@ class Blob:
         signed_resp = await iam_client.sign_blob(
             str_to_sign, service_account_email=service_account_email, session=session,
         )
-        return decode(signed_resp)
+        return decode(signed_resp['signedBlob'])

--- a/storage/gcloud/aio/storage/blob.py
+++ b/storage/gcloud/aio/storage/blob.py
@@ -202,7 +202,8 @@ class Blob:
             signed_blob = self.get_pem_signature(str_to_sign, private_key)
         else:
             try:
-                iam_client = iam_client or IamClient(token=token, session=session)
+                iam_client = iam_client or IamClient(
+                    token=token, session=session)
             except TypeError as e:
                 raise TypeError('Blob signing is not yet supported'
                                 ' for AUTHORIZED_USER tokens') from e

--- a/storage/gcloud/aio/storage/blob.py
+++ b/storage/gcloud/aio/storage/blob.py
@@ -71,9 +71,10 @@ class PemKind(enum.Enum):
 
 class _SignatureMethod(enum.Enum):
     """
-    Indicates where the url signing will be done through Google's IAM API or through
-    local signing with a PEM file, which is faster but requires that the provided token contains
-    client_email and private_key data
+    Indicates where the url signing will be done through Google's
+    IAM API or through local signing with a PEM file, which is faster
+    but requires that the provided token contains client_email and
+    private_key data
     """
 
     PEM = 0
@@ -208,8 +209,11 @@ class Blob:
             except TypeError as e:
                 raise TypeError('Blob signing is not yet supported'
                                 ' for AUTHORIZED_USER tokens') from e
-            signed_blob = await self.get_iam_api_signature(str_to_sign, iam_client,
-                                                           service_account_email, session)
+            signed_blob = await self.get_iam_api_signature(
+                str_to_sign,
+                iam_client,
+                service_account_email, session
+            )
 
         signature = binascii.hexlify(signed_blob).decode()
 
@@ -243,12 +247,19 @@ class Blob:
             key_bytes = private_key_info.asOctets()
 
         key = rsa.key.PrivateKey.load_pkcs1(key_bytes, format='DER')
-        signed_blob = rsa.pkcs1.sign(str_to_sign.encode(), key, 'SHA-256')
+        signed_blob = rsa.pkcs1.sign(
+            str_to_sign.encode(),
+            key,
+            'SHA-256',
+        )
         return signed_blob
 
     @staticmethod
-    async def get_iam_api_signature(str_to_sign, iam_client, service_account_email, session):
+    async def get_iam_api_signature(
+            str_to_sign, iam_client, service_account_email, session):
         signed_resp = await iam_client.sign_blob(
-            str_to_sign, service_account_email=service_account_email, session=session,
+            str_to_sign,
+            service_account_email=service_account_email,
+            session=session,
         )
         return decode(signed_resp['signedBlob'])

--- a/storage/gcloud/aio/storage/blob.py
+++ b/storage/gcloud/aio/storage/blob.py
@@ -12,6 +12,8 @@ from urllib.parse import quote
 
 import rsa
 from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
+from gcloud.aio.auth import decode  # pylint: disable=no-name-in-module
+from gcloud.aio.auth import IamClient  # pylint: disable=no-name-in-module
 from gcloud.aio.auth import Token  # pylint: disable=no-name-in-module
 from pyasn1.codec.der import decoder
 from pyasn1_modules import pem
@@ -67,6 +69,17 @@ class PemKind(enum.Enum):
     PKCS8 = 1
 
 
+class _SignatureMethod(enum.Enum):
+    """
+    Indicates where the url signing will be done through Google's IAM API or through
+    local signing with a PEM file, which is faster but requires that the provided token contains
+    client_email and private_key data
+    """
+
+    PEM = 0
+    IAM_API = 1
+
+
 class Blob:
     def __init__(
         self, bucket: 'Bucket', name: str,
@@ -107,7 +120,9 @@ class Blob:
     async def get_signed_url(  # pylint: disable=too-many-locals
             self, expiration: int, headers: Optional[Dict[str, str]] = None,
             query_params: Optional[Dict[str, Any]] = None,
-            http_method: str = 'GET', token: Optional[Token] = None,
+            http_method: str = 'GET', iam_client: Optional[IamClient] = None,
+            service_account_email: Optional[str] = None,
+            token: Optional[Token] = None, session: Optional[Session] = None
     ) -> str:
         """
         Create a temporary access URL for Storage Blob accessible by anyone
@@ -129,22 +144,13 @@ class Blob:
         request_timestamp = datetime_now.strftime('%Y%m%dT%H%M%SZ')
         datestamp = datetime_now.strftime('%Y%m%d')
 
-        # TODO: support for GCE_METADATA and AUTHORIZED_USER tokens. It should
-        # be possible via API, but seems to not be working for us in some
-        # cases.
-        #
-        # https://cloud.google.com/iam/docs/reference/credentials/rest/v1/
-        # projects.serviceAccounts/signBlob
         token = token or self.bucket.storage.token
+        signature_method = _SignatureMethod.PEM  # Try to sign locally by default, if available
         client_email = token.service_data.get('client_email')
         private_key = token.service_data.get('private_key')
         if not client_email or not private_key:
-            raise KeyError(
-                'Blob signing is only suported for tokens with '
-                'explicit client_email and private_key data; '
-                'please check your token points to a JSON service '
-                'account file',
-            )
+            # Cannot sign locally, so we'll have to use Google's IAM API
+            signature_method = _SignatureMethod.IAM_API
 
         credential_scope = f'{datestamp}/auto/storage/goog4_request'
         credential = f'{client_email}/{credential_scope}'
@@ -191,6 +197,22 @@ class Blob:
             credential_scope, canonical_req_hash,
         ])
 
+        if signature_method == _SignatureMethod.PEM:
+            signed_blob = self.get_pem_signature(str_to_sign, private_key)
+        else:
+            iam_client = iam_client or IamClient(token=token, session=session)
+            signed_blob = await self.get_iam_api_signature(str_to_sign, iam_client,
+                                                           service_account_email, session)
+
+        signature = binascii.hexlify(signed_blob).decode()
+
+        return (
+            f'https://{HOST}{canonical_uri}?'
+            f'{canonical_query_str}&X-Goog-Signature={signature}'
+        )
+
+    @staticmethod
+    def get_pem_signature(str_to_sign, private_key):
         # N.B. see the ``PemKind`` enum
         marker_id, key_bytes = pem.readPemBlocksFromFile(
             io.StringIO(private_key), PKCS1_MARKER, PKCS8_MARKER,
@@ -215,10 +237,11 @@ class Blob:
 
         key = rsa.key.PrivateKey.load_pkcs1(key_bytes, format='DER')
         signed_blob = rsa.pkcs1.sign(str_to_sign.encode(), key, 'SHA-256')
+        return signed_blob
 
-        signature = binascii.hexlify(signed_blob).decode()
-
-        return (
-            f'https://{HOST}{canonical_uri}?'
-            f'{canonical_query_str}&X-Goog-Signature={signature}'
+    @staticmethod
+    async def get_iam_api_signature(str_to_sign, iam_client, service_account_email, session):
+        signed_resp = await iam_client.sign_blob(
+            str_to_sign, service_account_email=service_account_email, session=session
         )
+        return decode(signed_resp)

--- a/storage/gcloud/aio/storage/blob.py
+++ b/storage/gcloud/aio/storage/blob.py
@@ -251,5 +251,4 @@ class Blob:
         signed_resp = await iam_client.sign_blob(
             str_to_sign, service_account_email=service_account_email, session=session,
         )
-        print(signed_resp)
         return decode(signed_resp['signedBlob'])

--- a/storage/pyproject.toml
+++ b/storage/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcloud-aio-storage"
-version = "9.1.1"
+version = "9.2.0"
 description = "Python Client for Google Cloud Storage"
 readme = "README.rst"
 

--- a/storage/pyproject.toml
+++ b/storage/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcloud-aio-storage"
-version = "9.1.0"
+version = "9.1.1"
 description = "Python Client for Google Cloud Storage"
 readme = "README.rst"
 

--- a/storage/pyproject.toml
+++ b/storage/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcloud-aio-storage"
-version = "9.3.0"
+version = "9.1.0"
 description = "Python Client for Google Cloud Storage"
 readme = "README.rst"
 

--- a/storage/pyproject.toml
+++ b/storage/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcloud-aio-storage"
-version = "9.0.0"
+version = "9.1.0"
 description = "Python Client for Google Cloud Storage"
 readme = "README.rst"
 

--- a/storage/pyproject.toml
+++ b/storage/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcloud-aio-storage"
-version = "9.2.0"
+version = "9.3.0"
 description = "Python Client for Google Cloud Storage"
 readme = "README.rst"
 

--- a/storage/tests/integration/signed_url_test.py
+++ b/storage/tests/integration/signed_url_test.py
@@ -36,7 +36,10 @@ async def test_gcs_signed_url(bucket_name, creds, data, headers):
 
         signed_url = await blob.get_signed_url(60, headers=headers)
 
-        await verify_signed_url(blob, bucket_name, data, headers, session, signed_url, storage)
+        await verify_signed_url(
+            blob, bucket_name, data, headers,
+            session, signed_url, storage,
+        )
 
 
 @pytest.mark.asyncio
@@ -63,10 +66,15 @@ async def test_gcs_iam_signed_url(bucket_name, creds, data, headers):
         blob = await bucket.get_blob(object_name, session=session)
         iam_client = IamClient(service_file=creds, session=session)
 
-        signed_url = await blob.get_signed_url(60, headers=headers, iam_client=iam_client)
+        signed_url = await blob.get_signed_url(
+            60, headers=headers, iam_client=iam_client,
+        )
 
-        await verify_signed_url(blob, bucket_name, data, headers, session, signed_url,
-                                storage)
+        await verify_signed_url(
+            blob, bucket_name, data,
+            headers, session, signed_url,
+            storage,
+        )
 
 
 async def verify_signed_url(blob, bucket_name, data, headers, session, signed_url, storage):

--- a/storage/tests/integration/signed_url_test.py
+++ b/storage/tests/integration/signed_url_test.py
@@ -5,6 +5,9 @@ from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-modu
 from gcloud.aio.storage import Bucket
 from gcloud.aio.storage import Storage
 
+from auth.gcloud.aio.auth import IamClient
+from auth.gcloud.aio.auth import Token
+
 # Selectively load libraries based on the package
 if BUILD_GCLOUD_REST:
     from requests import Session
@@ -33,14 +36,46 @@ async def test_gcs_signed_url(bucket_name, creds, data, headers):
 
         signed_url = await blob.get_signed_url(60, headers=headers)
 
-        resp = await session.get(signed_url, headers=headers)
+        await verify_signed_url(blob, bucket_name, data, headers, session, signed_url, storage)
 
-        try:
-            downloaded_data: str = await resp.text()
-        except (AttributeError, TypeError):
-            downloaded_data: str = str(resp.text)
+@pytest.mark.asyncio
+@pytest.mark.parametrize('data', ['test'])
+@pytest.mark.parametrize('headers', [
+    {},
+    {'X-Goog-ACL': 'public-read', 'Content-Type': 'text/plain'},
+])
+async def test_gcs_iam_signed_url(bucket_name, creds, data, headers):
+    object_name = f'{uuid.uuid4().hex}/{uuid.uuid4().hex}.txt'
+    token = Token(scopes=['https://www.googleapis.com/auth/devstorage.read_write'])
 
-        try:
-            assert data == downloaded_data
-        finally:
-            await storage.delete(bucket_name, blob.name)
+    async with Session() as session:
+        # Passing a token without the service account private key will force
+        # signing by hitting the signBlob endpoint of the IAM API
+        storage = Storage(token=token, session=session)
+        await storage.upload(
+            bucket_name, object_name, data,
+            force_resumable_upload=True,
+        )
+
+        bucket = Bucket(storage, bucket_name)
+        blob = await bucket.get_blob(object_name, session=session)
+        iam_client = IamClient(service_file=creds, session=session)
+
+        signed_url = await blob.get_signed_url(60, iam_client=iam_client)
+
+        await verify_signed_url(blob, bucket_name, data, headers, session, signed_url,
+                                storage)
+
+
+async def verify_signed_url(blob, bucket_name, data, headers, session, signed_url, storage):
+    resp = await session.get(signed_url, headers=headers)
+    try:
+        downloaded_data: str = await resp.text()
+    except (AttributeError, TypeError):
+        downloaded_data: str = str(resp.text)
+    try:
+        assert data == downloaded_data
+    finally:
+        await storage.delete(bucket_name, blob.name)
+
+

--- a/storage/tests/integration/signed_url_test.py
+++ b/storage/tests/integration/signed_url_test.py
@@ -77,7 +77,10 @@ async def test_gcs_iam_signed_url(bucket_name, creds, data, headers):
         )
 
 
-async def verify_signed_url(blob, bucket_name, data, headers, session, signed_url, storage):
+async def verify_signed_url(
+        blob, bucket_name, data, headers,
+        session, signed_url, storage,
+):
     resp = await session.get(signed_url, headers=headers)
     try:
         downloaded_data: str = await resp.text()

--- a/storage/tests/integration/signed_url_test.py
+++ b/storage/tests/integration/signed_url_test.py
@@ -63,7 +63,7 @@ async def test_gcs_iam_signed_url(bucket_name, creds, data, headers):
         blob = await bucket.get_blob(object_name, session=session)
         iam_client = IamClient(service_file=creds, session=session)
 
-        signed_url = await blob.get_signed_url(60, iam_client=iam_client)
+        signed_url = await blob.get_signed_url(60, headers=headers, iam_client=iam_client)
 
         await verify_signed_url(blob, bucket_name, data, headers, session, signed_url,
                                 storage)

--- a/storage/tests/integration/signed_url_test.py
+++ b/storage/tests/integration/signed_url_test.py
@@ -2,11 +2,11 @@ import uuid
 
 import pytest
 from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
+from gcloud.aio.auth import IamClient  # pylint: disable=no-name-in-module
+from gcloud.aio.auth import Token  # pylint: disable=no-name-in-module
 from gcloud.aio.storage import Bucket
 from gcloud.aio.storage import Storage
 
-from auth.gcloud.aio.auth import IamClient
-from auth.gcloud.aio.auth import Token
 
 # Selectively load libraries based on the package
 if BUILD_GCLOUD_REST:


### PR DESCRIPTION
## Summary

This PR aims to solve the issues explained in https://github.com/talkiq/gcloud-aio/pull/323#issuecomment-1900605859.
To summarize, this PR re-adds support for using the IAM API to sign blobs in case there is no service account private key available locally.