### PR TITLE
fix(rest-auth): resp.text() for aiohttp but resp.text for requests lib

### DIFF
--- a/auth/gcloud/aio/auth/token.py
+++ b/auth/gcloud/aio/auth/token.py
@@ -469,7 +469,10 @@ class IapToken(BaseToken):
         resp = await self.session.get(
             GCE_ENDPOINT_ID_TOKEN.format(audience=iap_client_id),
             headers=GCE_METADATA_HEADERS, timeout=timeout)
-        token = await resp.text()
+        try:
+            token = await resp.text()  # aiohttp lib
+        except (AttributeError, TypeError):
+            token = str(resp.text)  # requests lib
         return TokenResponse(value=token,
                              expires_in=self.default_token_ttl)
 


### PR DESCRIPTION
## Summary
Since this lib uses `aiohttp` for aio calls and `requests` for rest calls, we need to suppport both usages.

For getting iap token I use the same solution as in lines 200-203. 