### PR TITLE
fix(auth): fixup aiohttp v3.3.0 compat

### DIFF
--- a/auth/poetry.lock
+++ b/auth/poetry.lock
@@ -740,4 +740,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.8, < 4.0"
-content-hash = "e295b88139ec01ee3308b84a919b8a168da97f3f49c00b5d0de73f6c775fbac8"
+content-hash = "4f4af4637004135c241d86fffa25a8f11f6e2c10f00a42103d646babda58e806"

--- a/auth/pyproject.rest.toml
+++ b/auth/pyproject.rest.toml
@@ -21,7 +21,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">= 3.8, < 4.0"
-# aiohttp = ">= 3.9.0, < 4.0.0"
+# aiohttp = ">= 3.3.0, < 4.0.0"
 backoff = ">= 1.0.0, < 3.0.0"
 chardet = ">= 2.0, < 6.0"
 # See https://cryptography.io/en/latest/api-stability/#deprecation

--- a/auth/pyproject.toml
+++ b/auth/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">= 3.8, < 4.0"
-aiohttp = ">= 3.9.0, < 4.0.0"
+aiohttp = ">= 3.3.0, < 4.0.0"
 backoff = ">= 1.0.0, < 3.0.0"
 chardet = ">= 2.0, < 6.0"
 # See https://cryptography.io/en/latest/api-stability/#deprecation


### PR DESCRIPTION
Avoid new API usage, introduce ability to avoid stomping over configured
session-level `auto_decompress` setting.
