### PR TITLE
feat(datastore): Support "IN" query filter

### DIFF
--- a/datastore/gcloud/aio/datastore/__init__.py
+++ b/datastore/gcloud/aio/datastore/__init__.py
@@ -181,6 +181,7 @@ with it, you will need to implement your own ``Value``, ``Query``, and
 """
 import importlib.metadata
 
+from .array import Array
 from .constants import CompositeFilterOperator
 from .constants import Consistency
 from .constants import Direction
@@ -215,6 +216,7 @@ from .value import Value
 
 __version__ = importlib.metadata.version('gcloud-aio-datastore')
 __all__ = [
+    'Array',
     'CompositeFilter',
     'CompositeFilterOperator',
     'Consistency',

--- a/datastore/gcloud/aio/datastore/constants.py
+++ b/datastore/gcloud/aio/datastore/constants.py
@@ -53,6 +53,7 @@ class PropertyFilterOperator(enum.Enum):
     LESS_THAN_OR_EQUAL = 'LESS_THAN_OR_EQUAL'
     NOT_EQUAL = 'NOT_EQUAL'
     UNSPECIFIED = 'OPERATOR_UNSPECIFIED'
+    IN = 'IN'
 
 
 class ResultType(enum.Enum):

--- a/datastore/gcloud/aio/datastore/constants.py
+++ b/datastore/gcloud/aio/datastore/constants.py
@@ -49,11 +49,12 @@ class PropertyFilterOperator(enum.Enum):
     GREATER_THAN = 'GREATER_THAN'
     GREATER_THAN_OR_EQUAL = 'GREATER_THAN_OR_EQUAL'
     HAS_ANCESTOR = 'HAS_ANCESTOR'
+    IN = 'IN'
     LESS_THAN = 'LESS_THAN'
     LESS_THAN_OR_EQUAL = 'LESS_THAN_OR_EQUAL'
     NOT_EQUAL = 'NOT_EQUAL'
+    NOT_IN = 'NOT_IN'
     UNSPECIFIED = 'OPERATOR_UNSPECIFIED'
-    IN = 'IN'
 
 
 class ResultType(enum.Enum):

--- a/datastore/gcloud/aio/datastore/constants.py
+++ b/datastore/gcloud/aio/datastore/constants.py
@@ -44,7 +44,6 @@ class Operation(enum.Enum):
 
 
 class PropertyFilterOperator(enum.Enum):
-    # TODO: support IN / NOT_IN (requires rhs to be ArrayValue)
     EQUAL = 'EQUAL'
     GREATER_THAN = 'GREATER_THAN'
     GREATER_THAN_OR_EQUAL = 'GREATER_THAN_OR_EQUAL'

--- a/datastore/gcloud/aio/datastore/filter.py
+++ b/datastore/gcloud/aio/datastore/filter.py
@@ -1,7 +1,9 @@
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Union
 
+from .array import Array
 from .constants import CompositeFilterOperator
 from .constants import PropertyFilterOperator
 from .value import Value
@@ -89,7 +91,7 @@ class PropertyFilter(BaseFilter):
 
     def __init__(
         self, prop: str, operator: PropertyFilterOperator,
-        value: Value,
+        value: Union[Value, Array]
     ) -> None:
         self.prop = prop
         self.operator = operator
@@ -113,8 +115,13 @@ class PropertyFilter(BaseFilter):
         return cls(prop=prop, operator=operator, value=value)
 
     def to_repr(self) -> Dict[str, Any]:
-        return {
+        rep = {
             'op': self.operator.value,
-            'property': {'name': self.prop},
-            'value': self.value.to_repr(),
+            'property': {'name': self.prop}
         }
+        # Temporary workaround for handling arrayValue with PropertyFilter
+        if isinstance(self.value, Array):
+            rep['value'] = {'arrayValue': self.value.to_repr()}
+        else:
+            rep['value'] = self.value.to_repr()
+        return rep

--- a/datastore/gcloud/aio/datastore/filter.py
+++ b/datastore/gcloud/aio/datastore/filter.py
@@ -91,7 +91,7 @@ class PropertyFilter(BaseFilter):
 
     def __init__(
         self, prop: str, operator: PropertyFilterOperator,
-        value: Union[Value, Array]
+        value: Union[Value, Array],
     ) -> None:
         self.prop = prop
         self.operator = operator
@@ -115,11 +115,11 @@ class PropertyFilter(BaseFilter):
         return cls(prop=prop, operator=operator, value=value)
 
     def to_repr(self) -> Dict[str, Any]:
-        rep = {
+        rep: Dict[str, Any] = {
             'op': self.operator.value,
-            'property': {'name': self.prop}
+            'property': {'name': self.prop},
         }
-        # Temporary workaround for handling arrayValue with PropertyFilter
+        # TODO: consider refactoring to look more like Value.to_repr()
         if isinstance(self.value, Array):
             rep['value'] = {'arrayValue': self.value.to_repr()}
         else:

--- a/datastore/tests/integration/smoke_test.py
+++ b/datastore/tests/integration/smoke_test.py
@@ -275,7 +275,8 @@ async def test_query(creds: str, kind: str, project: str) -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.xfail(strict=False)
-async def test_query_with_in_filter(creds: str, kind: str, project: str) -> None:
+async def test_query_with_in_filter(
+        creds: str, kind: str, project: str) -> None:
     async with Session() as s:
         ds = Datastore(project=project, service_file=creds, session=s)
 
@@ -349,9 +350,11 @@ async def test_gql_query(creds: str, kind: str, project: str) -> None:
         after = await ds.runQuery(query, session=s)
         assert len(after.entity_results) == num_results + 3
 
+
 @pytest.mark.asyncio
 @pytest.mark.xfail(strict=False)
-async def test_gql_query_with_in_filter(creds: str, kind: str, project: str) -> None:
+async def test_gql_query_with_in_filter(
+        creds: str, kind: str, project: str) -> None:
     async with Session() as s:
         ds = Datastore(project=project, service_file=creds, session=s)
 
@@ -385,6 +388,7 @@ async def test_gql_query_with_in_filter(creds: str, kind: str, project: str) -> 
 
         after = await ds.runQuery(query, session=s)
         assert len(after.entity_results) == num_results + 2
+
 
 @pytest.mark.asyncio
 @pytest.mark.xfail(strict=False)

--- a/datastore/tests/integration/smoke_test.py
+++ b/datastore/tests/integration/smoke_test.py
@@ -2,6 +2,7 @@ import uuid
 
 import pytest
 from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
+from gcloud.aio.datastore import Array
 from gcloud.aio.datastore import Datastore
 from gcloud.aio.datastore import Filter
 from gcloud.aio.datastore import GQLCursor
@@ -274,6 +275,45 @@ async def test_query(creds: str, kind: str, project: str) -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.xfail(strict=False)
+async def test_query_with_in_filter(creds: str, kind: str, project: str) -> None:
+    async with Session() as s:
+        ds = Datastore(project=project, service_file=creds, session=s)
+
+        property_filter = PropertyFilter(
+            prop='value', operator=PropertyFilterOperator.IN,
+            value=Array([Value(99), Value(100)])
+        )
+        query = Query(kind=kind, query_filter=Filter(property_filter))
+
+        before = await ds.runQuery(query, session=s)
+        num_results = len(before.entity_results)
+
+        transaction = await ds.beginTransaction(session=s)
+        mutations = [
+            ds.make_mutation(
+                Operation.INSERT,
+                Key(project, [PathElement(kind)]),
+                properties={'value': 99},
+            ),
+            ds.make_mutation(
+                Operation.INSERT,
+                Key(project, [PathElement(kind)]),
+                properties={'value': 100},
+            ),
+            ds.make_mutation(
+                Operation.INSERT,
+                Key(project, [PathElement(kind)]),
+                properties={'value': 101},
+            )
+        ]
+        await ds.commit(mutations, transaction=transaction, session=s)
+
+        after = await ds.runQuery(query, session=s)
+        assert len(after.entity_results) == num_results + 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(strict=False)
 async def test_gql_query(creds: str, kind: str, project: str) -> None:
     async with Session() as s:
         ds = Datastore(project=project, service_file=creds, session=s)
@@ -309,6 +349,42 @@ async def test_gql_query(creds: str, kind: str, project: str) -> None:
         after = await ds.runQuery(query, session=s)
         assert len(after.entity_results) == num_results + 3
 
+@pytest.mark.asyncio
+@pytest.mark.xfail(strict=False)
+async def test_gql_query_with_in_filter(creds: str, kind: str, project: str) -> None:
+    async with Session() as s:
+        ds = Datastore(project=project, service_file=creds, session=s)
+
+        query = GQLQuery(
+            f'SELECT * FROM {kind} WHERE value IN @values',
+            named_bindings={'values': Array([Value(99), Value(100)])},
+        )
+
+        before = await ds.runQuery(query, session=s)
+        num_results = len(before.entity_results)
+
+        transaction = await ds.beginTransaction(session=s)
+        mutations = [
+            ds.make_mutation(
+                Operation.INSERT,
+                Key(project, [PathElement(kind)]),
+                properties={'value': 99},
+            ),
+            ds.make_mutation(
+                Operation.INSERT,
+                Key(project, [PathElement(kind)]),
+                properties={'value': 100},
+            ),
+            ds.make_mutation(
+                Operation.INSERT,
+                Key(project, [PathElement(kind)]),
+                properties={'value': 101},
+            ),
+        ]
+        await ds.commit(mutations, transaction=transaction, session=s)
+
+        after = await ds.runQuery(query, session=s)
+        assert len(after.entity_results) == num_results + 2
 
 @pytest.mark.asyncio
 @pytest.mark.xfail(strict=False)

--- a/datastore/tests/integration/smoke_test.py
+++ b/datastore/tests/integration/smoke_test.py
@@ -315,6 +315,45 @@ async def test_query_with_in_filter(
 
 @pytest.mark.asyncio
 @pytest.mark.xfail(strict=False)
+async def test_query_with_not_in_filter(creds: str, kind: str, project: str) -> None:
+    async with Session() as s:
+        ds = Datastore(project=project, service_file=creds, session=s)
+
+        property_filter = PropertyFilter(
+            prop='value', operator=PropertyFilterOperator.NOT_IN,
+            value=Array([Value(99), Value(100), Value(30), Value(42)])
+        )
+        query = Query(kind=kind, query_filter=Filter(property_filter))
+
+        before = await ds.runQuery(query, session=s)
+        num_results = len(before.entity_results)
+
+        transaction = await ds.beginTransaction(session=s)
+        mutations = [
+            ds.make_mutation(
+                Operation.INSERT,
+                Key(project, [PathElement(kind)]),
+                properties={'value': 99},
+            ),
+            ds.make_mutation(
+                Operation.INSERT,
+                Key(project, [PathElement(kind)]),
+                properties={'value': 100},
+            ),
+            ds.make_mutation(
+                Operation.INSERT,
+                Key(project, [PathElement(kind)]),
+                properties={'value': 999},
+            )
+        ]
+        await ds.commit(mutations, transaction=transaction, session=s)
+
+        after = await ds.runQuery(query, session=s)
+        assert len(after.entity_results) == num_results + 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(strict=False)
 async def test_gql_query(creds: str, kind: str, project: str) -> None:
     async with Session() as s:
         ds = Datastore(project=project, service_file=creds, session=s)
@@ -388,6 +427,44 @@ async def test_gql_query_with_in_filter(
 
         after = await ds.runQuery(query, session=s)
         assert len(after.entity_results) == num_results + 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(strict=False)
+async def test_gql_query_with_not_in_filter(creds: str, kind: str, project: str) -> None:
+    async with Session() as s:
+        ds = Datastore(project=project, service_file=creds, session=s)
+
+        query = GQLQuery(
+            f'SELECT * FROM {kind} WHERE value NOT IN @values',
+            named_bindings={'values': Array([Value(30), Value(42), Value(99), Value(100)])},
+        )
+
+        before = await ds.runQuery(query, session=s)
+        num_results = len(before.entity_results)
+
+        transaction = await ds.beginTransaction(session=s)
+        mutations = [
+            ds.make_mutation(
+                Operation.INSERT,
+                Key(project, [PathElement(kind)]),
+                properties={'value': 99},
+            ),
+            ds.make_mutation(
+                Operation.INSERT,
+                Key(project, [PathElement(kind)]),
+                properties={'value': 100},
+            ),
+            ds.make_mutation(
+                Operation.INSERT,
+                Key(project, [PathElement(kind)]),
+                properties={'value': 999},
+            ),
+        ]
+        await ds.commit(mutations, transaction=transaction, session=s)
+
+        after = await ds.runQuery(query, session=s)
+        assert len(after.entity_results) == num_results + 1
 
 
 @pytest.mark.asyncio

--- a/datastore/tests/integration/smoke_test.py
+++ b/datastore/tests/integration/smoke_test.py
@@ -282,7 +282,7 @@ async def test_query_with_in_filter(
 
         property_filter = PropertyFilter(
             prop='value', operator=PropertyFilterOperator.IN,
-            value=Array([Value(99), Value(100)])
+            value=Array([Value(99), Value(100)]),
         )
         query = Query(kind=kind, query_filter=Filter(property_filter))
 
@@ -305,7 +305,7 @@ async def test_query_with_in_filter(
                 Operation.INSERT,
                 Key(project, [PathElement(kind)]),
                 properties={'value': 101},
-            )
+            ),
         ]
         await ds.commit(mutations, transaction=transaction, session=s)
 
@@ -322,7 +322,7 @@ async def test_query_with_not_in_filter(
 
         property_filter = PropertyFilter(
             prop='value', operator=PropertyFilterOperator.NOT_IN,
-            value=Array([Value(99), Value(100), Value(30), Value(42)])
+            value=Array([Value(99), Value(100), Value(30), Value(42)]),
         )
         query = Query(kind=kind, query_filter=Filter(property_filter))
 
@@ -345,7 +345,7 @@ async def test_query_with_not_in_filter(
                 Operation.INSERT,
                 Key(project, [PathElement(kind)]),
                 properties={'value': 999},
-            )
+            ),
         ]
         await ds.commit(mutations, transaction=transaction, session=s)
 

--- a/datastore/tests/integration/smoke_test.py
+++ b/datastore/tests/integration/smoke_test.py
@@ -315,7 +315,8 @@ async def test_query_with_in_filter(
 
 @pytest.mark.asyncio
 @pytest.mark.xfail(strict=False)
-async def test_query_with_not_in_filter(creds: str, kind: str, project: str) -> None:
+async def test_query_with_not_in_filter(
+        creds: str, kind: str, project: str) -> None:
     async with Session() as s:
         ds = Datastore(project=project, service_file=creds, session=s)
 
@@ -431,13 +432,15 @@ async def test_gql_query_with_in_filter(
 
 @pytest.mark.asyncio
 @pytest.mark.xfail(strict=False)
-async def test_gql_query_with_not_in_filter(creds: str, kind: str, project: str) -> None:
+async def test_gql_query_with_not_in_filter(
+        creds: str, kind: str, project: str) -> None:
     async with Session() as s:
         ds = Datastore(project=project, service_file=creds, session=s)
 
         query = GQLQuery(
             f'SELECT * FROM {kind} WHERE value NOT IN @values',
-            named_bindings={'values': Array([Value(30), Value(42), Value(99), Value(100)])},
+            named_bindings={'values': Array(
+                [Value(30), Value(42), Value(99), Value(100)])},
         )
 
         before = await ds.runQuery(query, session=s)


### PR DESCRIPTION
## Summary
Add support for "IN" filter so that Firestore in Datastore mode would be able to execute single query with IN filter instead of multiple parallel queries.

