### PR TITLE
fix(auth): use the full format for the JWT payload in IAPToken

### DIFF
--- a/auth/gcloud/aio/auth/token.py
+++ b/auth/gcloud/aio/auth/token.py
@@ -57,7 +57,7 @@ GCE_ENDPOINT_TOKEN = (
 )
 GCE_ENDPOINT_ID_TOKEN = (
     f'{GCE_METADATA_BASE}/instance/service-accounts'
-    '/default/identity?audience={audience}'
+    '/default/identity?audience={audience}&format=full'
 )
 GCLOUD_ENDPOINT_GENERATE_ACCESS_TOKEN = (
     'https://iamcredentials.googleapis.com'

--- a/auth/pyproject.toml
+++ b/auth/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcloud-aio-auth"
-version = "5.3.1"
+version = "5.3.2"
 description = "Python Client for Google Cloud Auth"
 readme = "README.rst"
 


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant issues / branches / other PRs / blockers / etc.
--->

Some of the GCP products when retrieving the JWT token from the GCE
Metadata Server come with the `email` claim, but some have recently
started not returning that claim as part of the JWT payload. Adding the
`format=full` query parameter to the GCE Metdata Server API seems to
return the `email` claim for these cases, along with other GCE Metadata
which for the time being we do not need and thus, we discard.

[See these docs for more
information.](https://cloud.google.com/compute/docs/instances/verifying-instance-identity#request_signature)

