### PR TITLE
feat(auth): support the standard gce metadata host env

### DIFF
--- a/auth/gcloud/aio/auth/token.py
+++ b/auth/gcloud/aio/auth/token.py
@@ -47,8 +47,17 @@ else:
     from aiohttp import ClientSession as Session  # type: ignore[assignment]
     import asyncio
 
+# Environment variable GCE_METADATA_HOST is originally named
+# GCE_METADATA_ROOT. For compatibility reasons, here it checks
+# the new variable first; if not set, the system falls back
+# to the old variable.
+_GCE_METADATA_HOST = os.getenv('GCE_METADATA_HOST', None)
+if not _GCE_METADATA_HOST:
+    _GCE_METADATA_HOST = os.getenv(
+        'GCE_METADATA_ROOT', 'metadata.google.internal'
+    )
 
-GCE_METADATA_BASE = 'http://metadata.google.internal/computeMetadata/v1'
+GCE_METADATA_BASE = 'http://{}/computeMetadata/v1'.format(_GCE_METADATA_HOST)
 GCE_METADATA_HEADERS = {'metadata-flavor': 'Google'}
 GCE_ENDPOINT_PROJECT = f'{GCE_METADATA_BASE}/project/project-id'
 GCE_ENDPOINT_TOKEN = (


### PR DESCRIPTION
## Summary
We have the use case such that we want to override the default gce compute metadata and proxy to other compute nodes (outside of gce) for them to be able to access gcloud APIs. Add `GCE_METADATA_HOST` and `GCE_METADATA_ROOT` support which is google's standard env vars (see https://github.com/googleapis/google-auth-library-python/blob/main/google/auth/compute_engine/_metadata.py#L45).