### PR TITLE
feat(datastore): Support plain old list arg with IN filter

### DIFF
--- a/datastore/gcloud/aio/datastore/filter.py
+++ b/datastore/gcloud/aio/datastore/filter.py
@@ -122,6 +122,10 @@ class PropertyFilter(BaseFilter):
         # TODO: consider refactoring to look more like Value.to_repr()
         if isinstance(self.value, Array):
             rep['value'] = {'arrayValue': self.value.to_repr()}
+        elif isinstance(self.value, Value) and isinstance(self.value.value, list):
+            # This is a special case where the value is type of Value, but its value is a list
+            rep['value'] = {'arrayValue': {'values': [Value(x).to_repr() for x in
+                                                      self.value.value]}}
         else:
             rep['value'] = self.value.to_repr()
         return rep

--- a/datastore/tests/unit/filter_test.py
+++ b/datastore/tests/unit/filter_test.py
@@ -134,6 +134,21 @@ class TestFilter:
     def test_repr_returns_to_repr_as_string(query_filter):
         assert repr(query_filter) == str(query_filter.to_repr())
 
+    def test_in_filter_with_list_arg(self):
+        expected_value = {'arrayValue': {
+            'values': [{'excludeFromIndexes': False, 'stringValue': 'value1'},
+                       {'excludeFromIndexes': False, 'stringValue': 'value2'}]}}
+
+        prop = 'prop1'
+        value = ['value1', 'value2']
+        operator = PropertyFilterOperator.IN
+        property_filter = PropertyFilter(prop, operator, Value(value))
+        query_filter = Filter(property_filter)
+        r = query_filter.to_repr()
+        assert r['propertyFilter']['property']['name'] == prop
+        assert r['propertyFilter']['op'] == operator.value
+        assert r['propertyFilter']['value'] == expected_value
+
     @staticmethod
     @pytest.fixture(scope='session')
     def property_filters() -> List[PropertyFilter]:


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant issues / branches / other PRs / blockers / etc.
--->
This PR adds support to IN filters with plain old list such as
`query.filter('names IN', ['aaa', 'bbb'])`