### PR TITLE
Adding support for and id_token result using a service account

### DIFF
--- a/auth/tests/integration/smoke_test.py
+++ b/auth/tests/integration/smoke_test.py
@@ -28,6 +28,8 @@ async def test_token_is_created(creds: str) -> None:
     assert result
     assert token.access_token is not None
     assert token.access_token_duration != 0
+    assert token.access_token_preempt_after != 0
+    assert token.access_token_refresh_after != 0
     assert token.access_token_acquired_at != datetime.datetime(1970, 1, 1)
 
 
@@ -41,6 +43,8 @@ async def test_token_does_not_require_session(creds: str) -> None:
     assert result
     assert token.access_token is not None
     assert token.access_token_duration != 0
+    assert token.access_token_preempt_after != 0
+    assert token.access_token_refresh_after != 0
     assert token.access_token_acquired_at != datetime.datetime(1970, 1, 1)
 
 
@@ -54,6 +58,8 @@ async def test_token_does_not_require_creds() -> None:
     assert result
     assert token.access_token is not None
     assert token.access_token_duration != 0
+    assert token.access_token_preempt_after != 0
+    assert token.access_token_refresh_after != 0
     assert token.access_token_acquired_at != datetime.datetime(1970, 1, 1)
 
 

--- a/bin/build-rest
+++ b/bin/build-rest
@@ -74,6 +74,8 @@ find . -type f \
     | xargs -L1 $SED -Ei 's/AioSession/SyncSession/g'
 find . -type f \
     | xargs -L1 $SED -Ei 's/asyncio.ensure_future(.*)/\1/g'
+find . -type f \
+    | xargs -L1 $SED -Ei 's/asyncio.create_task(.*)/\1/g'
 find . -type f -path '*py' \
     | xargs -L1 $SED -Ei 's/(async|await) //g'
 find . -type f -path '*tests/*' \


### PR DESCRIPTION
- ensure_token will now not block everything after 50% of TTL.
- Token class now able to deal with an `id_token` return payload.