### PR TITLE
Fix 'Token' object has no attribute 'scopes' error

### DIFF
--- a/auth/gcloud/aio/auth/token.py
+++ b/auth/gcloud/aio/auth/token.py
@@ -307,12 +307,13 @@ class Token(BaseToken):
 
         if scopes:
             self.scopes = ' '.join(scopes or [])
-        elif self.service_data:
-            if self.token_type == Type.IMPERSONATED_SERVICE_ACCOUNT:
-                # If service file was provided and the type is
-                # IMPERSONATED_SERVICE_ACCOUNT, gcloud requires this default
-                # scope but does not write it to the file
-                self.scopes = 'https://www.googleapis.com/auth/cloud-platform'
+        elif self.service_data and self.token_type == Type.IMPERSONATED_SERVICE_ACCOUNT:
+            # If service file was provided and the type is
+            # IMPERSONATED_SERVICE_ACCOUNT, gcloud requires this default
+            # scope but does not write it to the file
+            self.scopes = 'https://www.googleapis.com/auth/cloud-platform'
+        else:
+            self.scopes = ''
 
         self.impersonation_uri: Optional[str] = None
         if target_principal:


### PR DESCRIPTION
If we don't do this, Token won't always have a scopes attribute, and sometimes (e.g. for service account keys) we'd get errors like

```
'Token' object has no attribute 'scopes'
```

Better to get an error that insufficient scopes are used (if that's the error).