### PR TITLE
fix(storage): BaseToken.ensure_token should not cache failed calls to acquire_access_token

### DIFF
--- a/auth/gcloud/aio/auth/token.py
+++ b/auth/gcloud/aio/auth/token.py
@@ -249,7 +249,7 @@ class BaseToken:
                 pass
             elif now_ts > self.access_token_preempt_after:
                 # Token is okay, but we need to fire up a preemptive refresh
-                if not self.acquiring:
+                if not self.acquiring or self.acquiring.done():
                     self.acquiring = asyncio.create_task(  # pylint: disable=possibly-used-before-assignment
                         self.acquire_access_token())
                 return
@@ -257,7 +257,7 @@ class BaseToken:
                 # Cached token is valid for use
                 return
 
-        if not self.acquiring:
+        if not self.acquiring or self.acquiring.done():
             self.acquiring = asyncio.create_task(  # pylint: disable=possibly-used-before-assignment
                 self.acquire_access_token())
         await self.acquiring

--- a/auth/gcloud/aio/auth/token.py
+++ b/auth/gcloud/aio/auth/token.py
@@ -260,7 +260,7 @@ class BaseToken:
         if not self.acquiring or self.acquiring.done():
             self.acquiring = asyncio.create_task(  # pylint: disable=possibly-used-before-assignment
                 self.acquire_access_token())
-        await self.acquire_access_token()
+        await self.acquiring
 
     @abstractmethod
     async def refresh(self, *, timeout: int) -> TokenResponse:

--- a/auth/gcloud/aio/auth/token.py
+++ b/auth/gcloud/aio/auth/token.py
@@ -260,7 +260,7 @@ class BaseToken:
         if not self.acquiring or self.acquiring.done():
             self.acquiring = asyncio.create_task(  # pylint: disable=possibly-used-before-assignment
                 self.acquire_access_token())
-        await self.acquiring
+        await self.acquire_access_token()
 
     @abstractmethod
     async def refresh(self, *, timeout: int) -> TokenResponse:

--- a/auth/tests/unit/token_test.py
+++ b/auth/tests/unit/token_test.py
@@ -74,8 +74,8 @@ async def test_acquiring_cancellation(acquire_access_token_mock):
     with pytest.raises(asyncio.TimeoutError):
         await t.get()
 
-    assert t.acquiring.done(), "Acquiring should be done after timeout"
-    assert not t.access_token, "Token should not be set after timeout"
+    assert t.acquiring.done(), 'Acquiring should be done after timeout'
+    assert not t.access_token, 'Token should not be set after timeout'
 
     # If the token timed out last time, it should retry instead of trying the
     # timed out coroutine again

--- a/auth/tests/unit/token_test.py
+++ b/auth/tests/unit/token_test.py
@@ -47,8 +47,8 @@ else:
             return await future
         t.refresh.side_effect = refresh
 
-        # Both tasks should try to acquire a token and block for the same refresh
-        # function
+        # Both tasks should try to acquire a token and block for the same
+        # refresh function
         task1 = asyncio.create_task(t.get())
         await asyncio.sleep(0)  # Let the task run
 
@@ -78,8 +78,8 @@ else:
         assert t.acquiring.done(), 'Acquiring should be done after timeout'
         assert not t.access_token, 'Token should not be set after timeout'
 
-        # If the token timed out last time, it should retry instead of trying the
-        # timed out coroutine again
+        # If the token timed out last time, it should retry instead of
+        # trying the timed out coroutine again
         t.acquire_access_token.side_effect = None
         t.acquire_access_token.return_value = None
         await t.get()

--- a/auth/tests/unit/token_test.py
+++ b/auth/tests/unit/token_test.py
@@ -4,7 +4,6 @@ import json
 from unittest import mock
 
 import pytest
-from gcloud.aio.auth import BUILD_GCLOUD_REST
 from gcloud.aio.auth import token
 
 
@@ -31,55 +30,38 @@ async def test_service_as_io():
     assert t.token_uri == 'https://oauth2.googleapis.com/token'
     assert await t.get_project() == 'random-project-123'
 
-# pylint: disable=too-complex
-if BUILD_GCLOUD_REST:
-    pass
-else:
-    @pytest.mark.asyncio
-    async def test_acquiring_refresh_called_once():
-        t = token.BaseToken()
-        t.refresh = mock.AsyncMock()
+@pytest.mark.asyncio
+async def test_acquiring_refresh_called_once():
+    t = token.BaseToken()
+    t.refresh = mock.AsyncMock()
 
-        # Use a future so we can control when refresh returns
-        future = asyncio.Future()
-
-        async def refresh(timeout):  # pylint: disable=unused-argument
-            return await future
-        t.refresh.side_effect = refresh
-
-        # Both tasks should try to acquire a token and block for the same
-        # refresh function
-        task1 = asyncio.create_task(t.get())
-        await asyncio.sleep(0)  # Let the task run
-
-        task2 = asyncio.create_task(t.get())
-        await asyncio.sleep(0)  # Let the task run
-
-        # Now set the result of the future, which should unblock both tasks
-        future.set_result(
-            token.TokenResponse(
-                value='fake_token',
-                expires_in=3600,
-            )
+    async def refresh(timeout):  # pylint: disable=unused-argument
+        return token.TokenResponse(
+            value='fake_token',
+            expires_in=3600,
         )
-        assert await task1 == await task2, 'Token should be cached and reused'
-        t.refresh.assert_awaited_once()
+    t.refresh.side_effect = refresh
 
-    @pytest.mark.asyncio
-    async def test_acquiring_cancellation():
-        t = token.BaseToken()
-        t.acquire_access_token = mock.AsyncMock()
+    task1 = await t.get()
+    task2 = await t.get()
+    assert task1 == task2, 'Token should be cached and reused'
+    t.refresh.assert_awaited_once()
 
-        # If we hit a timeout the first time, an error should return
-        t.acquire_access_token.side_effect = asyncio.TimeoutError()
-        with pytest.raises(asyncio.TimeoutError):
-            await t.get()
+@pytest.mark.asyncio
+async def test_acquiring_cancellation():
+    t = token.BaseToken()
+    t.acquire_access_token = mock.AsyncMock()
 
-        assert t.acquiring.done(), 'Acquiring should be done after timeout'
-        assert not t.access_token, 'Token should not be set after timeout'
-
-        # If the token timed out last time, it should retry instead of
-        # trying the timed out coroutine again
-        t.acquire_access_token.side_effect = None
-        t.acquire_access_token.return_value = None
+    # If we hit an exception the first time, an error should return
+    t.acquire_access_token.side_effect = ValueError()
+    with pytest.raises(ValueError):
         await t.get()
+
+    assert t.acquiring.done(), 'Acquiring should be done after timeout'
+    assert not t.access_token, 'Token should not be set after timeout'
+
+    # If the token timed out last time, it should retry instead of
+    # trying the timed out coroutine again
+    t.acquire_access_token.side_effect = None
+    t.acquire_access_token.return_value = None
+    await t.get()

--- a/auth/tests/unit/token_test.py
+++ b/auth/tests/unit/token_test.py
@@ -4,7 +4,12 @@ import json
 from unittest import mock
 
 import pytest
-from gcloud.aio.auth import token
+from gcloud.aio.auth.build_constants import BUILD_GCLOUD_REST
+
+if BUILD_GCLOUD_REST:
+    from gcloud.rest.auth import token
+else:
+    from gcloud.aio.auth import token
 
 
 @pytest.mark.asyncio

--- a/auth/tests/unit/token_test.py
+++ b/auth/tests/unit/token_test.py
@@ -32,18 +32,20 @@ async def test_service_as_io():
 
 
 @pytest.mark.asyncio
-@mock.patch("gcloud.aio.auth.token.BaseToken.refresh",
+@mock.patch('gcloud.aio.auth.token.BaseToken.refresh',
             new_callable=mock.AsyncMock)
 async def test_acquiring_refresh_called_once(refresh_mock: mock.AsyncMock):
     t = token.BaseToken()
 
     # Use a future so we can control when refresh returns
     future = asyncio.Future()
+
     async def refresh(timeout):
         return await future
     refresh_mock.side_effect = refresh
 
-    # Both tasks should try to acquire a token and block for the same refresh function
+    # Both tasks should try to acquire a token and block for the same refresh
+    # function
     task1 = asyncio.create_task(t.get())
     await asyncio.sleep(0)  # Let the task run
 
@@ -53,11 +55,11 @@ async def test_acquiring_refresh_called_once(refresh_mock: mock.AsyncMock):
     # Now set the result of the future, which should unblock both tasks
     future.set_result(
         token.TokenResponse(
-            value="fake_token",
+            value='fake_token',
             expires_in=3600,
         )
     )
-    assert await task1 == await task2, "Token should be cached and reused"
+    assert await task1 == await task2, 'Token should be cached and reused'
     refresh_mock.assert_awaited_once()
 
 

--- a/auth/tests/unit/token_test.py
+++ b/auth/tests/unit/token_test.py
@@ -4,12 +4,7 @@ import json
 from unittest import mock
 
 import pytest
-from gcloud.aio.auth.build_constants import BUILD_GCLOUD_REST
-
-if BUILD_GCLOUD_REST:
-    from gcloud.rest.auth import token
-else:
-    from gcloud.aio.auth import token
+from gcloud.aio.auth import token
 
 
 @pytest.mark.asyncio

--- a/auth/tests/unit/token_test.py
+++ b/auth/tests/unit/token_test.py
@@ -40,7 +40,7 @@ async def test_acquiring_refresh_called_once(refresh_mock: mock.AsyncMock):
     # Use a future so we can control when refresh returns
     future = asyncio.Future()
 
-    async def refresh(timeout): # pylint: disable=unused-argument
+    async def refresh(timeout):  # pylint: disable=unused-argument
         return await future
     refresh_mock.side_effect = refresh
 

--- a/auth/tests/unit/token_test.py
+++ b/auth/tests/unit/token_test.py
@@ -74,6 +74,9 @@ async def test_acquiring_cancellation(acquire_access_token_mock):
     with pytest.raises(asyncio.TimeoutError):
         await t.get()
 
+    assert t.acquiring.done(), "Acquiring should be done after timeout"
+    assert not t.access_token, "Token should not be set after timeout"
+
     # If the token timed out last time, it should retry instead of trying the
     # timed out coroutine again
     acquire_access_token_mock.side_effect = None

--- a/auth/tests/unit/token_test.py
+++ b/auth/tests/unit/token_test.py
@@ -40,7 +40,7 @@ async def test_acquiring_refresh_called_once(refresh_mock: mock.AsyncMock):
     # Use a future so we can control when refresh returns
     future = asyncio.Future()
 
-    async def refresh(timeout):
+    async def refresh(timeout): # pylint: disable=unused-argument
         return await future
     refresh_mock.side_effect = refresh
 

--- a/auth/tests/unit/token_test.py
+++ b/auth/tests/unit/token_test.py
@@ -32,6 +32,36 @@ async def test_service_as_io():
 
 
 @pytest.mark.asyncio
+@mock.patch("gcloud.aio.auth.token.BaseToken.refresh",
+            new_callable=mock.AsyncMock)
+async def test_acquiring_refresh_called_once(refresh_mock: mock.AsyncMock):
+    t = token.BaseToken()
+
+    # Use a future so we can control when refresh returns
+    future = asyncio.Future()
+    async def refresh(timeout):
+        return await future
+    refresh_mock.side_effect = refresh
+
+    # Both tasks should try to acquire a token and block for the same refresh function
+    task1 = asyncio.create_task(t.get())
+    await asyncio.sleep(0)  # Let the task run
+
+    task2 = asyncio.create_task(t.get())
+    await asyncio.sleep(0)  # Let the task run
+
+    # Now set the result of the future, which should unblock both tasks
+    future.set_result(
+        token.TokenResponse(
+            value="fake_token",
+            expires_in=3600,
+        )
+    )
+    assert await task1 == await task2, "Token should be cached and reused"
+    refresh_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 @mock.patch('gcloud.aio.auth.token.BaseToken.acquire_access_token',
             new_callable=mock.AsyncMock)
 async def test_acquiring_cancellation(acquire_access_token_mock):

--- a/auth/tests/unit/token_test.py
+++ b/auth/tests/unit/token_test.py
@@ -30,8 +30,10 @@ async def test_service_as_io():
     assert t.token_uri == 'https://oauth2.googleapis.com/token'
     assert await t.get_project() == 'random-project-123'
 
+
 @pytest.mark.asyncio
-@mock.patch("gcloud.aio.auth.token.BaseToken.acquire_access_token", new_callable=mock.AsyncMock)
+@mock.patch('gcloud.aio.auth.token.BaseToken.acquire_access_token',
+            new_callable=mock.AsyncMock)
 async def test_acquiring_cancellation(acquire_access_token_mock):
     t = token.BaseToken()
 
@@ -40,7 +42,8 @@ async def test_acquiring_cancellation(acquire_access_token_mock):
     with pytest.raises(asyncio.TimeoutError):
         await t.get()
 
-    # If the token timed out last time, it should retry instead of trying the timed out coroutine again
+    # If the token timed out last time, it should retry instead of trying the
+    # timed out coroutine again
     acquire_access_token_mock.side_effect = None
     acquire_access_token_mock.return_value = None
     await t.get()

--- a/auth/tests/unit/token_test.py
+++ b/auth/tests/unit/token_test.py
@@ -4,7 +4,7 @@ import json
 from unittest import mock
 
 import pytest
-from gcloud.aio.auth import token
+from gcloud.aio.auth import token, BUILD_GCLOUD_REST
 
 
 @pytest.mark.asyncio
@@ -30,53 +30,56 @@ async def test_service_as_io():
     assert t.token_uri == 'https://oauth2.googleapis.com/token'
     assert await t.get_project() == 'random-project-123'
 
+# pylint: disable=too-complex
+if BUILD_GCLOUD_REST:
+    pass
+else:
+    @pytest.mark.asyncio
+    async def test_acquiring_refresh_called_once():
+        t = token.BaseToken()
+        t.refresh = mock.AsyncMock()
 
-@pytest.mark.asyncio
-async def test_acquiring_refresh_called_once():
-    t = token.BaseToken()
-    t.refresh = mock.AsyncMock()
+        # Use a future so we can control when refresh returns
+        future = asyncio.Future()
 
-    # Use a future so we can control when refresh returns
-    future = asyncio.Future()
+        async def refresh(timeout):  # pylint: disable=unused-argument
+            return await future
+        t.refresh.side_effect = refresh
 
-    async def refresh(timeout):  # pylint: disable=unused-argument
-        return await future
-    t.refresh.side_effect = refresh
+        # Both tasks should try to acquire a token and block for the same refresh
+        # function
+        task1 = asyncio.create_task(t.get())
+        await asyncio.sleep(0)  # Let the task run
 
-    # Both tasks should try to acquire a token and block for the same refresh
-    # function
-    task1 = asyncio.create_task(t.get())
-    await asyncio.sleep(0)  # Let the task run
+        task2 = asyncio.create_task(t.get())
+        await asyncio.sleep(0)  # Let the task run
 
-    task2 = asyncio.create_task(t.get())
-    await asyncio.sleep(0)  # Let the task run
-
-    # Now set the result of the future, which should unblock both tasks
-    future.set_result(
-        token.TokenResponse(
-            value='fake_token',
-            expires_in=3600,
+        # Now set the result of the future, which should unblock both tasks
+        future.set_result(
+            token.TokenResponse(
+                value='fake_token',
+                expires_in=3600,
+            )
         )
-    )
-    assert await task1 == await task2, 'Token should be cached and reused'
-    t.refresh.assert_awaited_once()
+        assert await task1 == await task2, 'Token should be cached and reused'
+        t.refresh.assert_awaited_once()
 
 
-@pytest.mark.asyncio
-async def test_acquiring_cancellation():
-    t = token.BaseToken()
-    t.acquire_access_token = mock.AsyncMock()
+    @pytest.mark.asyncio
+    async def test_acquiring_cancellation():
+        t = token.BaseToken()
+        t.acquire_access_token = mock.AsyncMock()
 
-    # If we hit a timeout the first time, an error should return
-    t.acquire_access_token.side_effect = asyncio.TimeoutError()
-    with pytest.raises(asyncio.TimeoutError):
+        # If we hit a timeout the first time, an error should return
+        t.acquire_access_token.side_effect = asyncio.TimeoutError()
+        with pytest.raises(asyncio.TimeoutError):
+            await t.get()
+
+        assert t.acquiring.done(), 'Acquiring should be done after timeout'
+        assert not t.access_token, 'Token should not be set after timeout'
+
+        # If the token timed out last time, it should retry instead of trying the
+        # timed out coroutine again
+        t.acquire_access_token.side_effect = None
+        t.acquire_access_token.return_value = None
         await t.get()
-
-    assert t.acquiring.done(), 'Acquiring should be done after timeout'
-    assert not t.access_token, 'Token should not be set after timeout'
-
-    # If the token timed out last time, it should retry instead of trying the
-    # timed out coroutine again
-    t.acquire_access_token.side_effect = None
-    t.acquire_access_token.return_value = None
-    await t.get()

--- a/auth/tests/unit/token_test.py
+++ b/auth/tests/unit/token_test.py
@@ -4,7 +4,8 @@ import json
 from unittest import mock
 
 import pytest
-from gcloud.aio.auth import token, BUILD_GCLOUD_REST
+from gcloud.aio.auth import BUILD_GCLOUD_REST
+from gcloud.aio.auth import token
 
 
 @pytest.mark.asyncio
@@ -63,7 +64,6 @@ else:
         )
         assert await task1 == await task2, 'Token should be cached and reused'
         t.refresh.assert_awaited_once()
-
 
     @pytest.mark.asyncio
     async def test_acquiring_cancellation():

--- a/auth/tests/unit/token_test.py
+++ b/auth/tests/unit/token_test.py
@@ -30,6 +30,7 @@ async def test_service_as_io():
     assert t.token_uri == 'https://oauth2.googleapis.com/token'
     assert await t.get_project() == 'random-project-123'
 
+
 @pytest.mark.asyncio
 async def test_acquiring_refresh_called_once():
     t = token.BaseToken()
@@ -46,6 +47,7 @@ async def test_acquiring_refresh_called_once():
     task2 = await t.get()
     assert task1 == task2, 'Token should be cached and reused'
     t.refresh.assert_awaited_once()
+
 
 @pytest.mark.asyncio
 async def test_acquiring_cancellation():

--- a/auth/tests/unit/token_test.py
+++ b/auth/tests/unit/token_test.py
@@ -30,7 +30,6 @@ async def test_service_as_io():
     assert t.token_uri == 'https://oauth2.googleapis.com/token'
     assert await t.get_project() == 'random-project-123'
 
-
 @pytest.mark.asyncio
 async def test_acquiring_refresh_called_once():
     t = token.BaseToken()
@@ -47,7 +46,6 @@ async def test_acquiring_refresh_called_once():
     task2 = await t.get()
     assert task1 == task2, 'Token should be cached and reused'
     t.refresh.assert_awaited_once()
-
 
 @pytest.mark.asyncio
 async def test_acquiring_cancellation():

--- a/auth/tests/unit/token_test.py
+++ b/auth/tests/unit/token_test.py
@@ -4,6 +4,7 @@ import json
 from unittest import mock
 
 import pytest
+from gcloud.aio.auth import BUILD_GCLOUD_REST
 from gcloud.aio.auth import token
 
 
@@ -30,38 +31,55 @@ async def test_service_as_io():
     assert t.token_uri == 'https://oauth2.googleapis.com/token'
     assert await t.get_project() == 'random-project-123'
 
-@pytest.mark.asyncio
-async def test_acquiring_refresh_called_once():
-    t = token.BaseToken()
-    t.refresh = mock.AsyncMock()
+# pylint: disable=too-complex
+if BUILD_GCLOUD_REST:
+    pass
+else:
+    @pytest.mark.asyncio
+    async def test_acquiring_refresh_called_once():
+        t = token.BaseToken()
+        t.refresh = mock.AsyncMock()
 
-    async def refresh(timeout):  # pylint: disable=unused-argument
-        return token.TokenResponse(
-            value='fake_token',
-            expires_in=3600,
+        # Use a future so we can control when refresh returns
+        future = asyncio.Future()
+
+        async def refresh(timeout):  # pylint: disable=unused-argument
+            return await future
+        t.refresh.side_effect = refresh
+
+        # Both tasks should try to acquire a token and block for the same
+        # refresh function
+        task1 = asyncio.create_task(t.get())
+        await asyncio.sleep(0)  # Let the task run
+
+        task2 = asyncio.create_task(t.get())
+        await asyncio.sleep(0)  # Let the task run
+
+        # Now set the result of the future, which should unblock both tasks
+        future.set_result(
+            token.TokenResponse(
+                value='fake_token',
+                expires_in=3600,
+            )
         )
-    t.refresh.side_effect = refresh
+        assert await task1 == await task2, 'Token should be cached and reused'
+        t.refresh.assert_awaited_once()
 
-    task1 = await t.get()
-    task2 = await t.get()
-    assert task1 == task2, 'Token should be cached and reused'
-    t.refresh.assert_awaited_once()
+    @pytest.mark.asyncio
+    async def test_acquiring_cancellation():
+        t = token.BaseToken()
+        t.acquire_access_token = mock.AsyncMock()
 
-@pytest.mark.asyncio
-async def test_acquiring_cancellation():
-    t = token.BaseToken()
-    t.acquire_access_token = mock.AsyncMock()
+        # If we hit a timeout the first time, an error should return
+        t.acquire_access_token.side_effect = asyncio.TimeoutError()
+        with pytest.raises(asyncio.TimeoutError):
+            await t.get()
 
-    # If we hit an exception the first time, an error should return
-    t.acquire_access_token.side_effect = ValueError()
-    with pytest.raises(ValueError):
+        assert t.acquiring.done(), 'Acquiring should be done after timeout'
+        assert not t.access_token, 'Token should not be set after timeout'
+
+        # If the token timed out last time, it should retry instead of
+        # trying the timed out coroutine again
+        t.acquire_access_token.side_effect = None
+        t.acquire_access_token.return_value = None
         await t.get()
-
-    assert t.acquiring.done(), 'Acquiring should be done after timeout'
-    assert not t.access_token, 'Token should not be set after timeout'
-
-    # If the token timed out last time, it should retry instead of
-    # trying the timed out coroutine again
-    t.acquire_access_token.side_effect = None
-    t.acquire_access_token.return_value = None
-    await t.get()

--- a/bin/build-rest
+++ b/bin/build-rest
@@ -81,6 +81,10 @@ find . -type f -path '*py' \
 find . -type f -path '*tests/*' \
     | xargs -L1 $SED -Ei 's/@pytest.mark.asyncio/#@pytest.mark.asyncio/g'
 find . -type f -path '*tests/*' \
+    | xargs -L1 $SED -Ei 's/mock.AsyncMock/mock.Mock/g'
+find . -type f -path '*tests/*' \
+    | xargs -L1 $SED -Ei 's/assert_awaited_once()/assert_called_once()/g'
+find . -type f -path '*tests/*' \
     | xargs -L1 $SED -Ei 's/Session\(.*\)\sas/Session() as/g'
 find . -type f -path '*py' \
     | xargs -L1 $SED -Ei 's/__aenter__/__enter__/g'

--- a/bin/build-rest
+++ b/bin/build-rest
@@ -81,10 +81,6 @@ find . -type f -path '*py' \
 find . -type f -path '*tests/*' \
     | xargs -L1 $SED -Ei 's/@pytest.mark.asyncio/#@pytest.mark.asyncio/g'
 find . -type f -path '*tests/*' \
-    | xargs -L1 $SED -Ei 's/mock.AsyncMock/mock.Mock/g'
-find . -type f -path '*tests/*' \
-    | xargs -L1 $SED -Ei 's/assert_awaited_once()/assert_called_once()/g'
-find . -type f -path '*tests/*' \
     | xargs -L1 $SED -Ei 's/Session\(.*\)\sas/Session() as/g'
 find . -type f -path '*py' \
     | xargs -L1 $SED -Ei 's/__aenter__/__enter__/g'


### PR DESCRIPTION
## Summary

If acquire_access_token exhausts retries (for any crazy reason), we continue to try to call it over and over again. This happens pretty infrequently but there's no way to fix it when it does happen. 

<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant issues / branches / other PRs / blockers / etc.
--->
