### PR TITLE
refactor(renovate): clean up renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,32 +1,19 @@
 {
-  "assignees": ["TheKevJames"],
-  "extends": [
-    "github>thekevjames/tools",
-    "github>thekevjames/tools:trustedpackages"
-  ],
-  "packageRules": [
-    {
-      // only autoupdate python patches, we'll handle minors more explicitly
-      "matchPackageNames": ["python"],
-      "matchUpdateTypes": ["major", "minor"],
-      "enabled": false,
+    "extends": [
+        "github>thekevjames/tools",
+        "github>thekevjames/tools//renovate/version-as-lib.json5"
+    ],
+    "assignees": ["TheKevJames"],
+    "packageRules": [
+        {
+            // only autoupdate python patches, we'll handle minors more explicitly
+            "matchPackageNames": ["python"],
+            "matchUpdateTypes": ["major", "minor"],
+            "enabled": false,
+        },
+    ],
+    "lockFileMaintenance": {
+        "enabled": true,
+        "schedule": "before 1pm on monday"
     },
-    {
-      "matchDepTypes": ["dependencies"],
-      "rangeStrategy": "widen",
-    },
-    {
-      "matchDepTypes": ["dev", "devDependencies"],
-      "rangeStrategy": "pin",
-      "automerge": true,
-    },
-    {
-      "matchUpdateTypes": ["patch"],
-      "automerge": true
-    },
-  ],
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": "before 1pm on monday"
-  },
 }


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant tickets / branches / other PRs / blockers / etc.
--->
I overhauled my shared renovate configs to make things a bunch more granular
(https://github.com/TheKevJames/tools/commit/0f05ec1246df62f732382648b00ee122fe57b611 ).
This commit migrates our changes in-place to follow the new schema. Should be a
noop!
