### PR TITLE
feat(auth): external credential type in auth

### DIFF
--- a/auth/README.rst
+++ b/auth/README.rst
@@ -19,6 +19,13 @@ against Google Cloud. The other ``gcloud-aio-*`` package components accept a
 these components or define one for each. Each component corresponds to a given
 Google Cloud service and each service requires various "`scopes`_".
 
+The library supports multiple authentication methods:
+- Service account credentials
+- Authorized user credentials
+- GCE metadata credentials
+- Impersonated service account credentials
+- External account credentials (for workload identity federation)
+
 |pypi| |pythons|
 
 Installation
@@ -31,7 +38,166 @@ Installation
 Usage
 -----
 
-See `our docs`_.
+Basic Usage
+~~~~~~~~~~
+
+.. code-block:: python
+
+    from gcloud.aio.auth import Token
+
+    # Using default credentials (searches for credentials in standard locations)
+    token = Token()
+    access_token = await token.get()
+
+    # Using a specific service account file
+    token = Token(service_file='path/to/service-account.json')
+    access_token = await token.get()
+
+    # Using a custom session
+    import aiohttp
+    async with aiohttp.ClientSession() as session:
+        token = Token(session=session)
+        access_token = await token.get()
+
+Service Account Authentication
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    from gcloud.aio.auth import Token
+
+    # Using service account with specific scopes
+    token = Token(
+        service_file='path/to/service-account.json',
+        scopes=['https://www.googleapis.com/auth/cloud-platform']
+    )
+    access_token = await token.get()
+
+    # Get the project ID
+    project_id = await token.get_project()
+
+Authorized User Authentication
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    from gcloud.aio.auth import Token
+
+    # Using authorized user credentials (e.g., from gcloud auth application-default login)
+    token = Token(service_file='~/.config/gcloud/application_default_credentials.json')
+    access_token = await token.get()
+
+GCE Metadata Authentication
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    from gcloud.aio.auth import Token
+
+    # When running on Google Compute Engine, metadata server is used automatically
+    token = Token()
+    access_token = await token.get()
+
+Service Account Impersonation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    from gcloud.aio.auth import Token
+
+    # Impersonate a service account
+    token = Token(
+        service_file='path/to/source-credentials.json',
+        target_principal='target-service@project.iam.gserviceaccount.com',
+        scopes=['https://www.googleapis.com/auth/cloud-platform']
+    )
+    access_token = await token.get()
+
+    # With delegation chain
+    token = Token(
+        service_file='path/to/source-credentials.json',
+        target_principal='target-service@project.iam.gserviceaccount.com',
+        delegates=['delegate-service@project.iam.gserviceaccount.com'],
+        scopes=['https://www.googleapis.com/auth/cloud-platform']
+    )
+    access_token = await token.get()
+
+External Account Credentials
+---------------------------
+
+The library supports external account credentials for workload identity federation. This allows you to use credentials from external identity providers (like AWS, Azure, or OIDC) to access Google Cloud resources.
+
+Example configuration file:
+
+.. code-block:: json
+
+    {
+        "type": "external_account",
+        "audience": "//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/pool/subject",
+        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+        "token_url": "https://sts.googleapis.com/v1/token",
+        "credential_source": {
+            "type": "url",
+            "url": "http://169.254.169.254/metadata/identity/oauth2/token",
+            "headers": {
+                "Metadata": "true"
+            }
+        }
+    }
+
+Usage:
+
+.. code-block:: python
+
+    from gcloud.aio.auth import Token
+
+    # Basic usage with external account credentials
+    token = Token(service_file='path/to/external_account_credentials.json')
+    access_token = await token.get()
+
+    # With specific scopes
+    token = Token(
+        service_file='path/to/external_account_credentials.json',
+        scopes=['https://www.googleapis.com/auth/cloud-platform']
+    )
+    access_token = await token.get()
+
+The library supports multiple credential source types:
+- URL: Fetches token from a URL endpoint (supports both text and JSON responses)
+- File: Reads token from a file
+- Environment: Gets token from an environment variable
+
+IAP Token Usage
+~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    from gcloud.aio.auth import IapToken
+
+    # Basic IAP token usage
+    iap_token = IapToken('https://your-iap-secured-service.com')
+    id_token = await iap_token.get()
+
+    # With service account impersonation
+    iap_token = IapToken(
+        'https://your-iap-secured-service.com',
+        impersonating_service_account='service@project.iam.gserviceaccount.com'
+    )
+    id_token = await iap_token.get()
+
+IAM Client Usage
+~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    from gcloud.aio.auth import IamClient
+
+    # List public keys
+    client = IamClient()
+    pubkeys = await client.list_public_keys()
+
+    # Get a specific public key
+    key = await client.get_public_key('key-id')
 
 Contributing
 ------------

--- a/auth/gcloud/aio/auth/token.py
+++ b/auth/gcloud/aio/auth/token.py
@@ -1,6 +1,7 @@
 """
 Google Cloud auth via service account file
 """
+
 import datetime
 import enum
 import json
@@ -51,43 +52,41 @@ else:
 # Environment variable GCE_METADATA_HOST is originally named GCE_METADATA_ROOT.
 # For compatibility reasons, here it checks the new variable first; if not set,
 # the system falls back to the old variable.
-_GCE_METADATA_HOST = os.environ.get('GCE_METADATA_HOST')
+_GCE_METADATA_HOST = os.environ.get("GCE_METADATA_HOST")
 if not _GCE_METADATA_HOST:
-    _GCE_METADATA_HOST = os.environ.get(
-        'GCE_METADATA_ROOT', 'metadata.google.internal'
-    )
+    _GCE_METADATA_HOST = os.environ.get("GCE_METADATA_ROOT", "metadata.google.internal")
 
-GCE_METADATA_BASE = f'http://{_GCE_METADATA_HOST}/computeMetadata/v1'
-GCE_METADATA_HEADERS = {'metadata-flavor': 'Google'}
-GCE_ENDPOINT_PROJECT = f'{GCE_METADATA_BASE}/project/project-id'
+GCE_METADATA_BASE = f"http://{_GCE_METADATA_HOST}/computeMetadata/v1"
+GCE_METADATA_HEADERS = {"metadata-flavor": "Google"}
+GCE_ENDPOINT_PROJECT = f"{GCE_METADATA_BASE}/project/project-id"
 GCE_ENDPOINT_TOKEN = (
-    f'{GCE_METADATA_BASE}/instance/service-accounts'
-    '/default/token?recursive=true'
+    f"{GCE_METADATA_BASE}/instance/service-accounts/default/token?recursive=true"
 )
 GCE_ENDPOINT_ID_TOKEN = (
-    f'{GCE_METADATA_BASE}/instance/service-accounts'
-    '/default/identity?audience={audience}&format=full'
+    f"{GCE_METADATA_BASE}/instance/service-accounts"
+    "/default/identity?audience={audience}&format=full"
 )
 GCLOUD_ENDPOINT_GENERATE_ACCESS_TOKEN = (
-    'https://iamcredentials.googleapis.com'
-    '/v1/projects/-/serviceAccounts/{service_account}:generateAccessToken'
+    "https://iamcredentials.googleapis.com"
+    "/v1/projects/-/serviceAccounts/{service_account}:generateAccessToken"
 )
 GCLOUD_ENDPOINT_GENERATE_ID_TOKEN = (
-    'https://iamcredentials.googleapis.com'
-    '/v1/projects/-/serviceAccounts/{service_account}:generateIdToken'
+    "https://iamcredentials.googleapis.com"
+    "/v1/projects/-/serviceAccounts/{service_account}:generateIdToken"
 )
-REFRESH_HEADERS = {'Content-Type': 'application/x-www-form-urlencoded'}
+REFRESH_HEADERS = {"Content-Type": "application/x-www-form-urlencoded"}
 
 
 class Type(enum.Enum):
-    AUTHORIZED_USER = 'authorized_user'
-    GCE_METADATA = 'gce_metadata'
-    SERVICE_ACCOUNT = 'service_account'
-    IMPERSONATED_SERVICE_ACCOUNT = 'impersonated_service_account'
+    AUTHORIZED_USER = "authorized_user"
+    GCE_METADATA = "gce_metadata"
+    SERVICE_ACCOUNT = "service_account"
+    IMPERSONATED_SERVICE_ACCOUNT = "impersonated_service_account"
+    EXTERNAL_ACCOUNT = "external_account"
 
 
 def get_service_data(
-        service: Optional[Union[str, IO[AnyStr]]],
+    service: Optional[Union[str, IO[AnyStr]]],
 ) -> Dict[str, Any]:
     """
     Get the service data dictionary for the current auth method.
@@ -101,28 +100,30 @@ def get_service_data(
     """
     # pylint: disable=too-complex
     # _get_explicit_environ_credentials()
-    service = service or os.environ.get('GOOGLE_APPLICATION_CREDENTIALS')
+    service = service or os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
 
     if not service:
         # _get_gcloud_sdk_credentials()
-        cloudsdk_config = os.environ.get('CLOUDSDK_CONFIG')
+        cloudsdk_config = os.environ.get("CLOUDSDK_CONFIG")
         if cloudsdk_config is not None:
             sdkpath = cloudsdk_config
-        elif os.name != 'nt':
+        elif os.name != "nt":
             sdkpath = os.path.join(
-                os.path.expanduser('~'), '.config',
-                'gcloud',
+                os.path.expanduser("~"),
+                ".config",
+                "gcloud",
             )
         else:
             try:
-                sdkpath = os.path.join(os.environ['APPDATA'], 'gcloud')
+                sdkpath = os.path.join(os.environ["APPDATA"], "gcloud")
             except KeyError:
                 sdkpath = os.path.join(
-                    os.environ.get('SystemDrive', 'C:'),
-                    '\\', 'gcloud',
+                    os.environ.get("SystemDrive", "C:"),
+                    "\\",
+                    "gcloud",
                 )
 
-        service = os.path.join(sdkpath, 'application_default_credentials.json')
+        service = os.path.join(sdkpath, "application_default_credentials.json")
         set_explicitly = bool(cloudsdk_config)
     else:
         set_explicitly = True
@@ -136,12 +137,40 @@ def get_service_data(
         try:
             with open(
                 service,  # type: ignore[arg-type]
-                encoding='utf-8',
+                encoding="utf-8",
             ) as f:
                 data: Dict[str, Any] = json.loads(f.read())
+                # Handle external account credentials
+                if data.get("type") == "external_account":
+                    # Ensure required fields are present
+                    required_fields = [
+                        "audience",
+                        "subject_token_type",
+                        "token_url",
+                        "credential_source",
+                    ]
+                    if not all(field in data for field in required_fields):
+                        raise ValueError(
+                            "External account credentials missing required fields: "
+                            f"{', '.join(required_fields)}"
+                        )
                 return data
         except TypeError:
             data = json.loads(service.read())  # type: ignore[union-attr]
+            # Handle external account credentials
+            if data.get("type") == "external_account":
+                # Ensure required fields are present
+                required_fields = [
+                    "audience",
+                    "subject_token_type",
+                    "token_url",
+                    "credential_source",
+                ]
+                if not all(field in data for field in required_fields):
+                    raise ValueError(
+                        "External account credentials missing required fields: "
+                        f"{', '.join(required_fields)}"
+                    )
             return data
     except CustomFileError:
         if set_explicitly:
@@ -164,21 +193,21 @@ class TokenResponse:
 
 class BaseToken:
     """GCP auth token base class."""
+
     # pylint: disable=too-many-instance-attributes
     __metaclass__ = ABCMeta
 
     def __init__(
-        self, service_file: Optional[Union[str, IO[AnyStr]]] = None,
+        self,
+        service_file: Optional[Union[str, IO[AnyStr]]] = None,
         session: Optional[Session] = None,
         background_refresh_after: float = 0.5,
         force_refresh_after: float = 0.95,
     ) -> None:
         if background_refresh_after <= 0 or background_refresh_after > 1:
-            raise ValueError(
-                'background_refresh_after must be a value between 0 and 1')
+            raise ValueError("background_refresh_after must be a value between 0 and 1")
         if force_refresh_after <= 0 or force_refresh_after > 1:
-            raise ValueError(
-                'force_refresh_after must be a value between 0 and 1')
+            raise ValueError("force_refresh_after must be a value between 0 and 1")
         # Portion of TTL after which a background refresh would start
         self.background_refresh_after = background_refresh_after
         # Portion of TTL after which a cached token is considered invalid
@@ -186,10 +215,25 @@ class BaseToken:
 
         self.service_data = get_service_data(service_file)
         if self.service_data:
-            self.token_type = Type(self.service_data['type'])
-            self.token_uri = self.service_data.get(
-                'token_uri', 'https://oauth2.googleapis.com/token',
-            )
+            self.token_type = Type(self.service_data["type"])
+            if self.token_type == Type.EXTERNAL_ACCOUNT:
+                required_fields = [
+                    "audience",
+                    "subject_token_type",
+                    "token_url",
+                    "credential_source",
+                ]
+                if not all(field in self.service_data for field in required_fields):
+                    raise ValueError(
+                        "External account credentials missing required fields: "
+                        f"{', '.join(required_fields)}"
+                    )
+                self.token_uri = self.service_data["token_url"]
+            else:
+                self.token_uri = self.service_data.get(
+                    "token_uri",
+                    "https://oauth2.googleapis.com/token",
+                )
         else:
             # At this point, all we can do is assume we're running somewhere
             # with default credentials, eg. GCE.
@@ -206,13 +250,13 @@ class BaseToken:
         # Timestamp after which we must re-fetch.
         self.access_token_refresh_after = 0
 
-        self.acquiring: Optional['asyncio.Task[None]'] = None
+        self.acquiring: Optional["asyncio.Task[None]"] = None
 
     async def get_project(self) -> Optional[str]:
         project = (
-            os.environ.get('GOOGLE_CLOUD_PROJECT')
-            or os.environ.get('GCLOUD_PROJECT')
-            or os.environ.get('APPLICATION_ID')
+            os.environ.get("GOOGLE_CLOUD_PROJECT")
+            or os.environ.get("GCLOUD_PROJECT")
+            or os.environ.get("APPLICATION_ID")
         )
         if project:
             return project
@@ -220,7 +264,8 @@ class BaseToken:
         if self.token_type == Type.GCE_METADATA:
             await self.ensure_token()
             resp = await self.session.get(
-                GCE_ENDPOINT_PROJECT, timeout=10,
+                GCE_ENDPOINT_PROJECT,
+                timeout=10,
                 headers=GCE_METADATA_HEADERS,
             )
 
@@ -230,7 +275,7 @@ class BaseToken:
                 return str(resp.text)
 
         if self.token_type == Type.SERVICE_ACCOUNT:
-            return self.service_data.get('project_id')
+            return self.service_data.get("project_id")
 
         return None
 
@@ -241,9 +286,7 @@ class BaseToken:
     async def ensure_token(self) -> None:
         if self.access_token:
             # Cached token exists
-            now_ts = int(
-                datetime.datetime.now(
-                    datetime.timezone.utc).timestamp())
+            now_ts = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
             if now_ts > self.access_token_refresh_after:
                 # Cached token does not have enough duration left, fall through
                 pass
@@ -251,7 +294,8 @@ class BaseToken:
                 # Token is okay, but we need to fire up a preemptive refresh
                 if not self.acquiring or self.acquiring.done():
                     self.acquiring = asyncio.create_task(  # pylint: disable=possibly-used-before-assignment
-                        self.acquire_access_token())
+                        self.acquire_access_token()
+                    )
                 return
             else:
                 # Cached token is valid for use
@@ -259,7 +303,8 @@ class BaseToken:
 
         if not self.acquiring or self.acquiring.done():
             self.acquiring = asyncio.create_task(  # pylint: disable=possibly-used-before-assignment
-                self.acquire_access_token())
+                self.acquire_access_token()
+            )
         await self.acquiring
 
     @abstractmethod
@@ -272,19 +317,20 @@ class BaseToken:
 
         self.access_token = resp.value
         self.access_token_duration = resp.expires_in
-        self.access_token_acquired_at = datetime.datetime.now(
-            datetime.timezone.utc)
+        self.access_token_acquired_at = datetime.datetime.now(datetime.timezone.utc)
         base_timestamp = self.access_token_acquired_at.timestamp()
         self.access_token_preempt_after = int(
-            base_timestamp + (resp.expires_in * self.background_refresh_after))
+            base_timestamp + (resp.expires_in * self.background_refresh_after)
+        )
         self.access_token_refresh_after = int(
-            base_timestamp + (resp.expires_in * self.force_refresh_after))
+            base_timestamp + (resp.expires_in * self.force_refresh_after)
+        )
         self.acquiring = None
 
     async def close(self) -> None:
         await self.session.close()
 
-    async def __aenter__(self) -> 'BaseToken':
+    async def __aenter__(self) -> "BaseToken":
         return self
 
     async def __aexit__(self, *args: Any) -> None:
@@ -293,11 +339,13 @@ class BaseToken:
 
 class Token(BaseToken):
     """GCP OAuth 2.0 access token."""
+
     # pylint: disable=too-many-instance-attributes
     default_token_ttl = 3600
 
     def __init__(
-        self, service_file: Optional[Union[str, IO[AnyStr]]] = None,
+        self,
+        service_file: Optional[Union[str, IO[AnyStr]]] = None,
         session: Optional[Session] = None,
         scopes: Optional[List[str]] = None,
         target_principal: Optional[str] = None,
@@ -305,151 +353,293 @@ class Token(BaseToken):
     ) -> None:
         super().__init__(service_file=service_file, session=session)
 
-        self.scopes = ''
+        self.scopes = ""
         if scopes:
-            self.scopes = ' '.join(scopes or [])
+            self.scopes = " ".join(scopes or [])
         elif self.service_data:
             if self.token_type == Type.IMPERSONATED_SERVICE_ACCOUNT:
                 # If service file was provided and the type is
                 # IMPERSONATED_SERVICE_ACCOUNT, gcloud requires this default
                 # scope but does not write it to the file
-                self.scopes = 'https://www.googleapis.com/auth/cloud-platform'
+                self.scopes = "https://www.googleapis.com/auth/cloud-platform"
 
         self.impersonation_uri: Optional[str] = None
         if target_principal:
-            self.impersonation_uri = (
-                GCLOUD_ENDPOINT_GENERATE_ACCESS_TOKEN.format(
-                    service_account=target_principal
-                )
+            self.impersonation_uri = GCLOUD_ENDPOINT_GENERATE_ACCESS_TOKEN.format(
+                service_account=target_principal
             )
-        elif self.service_data.get('service_account_impersonation_url'):
+        elif self.service_data.get("service_account_impersonation_url"):
             self.impersonation_uri = self.service_data[
-                'service_account_impersonation_url'
+                "service_account_impersonation_url"
             ]
 
         if self.impersonation_uri and not self.scopes:
             raise Exception(
-                'scopes must be provided when token type requires '
-                'impersonation',
+                "scopes must be provided when token type requires impersonation",
             )
         self.delegates = delegates
 
     async def _refresh_authorized_user(self, timeout: int) -> TokenResponse:
-        payload = urlencode({
-            'grant_type': 'refresh_token',
-            'client_id': self.service_data['client_id'],
-            'client_secret': self.service_data['client_secret'],
-            'refresh_token': self.service_data['refresh_token'],
-        })
+        payload = urlencode(
+            {
+                "grant_type": "refresh_token",
+                "client_id": self.service_data["client_id"],
+                "client_secret": self.service_data["client_secret"],
+                "refresh_token": self.service_data["refresh_token"],
+            }
+        )
 
         resp = await self.session.post(
-            url=self.token_uri, data=payload, headers=REFRESH_HEADERS,
+            url=self.token_uri,
+            data=payload,
+            headers=REFRESH_HEADERS,
             timeout=timeout,
         )
         content = await resp.json()
-        return TokenResponse(value=str(content['access_token']),
-                             expires_in=int(content['expires_in']))
+        return TokenResponse(
+            value=str(content["access_token"]), expires_in=int(content["expires_in"])
+        )
 
     async def _refresh_source_authorized_user(
-            self, timeout: int,
+        self,
+        timeout: int,
     ) -> TokenResponse:
-        source_credentials = self.service_data['source_credentials']
-        payload = urlencode({
-            'grant_type': 'refresh_token',
-            'client_id': source_credentials['client_id'],
-            'client_secret': source_credentials['client_secret'],
-            'refresh_token': source_credentials['refresh_token'],
-        })
+        source_credentials = self.service_data["source_credentials"]
+        payload = urlencode(
+            {
+                "grant_type": "refresh_token",
+                "client_id": source_credentials["client_id"],
+                "client_secret": source_credentials["client_secret"],
+                "refresh_token": source_credentials["refresh_token"],
+            }
+        )
 
         resp = await self.session.post(
-            url=self.token_uri, data=payload, headers=REFRESH_HEADERS,
+            url=self.token_uri,
+            data=payload,
+            headers=REFRESH_HEADERS,
             timeout=timeout,
         )
         content = await resp.json()
-        return TokenResponse(value=str(content['access_token']),
-                             expires_in=int(content['expires_in']))
+        return TokenResponse(
+            value=str(content["access_token"]), expires_in=int(content["expires_in"])
+        )
 
     async def _refresh_gce_metadata(self, timeout: int) -> TokenResponse:
         resp = await self.session.get(
-            url=self.token_uri, headers=GCE_METADATA_HEADERS, timeout=timeout,
+            url=self.token_uri,
+            headers=GCE_METADATA_HEADERS,
+            timeout=timeout,
         )
         content = await resp.json()
-        return TokenResponse(value=str(content['access_token']),
-                             expires_in=int(content['expires_in']))
+        return TokenResponse(
+            value=str(content["access_token"]), expires_in=int(content["expires_in"])
+        )
 
     async def _refresh_service_account(self, timeout: int) -> TokenResponse:
         now = int(time.time())
         assertion_payload = {
-            'aud': self.token_uri,
-            'exp': now + self.default_token_ttl,
-            'iat': now,
-            'iss': self.service_data['client_email'],
-            'scope': self.scopes,
+            "aud": self.token_uri,
+            "exp": now + self.default_token_ttl,
+            "iat": now,
+            "iss": self.service_data["client_email"],
+            "scope": self.scopes,
         }
 
         # N.B. algorithm='RS256' requires an extra 240MB in dependencies...
         assertion = jwt.encode(
             assertion_payload,
-            self.service_data['private_key'],
-            algorithm='RS256',
+            self.service_data["private_key"],
+            algorithm="RS256",
         )
-        payload = urlencode({
-            'assertion': assertion,
-            'grant_type': 'urn:ietf:params:oauth:grant-type:jwt-bearer',
-        })
+        payload = urlencode(
+            {
+                "assertion": assertion,
+                "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            }
+        )
 
         resp = await self.session.post(
-            self.token_uri, data=payload, headers=REFRESH_HEADERS,
+            self.token_uri,
+            data=payload,
+            headers=REFRESH_HEADERS,
             timeout=timeout,
         )
         content = await resp.json()
 
         # no .get() on the second option - Raises KeyError if neither found
-        token = str(content.get('access_token') or content['id_token'])
-        expires = int(content.get('expires_in', '0')) or self.default_token_ttl
+        token = str(content.get("access_token") or content["id_token"])
+        expires = int(content.get("expires_in", "0")) or self.default_token_ttl
         return TokenResponse(value=token, expires_in=expires)
 
-    async def _impersonate(self, token: TokenResponse,
-                           *, timeout: int) -> TokenResponse:
+    async def _impersonate(
+        self, token: TokenResponse, *, timeout: int
+    ) -> TokenResponse:
         if not self.impersonation_uri:
-            raise Exception('cannot impersonate without impersonation_uri set')
+            raise Exception("cannot impersonate without impersonation_uri set")
 
         # impersonate the target principal with optional delegates
         headers = {
-            'Authorization': f'Bearer {token.value}',
+            "Authorization": f"Bearer {token.value}",
         }
-        payload = json.dumps({
-            'lifetime': f'{self.default_token_ttl}s',
-            'scope': self.scopes.split(' '),
-            'delegates': self.delegates,
-        })
+        payload = json.dumps(
+            {
+                "lifetime": f"{self.default_token_ttl}s",
+                "scope": self.scopes.split(" "),
+                "delegates": self.delegates,
+            }
+        )
 
         resp = await self.session.post(
-            self.impersonation_uri, data=payload, headers=headers,
+            self.impersonation_uri,
+            data=payload,
+            headers=headers,
             timeout=timeout,
         )
 
         data = await resp.json()
-        token.value = str(data['accessToken'])
+        token.value = str(data["accessToken"])
         return token
 
-    async def refresh(self, *, timeout: int) -> TokenResponse:
-        if self.token_type == Type.AUTHORIZED_USER:
-            resp = await self._refresh_authorized_user(timeout=timeout)
-        elif self.token_type == Type.GCE_METADATA:
-            resp = await self._refresh_gce_metadata(timeout=timeout)
-        elif self.token_type == Type.SERVICE_ACCOUNT:
-            resp = await self._refresh_service_account(timeout=timeout)
-        elif self.token_type == Type.IMPERSONATED_SERVICE_ACCOUNT:
-            # impersonation requires a source authorized user
-            resp = await self._refresh_source_authorized_user(timeout=timeout)
+    async def _refresh_external_account(self, timeout: int) -> TokenResponse:
+        """Refresh token for external account credentials."""
+        if not self.service_data:
+            raise ValueError(
+                "No service data available for external account credentials"
+            )
+
+        # Ensure required fields are present
+        required_fields = [
+            "audience",
+            "subject_token_type",
+            "token_url",
+            "credential_source",
+        ]
+        if not all(field in self.service_data for field in required_fields):
+            raise ValueError(
+                "External account credentials missing required fields: "
+                f"{', '.join(required_fields)}"
+            )
+
+        # Get the subject token from the credential source
+        credential_source = self.service_data["credential_source"]
+        subject_token = await self._get_subject_token(credential_source, timeout)
+
+        # Exchange the subject token for a Google access token
+        data = {
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "audience": self.service_data["audience"],
+            "subject_token_type": self.service_data["subject_token_type"],
+            "subject_token": subject_token,
+            "requested_token_type": "urn:ietf:params:oauth:token-type:access_token",
+        }
+
+        # Add optional service account impersonation if configured
+        if "service_account_impersonation_url" in self.service_data:
+            data["service_account_impersonation_url"] = self.service_data[
+                "service_account_impersonation_url"
+            ]
+
+        # Add optional client ID and secret if configured
+        if "client_id" in self.service_data:
+            data["client_id"] = self.service_data["client_id"]
+        if "client_secret" in self.service_data:
+            data["client_secret"] = self.service_data["client_secret"]
+
+        # Add scopes if configured
+        if hasattr(self, "scopes") and self.scopes:
+            data["scope"] = " ".join(self.scopes)
+
+        resp = await self.session.post(
+            self.service_data["token_url"],
+            data=urlencode(data),
+            headers=REFRESH_HEADERS,
+            timeout=timeout,
+        )
+
+        if resp.status != 200:
+            raise ValueError(
+                f"Failed to refresh external account token: {resp.status} {resp.reason}"
+            )
+
+        try:
+            data = await resp.json()
+        except (AttributeError, TypeError):
+            data = json.loads(resp.text)
+
+        return TokenResponse(
+            value=data["access_token"],
+            expires_in=data.get("expires_in", self.default_token_ttl),
+        )
+
+    async def _get_subject_token(
+        self, credential_source: Dict[str, Any], timeout: int
+    ) -> str:
+        """Get the subject token from the credential source."""
+        source_type = credential_source.get("type")
+        if not source_type:
+            raise ValueError("Credential source missing type")
+
+        if source_type == "url":
+            # Get token from URL
+            url = credential_source["url"]
+            headers = credential_source.get("headers", {})
+            format_type = credential_source.get("format", {}).get("type", "text")
+
+            resp = await self.session.get(url, headers=headers, timeout=timeout)
+            if resp.status != 200:
+                raise ValueError(
+                    f"Failed to get subject token from URL: {resp.status} {resp.reason}"
+                )
+
+            if format_type == "json":
+                try:
+                    data = await resp.json()
+                except (AttributeError, TypeError):
+                    data = json.loads(resp.text)
+                return data[credential_source["format"]["subject_token_field_name"]]
+            else:
+                try:
+                    return await resp.text()
+                except (AttributeError, TypeError):
+                    return str(resp.text)
+
+        elif source_type == "file":
+            # Get token from file
+            file_path = credential_source["file"]
+            try:
+                with open(file_path, "r", encoding="utf-8") as f:
+                    return f.read().strip()
+            except Exception as e:
+                raise ValueError(f"Failed to read subject token from file: {e}")
+
+        elif source_type == "environment":
+            # Get token from environment variable
+            env_var = credential_source["environment_id"]
+            token = os.environ.get(env_var)
+            if not token:
+                raise ValueError(f"Environment variable {env_var} not set")
+            return token
+
         else:
-            raise Exception(f'unsupported token type {self.token_type}')
+            raise ValueError(f"Unsupported credential source type: {source_type}")
 
-        if self.impersonation_uri:
-            resp = await self._impersonate(resp, timeout=timeout)
-
-        return resp
+    async def refresh(self, *, timeout: int) -> TokenResponse:
+        """Refresh the token."""
+        if self.token_type == Type.AUTHORIZED_USER:
+            return await self._refresh_authorized_user(timeout)
+        if self.token_type == Type.GCE_METADATA:
+            return await self._refresh_gce_metadata(timeout)
+        if self.token_type == Type.SERVICE_ACCOUNT:
+            return await self._refresh_service_account(timeout)
+        if self.token_type == Type.EXTERNAL_ACCOUNT:
+            return await self._refresh_external_account(timeout)
+        if self.token_type == Type.IMPERSONATED_SERVICE_ACCOUNT:
+            # First get a token from the source credentials
+            source_token = await self._refresh_source_authorized_user(timeout)
+            # Then impersonate the target service account
+            return await self._impersonate(source_token, timeout=timeout)
+        raise ValueError(f"Unsupported token type: {self.token_type}")
 
 
 class IapToken(BaseToken):
@@ -458,7 +648,8 @@ class IapToken(BaseToken):
     default_token_ttl = 3600
 
     def __init__(
-        self, app_uri: str,
+        self,
+        app_uri: str,
         service_file: Optional[Union[str, IO[AnyStr]]] = None,
         session: Optional[Session] = None,
         impersonating_service_account: Optional[str] = None,
@@ -468,11 +659,10 @@ class IapToken(BaseToken):
         self.app_uri = app_uri
         self.service_account = impersonating_service_account
 
-        if (self.token_type == Type.AUTHORIZED_USER
-                and not self.service_account):
+        if self.token_type == Type.AUTHORIZED_USER and not self.service_account:
             raise Exception(
-                'service account name must be provided when token type is '
-                'authorized user',
+                "service account name must be provided when token type is "
+                "authorized user",
             )
 
     async def _get_iap_client_id(self, *, timeout: int) -> str:
@@ -487,24 +677,30 @@ class IapToken(BaseToken):
         For more details, see the GCP docs for programmatic IAP access:
         https://cloud.google.com/iap/docs/authentication-howto
         """
-        resp = await self.session.head(self.app_uri, timeout=timeout,
-                                       allow_redirects=False)
+        resp = await self.session.head(
+            self.app_uri, timeout=timeout, allow_redirects=False
+        )
 
-        redirect_location = resp.headers.get('location')
+        redirect_location = resp.headers.get("location")
         if not redirect_location:
-            raise Exception(f'No redirect location for service {self.app_uri},'
-                            ' is it secured with IAP?')
+            raise Exception(
+                f"No redirect location for service {self.app_uri},"
+                " is it secured with IAP?"
+            )
 
         parsed_uri = urlparse(redirect_location)
         query = parse_qs(parsed_uri.query)
-        client_id: str = query.get('client_id', [''])[0]
+        client_id: str = query.get("client_id", [""])[0]
         if not client_id:
-            raise Exception(f'No client ID found for service {self.app_uri},'
-                            ' is it secured with IAP?')
+            raise Exception(
+                f"No client ID found for service {self.app_uri},"
+                " is it secured with IAP?"
+            )
         return client_id
 
     async def _refresh_authorized_user(
-        self, iap_client_id: str,
+        self,
+        iap_client_id: str,
         timeout: int,
     ) -> TokenResponse:
         """
@@ -513,37 +709,47 @@ class IapToken(BaseToken):
         https://cloud.google.com/iap/docs/authentication-howto#obtaining_an_oidc_token_in_all_other_cases
         """
         # Fetch the OAuth access token to use in generating an ID token.
-        refresh_payload = urlencode({
-            'grant_type': 'refresh_token',
-            'client_id': self.service_data['client_id'],
-            'client_secret': self.service_data['client_secret'],
-            'refresh_token': self.service_data['refresh_token'],
-        })
+        refresh_payload = urlencode(
+            {
+                "grant_type": "refresh_token",
+                "client_id": self.service_data["client_id"],
+                "client_secret": self.service_data["client_secret"],
+                "refresh_token": self.service_data["refresh_token"],
+            }
+        )
         refresh_resp = await self.session.post(
-            url=self.token_uri, data=refresh_payload, headers=REFRESH_HEADERS,
+            url=self.token_uri,
+            data=refresh_payload,
+            headers=REFRESH_HEADERS,
             timeout=timeout,
         )
         refresh_content = await refresh_resp.json()
 
         headers = {
-            'Authorization': f'Bearer {refresh_content["access_token"]}',
+            "Authorization": f"Bearer {refresh_content['access_token']}",
         }
-        payload = json.dumps({
-            'includeEmail': True,
-            'audience': iap_client_id,
-        })
+        payload = json.dumps(
+            {
+                "includeEmail": True,
+                "audience": iap_client_id,
+            }
+        )
         resp = await self.session.post(
             GCLOUD_ENDPOINT_GENERATE_ID_TOKEN.format(
-                service_account=self.service_account),
-            data=payload, headers=headers, timeout=timeout)
+                service_account=self.service_account
+            ),
+            data=payload,
+            headers=headers,
+            timeout=timeout,
+        )
 
         content = await resp.json()
-        return TokenResponse(value=content['token'],
-                             expires_in=self.default_token_ttl)
+        return TokenResponse(value=content["token"], expires_in=self.default_token_ttl)
 
     async def _refresh_gce_metadata(
-            self, iap_client_id: str,
-            timeout: int,
+        self,
+        iap_client_id: str,
+        timeout: int,
     ) -> TokenResponse:
         """
         Fetch IAP ID token from the GCE metadata servers.
@@ -556,63 +762,65 @@ class IapToken(BaseToken):
         """
         resp = await self.session.get(
             GCE_ENDPOINT_ID_TOKEN.format(audience=iap_client_id),
-            headers=GCE_METADATA_HEADERS, timeout=timeout)
+            headers=GCE_METADATA_HEADERS,
+            timeout=timeout,
+        )
         try:
             token = await resp.text()  # aiohttp lib
         except (AttributeError, TypeError):
             token = str(resp.text)  # requests lib
-        return TokenResponse(value=token,
-                             expires_in=self.default_token_ttl)
+        return TokenResponse(value=token, expires_in=self.default_token_ttl)
 
     async def _refresh_service_account(
-        self, iap_client_id: str,
+        self,
+        iap_client_id: str,
         timeout: int,
     ) -> TokenResponse:
         now = int(time.time())
         expiry = now + self.default_token_ttl
 
         assertion_payload = {
-            'iss': self.service_data['client_email'],
-            'aud': self.token_uri,
-            'exp': expiry,
-            'iat': now,
-            'sub': self.service_data['client_email'],
-            'target_audience': iap_client_id,
+            "iss": self.service_data["client_email"],
+            "aud": self.token_uri,
+            "exp": expiry,
+            "iat": now,
+            "sub": self.service_data["client_email"],
+            "target_audience": iap_client_id,
         }
 
         assertion = jwt.encode(
             assertion_payload,
-            self.service_data['private_key'],
-            algorithm='RS256',
+            self.service_data["private_key"],
+            algorithm="RS256",
         )
 
-        payload = urlencode({
-            'assertion': assertion,
-            'grant_type': 'urn:ietf:params:oauth:grant-type:jwt-bearer',
-        })
+        payload = urlencode(
+            {
+                "assertion": assertion,
+                "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            }
+        )
 
-        resp = await self.session.post(self.token_uri, data=payload,
-                                       headers=REFRESH_HEADERS,
-                                       timeout=timeout)
+        resp = await self.session.post(
+            self.token_uri, data=payload, headers=REFRESH_HEADERS, timeout=timeout
+        )
 
         content = await resp.json()
-        return TokenResponse(value=content['id_token'],
-                             expires_in=expiry - int(time.time()))
+        return TokenResponse(
+            value=content["id_token"], expires_in=expiry - int(time.time())
+        )
 
     async def refresh(self, *, timeout: int) -> TokenResponse:
         iap_client_id = await self._get_iap_client_id(timeout=timeout)
         if self.token_type == Type.AUTHORIZED_USER:
-            resp = await self._refresh_authorized_user(
-                iap_client_id, timeout)
+            resp = await self._refresh_authorized_user(iap_client_id, timeout)
         elif self.token_type == Type.GCE_METADATA:
-            resp = await self._refresh_gce_metadata(
-                iap_client_id, timeout)
+            resp = await self._refresh_gce_metadata(iap_client_id, timeout)
         elif self.token_type == Type.SERVICE_ACCOUNT:
-            resp = await self._refresh_service_account(
-                iap_client_id, timeout)
+            resp = await self._refresh_service_account(iap_client_id, timeout)
         elif self.token_type == Type.IMPERSONATED_SERVICE_ACCOUNT:
-            raise Exception('impersonation is not supported for IAP tokens')
+            raise Exception("impersonation is not supported for IAP tokens")
         else:
-            raise Exception(f'unsupported token type {self.token_type}')
+            raise Exception(f"unsupported token type {self.token_type}")
 
         return resp

--- a/auth/tests/unit/token_test.py
+++ b/auth/tests/unit/token_test.py
@@ -12,29 +12,153 @@ from gcloud.aio.auth import token
 async def test_service_as_io():
     # pylint: disable=line-too-long
     service_data = {
-        'type': 'service_account',
-        'project_id': 'random-project-123',
-        'private_key_id': '399asdfsdf92923k32423a9f9sdf',
-        'private_key': '-----BEGIN PRIVATE KEY-----\nABCDF012923949394239492349234923==\n-----END PRIVATE KEY-----\n',
-        'client_email': 'gcloud-aio-test@random-project-123.iam.gserviceaccount.com',
-        'client_id': '2384283429349234293',
-        'auth_uri': 'https://accounts.google.com/o/oauth2/auth',
-        'token_uri': 'https://oauth2.googleapis.com/token',
-        'auth_provider_x509_cert_url': 'https://www.googleapis.com/oauth2/v1/certs',
-        'client_x509_cert_url': 'https://www.googleapis.com/robot/v1/metadata/x509/gcloud-aio%40random-project-123.iam.gserviceaccount.com',
+        "type": "service_account",
+        "project_id": "random-project-123",
+        "private_key_id": "399asdfsdf92923k32423a9f9sdf",
+        "private_key": "-----BEGIN PRIVATE KEY-----\nABCDF012923949394239492349234923==\n-----END PRIVATE KEY-----\n",
+        "client_email": "gcloud-aio-test@random-project-123.iam.gserviceaccount.com",
+        "client_id": "2384283429349234293",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+        "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/gcloud-aio%40random-project-123.iam.gserviceaccount.com",
     }
 
-    service_file = io.StringIO(f'{json.dumps(service_data)}')
+    service_file = io.StringIO(f"{json.dumps(service_data)}")
     t = token.BaseToken(service_file=service_file)
 
     assert t.token_type == token.Type.SERVICE_ACCOUNT
-    assert t.token_uri == 'https://oauth2.googleapis.com/token'
-    assert await t.get_project() == 'random-project-123'
+    assert t.token_uri == "https://oauth2.googleapis.com/token"
+    assert await t.get_project() == "random-project-123"
+
+
+@pytest.mark.asyncio
+async def test_external_account_as_io():
+    service_data = {
+        "type": "external_account",
+        "audience": "//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/pool/subject",
+        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+        "token_url": "https://sts.googleapis.com/v1/token",
+        "credential_source": {
+            "type": "url",
+            "url": "http://169.254.169.254/metadata/identity/oauth2/token",
+            "headers": {"Metadata": "true"},
+        },
+    }
+
+    service_file = io.StringIO(f"{json.dumps(service_data)}")
+    t = token.BaseToken(service_file=service_file)
+
+    assert t.token_type == token.Type.EXTERNAL_ACCOUNT
+    assert t.token_uri == "https://sts.googleapis.com/v1/token"
+
+
+@pytest.mark.asyncio
+async def test_external_account_missing_required_fields():
+    service_data = {
+        "type": "external_account",
+        "audience": "//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/pool/subject",
+        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+        # Missing token_url and credential_source
+    }
+
+    service_file = io.StringIO(f"{json.dumps(service_data)}")
+    with mock.patch(
+        "gcloud.aio.auth.token.get_service_data", return_value=service_data
+    ):
+        with pytest.raises(
+            ValueError, match="External account credentials missing required fields"
+        ):
+            await token.Token(service_file=service_file).get()
+
+
+@pytest.mark.asyncio
+async def test_external_account_token_refresh():
+    service_data = {
+        "type": "external_account",
+        "audience": "//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/pool/subject",
+        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+        "token_url": "https://sts.googleapis.com/v1/token",
+        "credential_source": {
+            "type": "url",
+            "url": "http://169.254.169.254/metadata/identity/oauth2/token",
+            "headers": {"Metadata": "true"},
+        },
+    }
+
+    service_file = io.StringIO(f"{json.dumps(service_data)}")
+    t = token.Token(service_file=service_file)
+
+    # Mock the session to return a subject token
+    mock_response = mock.AsyncMock()
+    mock_response.status = 200
+    mock_response.text = "subject_token_123"
+    t.session.get = mock.AsyncMock(return_value=mock_response)
+
+    # Mock the token exchange response
+    mock_token_response = mock.AsyncMock()
+    mock_token_response.status = 200
+    mock_token_response.json = mock.AsyncMock(
+        return_value={"access_token": "access_token_123", "expires_in": 3600}
+    )
+    t.session.post = mock.AsyncMock(return_value=mock_token_response)
+
+    # Test token refresh
+    token_response = await t._refresh_external_account(timeout=10)
+    assert token_response.value == "access_token_123"
+    assert token_response.expires_in == 3600
+
+    # Verify the correct requests were made
+    t.session.get.assert_called_once_with(
+        "http://169.254.169.254/metadata/identity/oauth2/token",
+        headers={"Metadata": "true"},
+        timeout=10,
+    )
+
+    t.session.post.assert_called_once()
+    call_args = t.session.post.call_args
+    assert call_args[0][0] == "https://sts.googleapis.com/v1/token"
+
+
+@pytest.mark.asyncio
+async def test_external_account_credential_source_types():
+    # Test URL credential source
+    url_source = {
+        "type": "url",
+        "url": "http://example.com/token",
+        "headers": {"Authorization": "Bearer secret"},
+    }
+    t = token.Token()
+    mock_response = mock.AsyncMock()
+    mock_response.status = 200
+    mock_response.text = "token_from_url"
+    t.session.get = mock.AsyncMock(return_value=mock_response)
+    token_value = await t._get_subject_token(url_source, timeout=10)
+    assert token_value == "token_from_url"
+
+    # Test file credential source
+    file_source = {"type": "file", "file": "test_token.txt"}
+    with mock.patch("builtins.open", mock.mock_open(read_data="token_from_file")):
+        token_value = await t._get_subject_token(file_source, timeout=10)
+        assert token_value == "token_from_file"
+
+    # Test environment credential source
+    env_source = {"type": "environment", "environment_id": "TEST_TOKEN"}
+    with mock.patch.dict("os.environ", {"TEST_TOKEN": "token_from_env"}):
+        token_value = await t._get_subject_token(env_source, timeout=10)
+        assert token_value == "token_from_env"
+
+    # Test invalid credential source type
+    invalid_source = {"type": "invalid"}
+    with pytest.raises(ValueError, match="Unsupported credential source type"):
+        await t._get_subject_token(invalid_source, timeout=10)
+
 
 # pylint: disable=too-complex
 if BUILD_GCLOUD_REST:
     pass
 else:
+
     @pytest.mark.asyncio
     async def test_acquiring_refresh_called_once():
         t = token.BaseToken()
@@ -45,6 +169,7 @@ else:
 
         async def refresh(timeout):  # pylint: disable=unused-argument
             return await future
+
         t.refresh.side_effect = refresh
 
         # Both tasks should try to acquire a token and block for the same
@@ -58,11 +183,11 @@ else:
         # Now set the result of the future, which should unblock both tasks
         future.set_result(
             token.TokenResponse(
-                value='fake_token',
+                value="fake_token",
                 expires_in=3600,
             )
         )
-        assert await task1 == await task2, 'Token should be cached and reused'
+        assert await task1 == await task2, "Token should be cached and reused"
         t.refresh.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -75,8 +200,8 @@ else:
         with pytest.raises(asyncio.TimeoutError):
             await t.get()
 
-        assert t.acquiring.done(), 'Acquiring should be done after timeout'
-        assert not t.access_token, 'Token should not be set after timeout'
+        assert t.acquiring.done(), "Acquiring should be done after timeout"
+        assert not t.access_token, "Token should not be set after timeout"
 
         # If the token timed out last time, it should retry instead of
         # trying the timed out coroutine again


### PR DESCRIPTION
## Summary
Related to https://github.com/talkiq/gcloud-aio/issues/578

Adds support for the external_account service account type, which is used in Workload Identity Federation.


