### PR TITLE
feat(storage): implement compose method

### DIFF
--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -484,6 +484,7 @@ class Storage:
             contents = await file_object.read()
             return await self.upload(bucket, object_name, contents, **kwargs)
 
+    # https://cloud.google.com/storage/docs/json_api/v1/objects/compose
     async def compose_objects(
         self, bucket: str, object_name: str,
         source_object_names: list[str], *,
@@ -492,17 +493,11 @@ class Storage:
         headers: Optional[Dict[str, Any]] = None,
         session: Optional[Session] = None,
         timeout: int = DEFAULT_TIMEOUT,
-    ) -> None:
-        """
-        TODO
-
-        See https://cloud.google.com/storage/docs/json_api/v1/objects/compose
-        """
+    ) -> Dict[str, Any]:
         url = f'{self._api_root_read}/{bucket}/o/{quote(object_name, safe="")}/compose'
         headers = headers or {}
         headers.update(await self._headers())
         params = params or {}
-        s = AioSession(session) if session else self.session
 
         payload = {
             'sourceObjects': [{'name': name} for name in source_object_names],
@@ -510,11 +505,13 @@ class Storage:
         if content_type:
             payload['destination'] = {'contentType': content_type}
 
+        s = AioSession(session) if session else self.session
         resp = await s.post(
             url, headers=headers, params=params, timeout=timeout,
             data=json.dumps(payload),
         )
-        # TODO
+        data: Dict[str, Any] = await resp.json(content_type=None)
+        return data
 
     @staticmethod
     def _get_stream_len(stream: IO[AnyStr]) -> int:

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -487,7 +487,7 @@ class Storage:
     # https://cloud.google.com/storage/docs/json_api/v1/objects/compose
     async def compose(
         self, bucket: str, object_name: str,
-        source_object_names: list[str], *,
+        source_object_names: List[str], *,
         content_type: Optional[str] = None,
         params: Optional[Dict[str, str]] = None,
         headers: Optional[Dict[str, Any]] = None,

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -485,7 +485,7 @@ class Storage:
             return await self.upload(bucket, object_name, contents, **kwargs)
 
     # https://cloud.google.com/storage/docs/json_api/v1/objects/compose
-    async def compose_objects(
+    async def compose(
         self, bucket: str, object_name: str,
         source_object_names: list[str], *,
         content_type: Optional[str] = None,

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -504,11 +504,16 @@ class Storage:
         }
         if content_type:
             payload['destination'] = {'contentType': content_type}
+        body = json.dumps(payload).encode('utf-8')
+        headers.update({
+            'Content-Length': str(len(body)),
+            'Content-Type': 'application/json; charset=UTF-8',
+        })
 
         s = AioSession(session) if session else self.session
         resp = await s.post(
             url, headers=headers, params=params, timeout=timeout,
-            data=json.dumps(payload),
+            data=body,
         )
         data: Dict[str, Any] = await resp.json(content_type=None)
         return data

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -494,12 +494,15 @@ class Storage:
         session: Optional[Session] = None,
         timeout: int = DEFAULT_TIMEOUT,
     ) -> Dict[str, Any]:
-        url = f'{self._api_root_read}/{bucket}/o/{quote(object_name, safe="")}/compose'
+        url = (
+            f'{self._api_root_read}/{bucket}/o/'
+            f'{quote(object_name, safe="")}/compose'
+        )
         headers = headers or {}
         headers.update(await self._headers())
         params = params or {}
 
-        payload = {
+        payload: Dict[str, Any] = {
             'sourceObjects': [{'name': name} for name in source_object_names],
         }
         if content_type:

--- a/storage/pyproject.rest.toml
+++ b/storage/pyproject.rest.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcloud-rest-storage"
-version = "9.4.0"
+version = "9.5.0"
 description = "Python Client for Google Cloud Storage"
 readme = "README.rst"
 

--- a/storage/pyproject.toml
+++ b/storage/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcloud-aio-storage"
-version = "9.4.0"
+version = "9.5.0"
 description = "Python Client for Google Cloud Storage"
 readme = "README.rst"
 

--- a/storage/tests/integration/compose_test.py
+++ b/storage/tests/integration/compose_test.py
@@ -1,0 +1,55 @@
+import uuid
+
+import pytest
+from gcloud.aio.auth import BUILD_GCLOUD_REST  # pylint: disable=no-name-in-module
+from gcloud.aio.storage import Storage
+
+# Selectively load libraries based on the package
+if BUILD_GCLOUD_REST:
+    from requests import Session
+else:
+    from aiohttp import ClientSession as Session
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'shard_data,expected_data,content_type,file_extension', [
+        (['foo ', 'bar ', 'baz'], b'foo bar baz', 'text/plain', 'txt'),
+    ],
+)
+async def test_compose(
+    bucket_name, creds, shard_data,
+    expected_data, content_type, file_extension,
+):
+    random_name = lambda: f'{uuid.uuid4().hex}/{uuid.uuid4().hex}.{file_extension}'
+    shard_names = [random_name() for _ in shard_data]
+    object_name = random_name()
+
+    async with Session() as session:
+        storage = Storage(service_file=creds, session=session)
+
+        for shard_name, shard_datum in zip(shard_names, shard_data):
+            await storage.upload(
+                bucket_name,
+                shard_name,
+                shard_datum,
+                metadata={
+                    'Content-Disposition': 'inline',
+                },
+            )
+        res = await storage.compose(
+            bucket_name,
+            object_name,
+            shard_names,
+            content_type=content_type,
+        )
+
+        try:
+            assert res['name'] == object_name
+            assert res['contentType'] == content_type
+
+            downloaded_data = await storage.download(bucket_name, res['name'])
+            assert downloaded_data == expected_data
+
+        finally:
+            pass

--- a/storage/tests/integration/compose_test.py
+++ b/storage/tests/integration/compose_test.py
@@ -48,12 +48,8 @@ async def test_compose(
             content_type=content_type,
         )
 
-        try:
-            assert res['name'] == object_name
-            assert res['contentType'] == content_type
+        assert res['name'] == object_name
+        assert res['contentType'] == content_type
 
-            downloaded_data = await storage.download(bucket_name, res['name'])
-            assert downloaded_data == expected_data
-
-        finally:
-            pass
+        downloaded_data = await storage.download(bucket_name, res['name'])
+        assert downloaded_data == expected_data

--- a/storage/tests/integration/compose_test.py
+++ b/storage/tests/integration/compose_test.py
@@ -21,7 +21,9 @@ async def test_compose(
     bucket_name, creds, shard_data,
     expected_data, content_type, file_extension,
 ):
-    random_name = lambda: f'{uuid.uuid4().hex}/{uuid.uuid4().hex}.{file_extension}'
+    def random_name():
+        return f'{uuid.uuid4().hex}/{uuid.uuid4().hex}.{file_extension}'
+
     shard_names = [random_name() for _ in shard_data]
     object_name = random_name()
 

--- a/storage/tests/integration/compose_test.py
+++ b/storage/tests/integration/compose_test.py
@@ -14,7 +14,9 @@ else:
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     'shard_data,expected_data,content_type,file_extension', [
-        (['foo ', 'bar ', 'baz'], b'foo bar baz', 'text/plain', 'txt'),
+        (['foo ', 'bar'], b'foo bar', 'text/plain', 'txt'),
+        (['{"foo":', '1,', '"bar":2}'],
+         b'{"foo":1,"bar":2}', 'application/json', 'json'),
     ],
 )
 async def test_compose(


### PR DESCRIPTION
## Summary

This PR implements support for basic object composition operations in GCS (see <https://cloud.google.com/storage/docs/composing-objects>) by adding a new method `compose` to `gcloud.aio.storage.Storage`. I say "basic" here, because this implementation currently doesn't support some of the more advanced query parameters, e.g. `ifGenerationMatch`, which can be used to halt a compose operation if certain preconditions about the constituent blobs aren't met. More information about these query parameters can be found here: <https://cloud.google.com/storage/docs/json_api/v1/objects/compose>. That said, the new method appears to work for these more basic cases, and provides a foundation to add more functionality onto later.