### PR TITLE
feat(datastore): add readTime param to lookup/runQuery

### DIFF
--- a/datastore/gcloud/aio/datastore/query.py
+++ b/datastore/gcloud/aio/datastore/query.py
@@ -199,7 +199,7 @@ class QueryResultBatch:
         entity_results: Optional[List[EntityResult]] = None,
         more_results: MoreResultsType = MoreResultsType.UNSPECIFIED,
         skipped_cursor: str = '', skipped_results: int = 0,
-        snapshot_version: str = '',
+        snapshot_version: str = '', read_time: str = '',
     ) -> None:
         self.end_cursor = end_cursor
 
@@ -209,6 +209,7 @@ class QueryResultBatch:
         self.skipped_cursor = skipped_cursor
         self.skipped_results = skipped_results
         self.snapshot_version = snapshot_version
+        self.read_time = read_time
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, QueryResultBatch):
@@ -221,7 +222,8 @@ class QueryResultBatch:
             and self.more_results == other.more_results
             and self.skipped_cursor == other.skipped_cursor
             and self.skipped_results == other.skipped_results
-            and self.snapshot_version == other.snapshot_version,
+            and self.snapshot_version == other.snapshot_version
+            and self.read_time == other.read_time,
         )
 
     def __repr__(self) -> str:
@@ -239,12 +241,14 @@ class QueryResultBatch:
         skipped_cursor = data.get('skippedCursor', '')
         skipped_results = data.get('skippedResults', 0)
         snapshot_version = data.get('snapshotVersion', '')
+        read_time = data.get('readTime', '')
         return cls(
             end_cursor, entity_result_type=entity_result_type,
             entity_results=entity_results, more_results=more_results,
             skipped_cursor=skipped_cursor,
             skipped_results=skipped_results,
             snapshot_version=snapshot_version,
+            read_time=read_time,
         )
 
     def to_repr(self) -> Dict[str, Any]:
@@ -259,5 +263,7 @@ class QueryResultBatch:
             data['skippedCursor'] = self.skipped_cursor
         if self.snapshot_version:
             data['snapshotVersion'] = self.snapshot_version
+        if self.read_time:
+            data['readTime'] = self.read_time
 
         return data

--- a/datastore/tests/unit/datastore_test.py
+++ b/datastore/tests/unit/datastore_test.py
@@ -1,3 +1,4 @@
+import datetime
 import pytest
 from gcloud.aio.datastore import Consistency
 from gcloud.aio.datastore import Datastore

--- a/datastore/tests/unit/datastore_test.py
+++ b/datastore/tests/unit/datastore_test.py
@@ -20,24 +20,25 @@ class TestDatastore:
     @staticmethod
     def test_build_read_options_priority():
         ds = Datastore()
+        dt = datetime.datetime(2025, 1, 1, 12, 0, 0, 0)
 
-        # transaction take precedence over readTime/consistency
+        # transaction > readTime > consistency
         result = ds._build_read_options(
-            Consistency.STRONG, None, 'txn123', '2025-01-01T12:00:00.000Z'
+            Consistency.STRONG, None, 'txn123', dt
         )
         assert result == {'transaction': 'txn123'}
 
-        # readTime takes precedence over consistency
+        # readTime > consistency
         result = ds._build_read_options(
-            Consistency.STRONG, None, None, '2025-01-01T12:00:00.000Z'
+            Consistency.STRONG, None, None, dt
         )
-        assert result == {'readTime': '2025-01-01T12:00:00.000Z'}
+        assert result == {'readTime': '2025-01-01T12:00:00.000000Z'}
 
-        # we fall back to consistency if nothing else is provided
+        # fall back to consistency if nothing else is provided
         result = ds._build_read_options(
-            Consistency.EVENTUAL, None, None, None
+            Consistency.STRONG, None, None, None
         )
-        assert result == {'readConsistency': 'EVENTUAL'}
+        assert result == {'readConsistency': 'STRONG'}
 
     @staticmethod
     @pytest.fixture(scope='session')

--- a/datastore/tests/unit/datastore_test.py
+++ b/datastore/tests/unit/datastore_test.py
@@ -1,4 +1,5 @@
 import pytest
+from gcloud.aio.datastore import Consistency
 from gcloud.aio.datastore import Datastore
 from gcloud.aio.datastore import Key
 from gcloud.aio.datastore import Operation
@@ -15,6 +16,28 @@ class TestDatastore:
         results = Datastore.make_mutation(Operation.INSERT, key, properties)
 
         assert results['insert']['properties']['value'] == value.to_repr()
+
+    @staticmethod
+    def test_build_read_options_priority():
+        ds = Datastore()
+
+        # transaction take precedence over readTime/consistency
+        result = ds._build_read_options(
+            Consistency.STRONG, None, 'txn123', '2025-01-01T12:00:00.000Z'
+        )
+        assert result == {'transaction': 'txn123'}
+
+        # readTime takes precedence over consistency
+        result = ds._build_read_options(
+            Consistency.STRONG, None, None, '2025-01-01T12:00:00.000Z'
+        )
+        assert result == {'readTime': '2025-01-01T12:00:00.000Z'}
+
+        # we fall back to consistency if nothing else is provided
+        result = ds._build_read_options(
+            Consistency.EVENTUAL, None, None, None
+        )
+        assert result == {'readConsistency': 'EVENTUAL'}
 
     @staticmethod
     @pytest.fixture(scope='session')

--- a/datastore/tests/unit/query_test.py
+++ b/datastore/tests/unit/query_test.py
@@ -5,6 +5,7 @@ from gcloud.aio.datastore import PropertyFilter
 from gcloud.aio.datastore import PropertyFilterOperator
 from gcloud.aio.datastore import PropertyOrder
 from gcloud.aio.datastore import Query
+from gcloud.aio.datastore import QueryResultBatch
 from gcloud.aio.datastore import Value
 
 
@@ -127,3 +128,38 @@ class TestQuery:
             value=Value(123),
         )
         return Filter(inner_filter)
+
+
+class TestQueryResultBatch:
+    @staticmethod
+    def test_query_result_batch_with_read_time():
+        data = {
+            'endCursor': 'cursor123',
+            'entityResultType': 'RESULT_TYPE_UNSPECIFIED',
+            'entityResults': [],
+            'moreResults': 'NO_MORE_RESULTS',
+            'skippedResults': 0,
+            'readTime': '2025-07-01T12:00:00.000Z'
+        }
+        
+        batch = QueryResultBatch.from_repr(data)
+        assert batch.read_time == '2025-07-01T12:00:00.000Z'
+        
+        result = batch.to_repr()
+        assert result['readTime'] == '2025-07-01T12:00:00.000Z'
+
+    @staticmethod
+    def test_query_result_batch_without_read_time():
+        data = {
+            'endCursor': 'cursor123',
+            'entityResultType': 'RESULT_TYPE_UNSPECIFIED',
+            'entityResults': [],
+            'moreResults': 'NO_MORE_RESULTS',
+            'skippedResults': 0,
+        }
+        
+        batch = QueryResultBatch.from_repr(data)
+        assert batch.read_time == ''
+        
+        result = batch.to_repr()
+        assert 'readTime' not in result


### PR DESCRIPTION
## Summary

Added `readTime` support to `lookup` and `runQuery` to allow reading from consistent snapshots.

## Changes

- Added optional `readTime` parameter to `lookup` and `runQuery` methods
- Standardized `readOptions` building between `lookup` and `runQuery` via `_build_read_options`
- Handled `readTime` field in `QueryResultBatch` and `_build_lookup_result`
- `read_time` accepts any `datetime` object (naive or tz-aware) and converts into a UTC timestamp. Returned `readTime` values are preserved as UTC timestamps.
- Added some simple unit and integration tests

ReadOptions now follow this priority: `transaction` > `newTransaction` > `readTime` > `readConsistency`
read_time