### PR TITLE
chore(ci): use debian:bullseye-slim executor for github job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ jobs:
 
   github:
     docker:
-      - image: debian:buster-slim
+      - image: debian:bullseye-slim
     steps:
       - run: apt update -qy
       - run: apt install -qy hub git


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant issues / branches / other PRs / blockers / etc.
--->

Buster (Debian 10) reached EOL