### PR TITLE
feat(datastore): added newTransaction option for runQuery

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -24,6 +24,15 @@ And run tests with:
     poetry run pytest tests/unit  # unit tests only
     poetry run pytest tests/integration  # integration tests only
 
+To run the tests that require authentication with Google, you should set the
+GOOGLE_APPLICATION_CREDENTIALS environment variable to point to your credentials
+JSON file. If you are using the ``gcloud auth application-default login`` command,
+they can be found in ``~/.config/gcloud/application_default_credentials.json``.
+
+.. code-block:: console
+
+    export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/application_default_credentials.json"
+
 ``aio`` and ``rest``
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/datastore/gcloud/aio/datastore/query.py
+++ b/datastore/gcloud/aio/datastore/query.py
@@ -261,3 +261,36 @@ class QueryResultBatch:
             data['snapshotVersion'] = self.snapshot_version
 
         return data
+
+
+class RunQueryResult:
+    def __init__(self, batch: QueryResultBatch,
+                 transaction: Optional[str] = None):
+        self.batch = batch
+        self.transaction = transaction
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, RunQueryResult):
+            return False
+
+        return bool(
+            self.batch == other.batch
+            and self.transaction == other.transaction
+        )
+
+    def __repr__(self) -> str:
+        return str(self.to_repr())
+
+    @classmethod
+    def from_repr(cls, data: Dict[str, Any]) -> 'RunQueryResult':
+        batch = QueryResultBatch.from_repr(data['batch'])
+        transaction = data.get('transaction')
+        return cls(batch, transaction)
+
+    def to_repr(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {
+            'batch': self.batch.to_repr(),
+        }
+        if self.transaction:
+            result['transaction'] = self.transaction
+        return result


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant issues / branches / other PRs / blockers / etc.
--->
Similar to https://github.com/talkiq/gcloud-aio/pull/589 for `lookup`, this PR adds the `newTransaction` param to `runQuery`, which is a performance optimization that allows to avoid the beginTransaction RPC call. This changes `runQuery`’s return object, making it a breaking change that requires a major version bump.

Also added a missing setup step in the contributing guide for running the integration tests.
