### PR TITLE
feat(pubsub): allow explicit ack/nack on messages

### DIFF
--- a/pubsub/gcloud/aio/pubsub/subscriber_message.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_message.py
@@ -29,6 +29,8 @@ class SubscriberMessage:
         self.attributes = attributes
         self.delivery_attempt = delivery_attempt
 
+        self.force_ack_nack: bool | None = None
+
     @staticmethod
     def from_repr(
         received_message: dict[str, Any],
@@ -66,3 +68,24 @@ class SubscriberMessage:
         if self.delivery_attempt is not None:
             r['deliveryAttempt'] = self.delivery_attempt
         return r
+
+    def ack(self) -> None:
+        """
+        Forcibly mark a message as acked.
+
+        By default, we only ack a message if the callback returns without
+        raising an exception. If this method has been called on the Message, we
+        will instead ack it regardless of exception status.
+        """
+        self.force_ack_nack = True
+
+    def nack(self) -> None:
+        """
+        Forcibly mark a message as nacked.
+
+        By default, we only nack a message if the callback raises an exception.
+        If this method has been called on the Message, we will instead nack it
+        regardless of exception status, ie. including if it completes
+        successfully.
+        """
+        self.force_ack_nack = False

--- a/pubsub/tests/unit/subscriber_test.py
+++ b/pubsub/tests/unit/subscriber_test.py
@@ -27,6 +27,7 @@ else:
         mock = MagicMock()
         mock.ack_id = 'ack_id'
         mock.publish_time.timestamp = MagicMock(return_value=time.time())
+        mock.force_ack_nack = None
         return mock
 
     @pytest.fixture(scope='function')


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant issues / branches / other PRs / blockers / etc.
--->
Adds new ack() and nack() methods on SubscriberMessage which allow users
to forcibly mark a messsage as getting acked or nacked, regardless of
the success of the callback. In plain English:

When `callback` terminates, if `.ack()` has been called it acks. Else,
if `.nack()` has been called it nacks. Else, it acks if no exception was
raised and nacks otherwise.

Fixes #837
