### PR TITLE
fix(bigquery): handle API-wrapped null values in NULLABLE fields

### DIFF
--- a/bigquery/gcloud/aio/bigquery/utils.py
+++ b/bigquery/gcloud/aio/bigquery/utils.py
@@ -101,8 +101,8 @@ def parse(field: dict[str, Any], value: Any) -> Any:
         )
         raise
 
-    if field['mode'] == 'NULLABLE' and value is None:
-        return value
+    if field['mode'] == 'NULLABLE' and flatten(value) is None:
+        return None
 
     if field['mode'] == 'REPEATED':
         if field['type'] == 'RECORD':

--- a/bigquery/gcloud/aio/bigquery/utils.py
+++ b/bigquery/gcloud/aio/bigquery/utils.py
@@ -101,7 +101,9 @@ def parse(field: dict[str, Any], value: Any) -> Any:
         )
         raise
 
-    if field['mode'] == 'NULLABLE' and flatten(value) is None:
+    value = flatten(value)
+
+    if field['mode'] == 'NULLABLE' and value is None:
         return None
 
     if field['mode'] == 'REPEATED':
@@ -110,17 +112,17 @@ def parse(field: dict[str, Any], value: Any) -> Any:
                 f['name']: parse(f, x)
                 for f, x in zip(field['fields'], xs)
             }
-                for xs in flatten(value)]
+                for xs in value]
 
-        return [convert(x) for x in flatten(value)]
+        return [convert(x) for x in value]
 
     if field['type'] == 'RECORD':
         return {
             f['name']: parse(f, x)
-            for f, x in zip(field['fields'], flatten(value))
+            for f, x in zip(field['fields'], value)
         }
 
-    return convert(flatten(value))
+    return convert(value)
 
 
 def query_response_to_dict(response: dict[str, Any]) -> list[dict[str, Any]]:

--- a/bigquery/tests/unit/utils_test.py
+++ b/bigquery/tests/unit/utils_test.py
@@ -105,6 +105,8 @@ def test_parse_nullable(kind):
     # make sure we never convert to a falsey typed equivalent
     # eg. for BOOLEAN, None != False
     assert parse(field, None) is None
+    # BigQuery API wraps null values as {'v': None} -- must not crash
+    assert parse(field, {'v': None}) is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
BigQuery returns nulls as {'v': None}, not bare None. The old check `value is None` never matched, causing convert(None) to raise TypeError (eg. int(None)) for NULLABLE fields. Use flatten(value) before the check.

Adds regression test for the {'v': None} API response shape.

## Summary
- BigQuery API returns null values wrapped as `{'v': None}`, not bare `None`
  - Old guard `value is None` never matched → fell through to `convert(None)` → `TypeError` (eg. `int(None)`) for any NULLABLE INTEGER/BOOLEAN/FLOAT/etc field
   with a null value                                                                                                                                          
  - Fix: use `flatten(value) is None` before the null check, consistent with how the rest of `parse()` already uses `flatten()`                               
  - Adds regression test covering the `{'v': None}` API response shape for all NULLABLE types

Fixes #577      
