### PR TITLE
feat(datastore): add _extra_request_fields() extension hook

### DIFF
--- a/datastore/gcloud/aio/datastore/datastore.py
+++ b/datastore/gcloud/aio/datastore/datastore.py
@@ -134,6 +134,13 @@ class Datastore:
             'Authorization': f'Bearer {token}',
         }
 
+    def _extra_request_fields(self) -> dict[str, Any]:
+        """Returns extra top-level fields to merge into every request body.
+
+        Override in a subclass to inject additional request-level fields.
+        """
+        return {}
+
     # TODO: support mutations w version specifiers, return new version (commit)
     @classmethod
     def make_mutation(
@@ -164,9 +171,11 @@ class Datastore:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:allocateIds'
 
-        payload = json.dumps({
+        body = {
             'keys': [k.to_repr() for k in keys],
-        }).encode('utf-8')
+        }
+        body.update(self._extra_request_fields())
+        payload = json.dumps(body).encode('utf-8')
 
         headers = await self.headers()
         headers.update({
@@ -192,13 +201,19 @@ class Datastore:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:beginTransaction'
         headers = await self.headers()
-        headers.update({
-            'Content-Length': '0',
-            'Content-Type': 'application/json',
-        })
+        headers['Content-Type'] = 'application/json'
+
+        extra = self._extra_request_fields()
+        kwargs: dict[str, Any] = {}
+        if extra:
+            payload = json.dumps(extra).encode('utf-8')
+            headers['Content-Length'] = str(len(payload))
+            kwargs['data'] = payload
+        else:
+            headers['Content-Length'] = '0'
 
         s = AioSession(session) if session else self.session
-        resp = await s.post(url, headers=headers, timeout=timeout)
+        resp = await s.post(url, headers=headers, timeout=timeout, **kwargs)
         data = await resp.json()
 
         transaction: str = data['transaction']
@@ -219,6 +234,7 @@ class Datastore:
             mutations, transaction=transaction,
             mode=mode,
         )
+        body.update(self._extra_request_fields())
         payload = json.dumps(body).encode('utf-8')
 
         headers = await self.headers()
@@ -314,10 +330,12 @@ class Datastore:
             consistency, newTransaction, transaction, read_time,
         )
 
-        payload = json.dumps({
+        lookup_body = {
             'keys': [k.to_repr() for k in keys],
             'readOptions': read_options,
-        }).encode('utf-8')
+            **self._extra_request_fields(),
+        }
+        payload = json.dumps(lookup_body).encode('utf-8')
 
         headers = await self.headers()
         headers.update({
@@ -385,10 +403,12 @@ class Datastore:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:reserveIds'
 
-        payload = json.dumps({
+        reserve_body = {
             'databaseId': database_id,
             'keys': [k.to_repr() for k in keys],
-        }).encode('utf-8')
+            **self._extra_request_fields(),
+        }
+        payload = json.dumps(reserve_body).encode('utf-8')
 
         headers = await self.headers()
         headers.update({
@@ -408,9 +428,11 @@ class Datastore:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:rollback'
 
-        payload = json.dumps({
+        rollback_body = {
             'transaction': transaction,
-        }).encode('utf-8')
+            **self._extra_request_fields(),
+        }
+        payload = json.dumps(rollback_body).encode('utf-8')
 
         headers = await self.headers()
         headers.update({
@@ -450,6 +472,7 @@ class Datastore:
         }
         if explain_options:
             payload_dict['explainOptions'] = explain_options.to_repr()
+        payload_dict.update(self._extra_request_fields())
         payload = json.dumps(payload_dict).encode('utf-8')
 
         headers = await self.headers()

--- a/datastore/gcloud/aio/datastore/datastore.py
+++ b/datastore/gcloud/aio/datastore/datastore.py
@@ -173,8 +173,8 @@ class Datastore:
 
         body = {
             'keys': [k.to_repr() for k in keys],
+            **self._extra_request_fields()
         }
-        body.update(self._extra_request_fields())
         payload = json.dumps(body).encode('utf-8')
 
         headers = await self.headers()

--- a/datastore/gcloud/aio/datastore/datastore.py
+++ b/datastore/gcloud/aio/datastore/datastore.py
@@ -134,6 +134,13 @@ class Datastore:
             'Authorization': f'Bearer {token}',
         }
 
+    def _extra_request_fields(self) -> dict[str, Any]:
+        """Returns extra top-level fields to merge into every request body.
+
+        Override in a subclass to inject additional request-level fields.
+        """
+        return {}
+
     # TODO: support mutations w version specifiers, return new version (commit)
     @classmethod
     def make_mutation(
@@ -164,9 +171,11 @@ class Datastore:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:allocateIds'
 
-        payload = json.dumps({
+        body = {
             'keys': [k.to_repr() for k in keys],
-        }).encode('utf-8')
+        }
+        body.update(self._extra_request_fields())
+        payload = json.dumps(body).encode('utf-8')
 
         headers = await self.headers()
         headers.update({
@@ -192,13 +201,18 @@ class Datastore:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:beginTransaction'
         headers = await self.headers()
-        headers.update({
-            'Content-Length': '0',
-            'Content-Type': 'application/json',
-        })
+        headers['Content-Type'] = 'application/json'
 
+        extra = self._extra_request_fields()
         s = AioSession(session) if session else self.session
-        resp = await s.post(url, headers=headers, timeout=timeout)
+        if extra:
+            payload = json.dumps(extra).encode('utf-8')
+            headers['Content-Length'] = str(len(payload))
+            resp = await s.post(url, data=payload, headers=headers,
+                                timeout=timeout)
+        else:
+            headers['Content-Length'] = '0'
+            resp = await s.post(url, headers=headers, timeout=timeout)
         data = await resp.json()
 
         transaction: str = data['transaction']
@@ -219,6 +233,7 @@ class Datastore:
             mutations, transaction=transaction,
             mode=mode,
         )
+        body.update(self._extra_request_fields())
         payload = json.dumps(body).encode('utf-8')
 
         headers = await self.headers()
@@ -314,10 +329,12 @@ class Datastore:
             consistency, newTransaction, transaction, read_time,
         )
 
-        payload = json.dumps({
+        lookup_body = {
             'keys': [k.to_repr() for k in keys],
             'readOptions': read_options,
-        }).encode('utf-8')
+        }
+        lookup_body.update(self._extra_request_fields())
+        payload = json.dumps(lookup_body).encode('utf-8')
 
         headers = await self.headers()
         headers.update({
@@ -385,10 +402,12 @@ class Datastore:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:reserveIds'
 
-        payload = json.dumps({
+        reserve_body = {
             'databaseId': database_id,
             'keys': [k.to_repr() for k in keys],
-        }).encode('utf-8')
+        }
+        reserve_body.update(self._extra_request_fields())
+        payload = json.dumps(reserve_body).encode('utf-8')
 
         headers = await self.headers()
         headers.update({
@@ -450,6 +469,7 @@ class Datastore:
         }
         if explain_options:
             payload_dict['explainOptions'] = explain_options.to_repr()
+        payload_dict.update(self._extra_request_fields())
         payload = json.dumps(payload_dict).encode('utf-8')
 
         headers = await self.headers()

--- a/datastore/tests/unit/datastore_test.py
+++ b/datastore/tests/unit/datastore_test.py
@@ -1,4 +1,11 @@
+import json
+from typing import Any
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
 import pytest
+from gcloud.aio.auth import AioSession  # pylint: disable=no-name-in-module
 from gcloud.aio.datastore import Consistency
 from gcloud.aio.datastore import Datastore
 from gcloud.aio.datastore import Key
@@ -40,6 +47,34 @@ class TestDatastore:
                 Consistency.STRONG, None, None, None
             )
             assert result == {'readConsistency': 'STRONG'}
+
+    @staticmethod
+    async def test_extra_request_fields_merged_into_payload():
+        class _WithSentinelField(Datastore):
+            def _extra_request_fields(self) -> dict[str, Any]:
+                return {'sentinel': 'injected'}
+
+        posted_body: dict[str, Any] = {}
+
+        async def _fake_post(self_session, url, headers, data=None, **kwargs):
+            del self_session, url, headers, kwargs
+            nonlocal posted_body
+            if data:
+                posted_body = json.loads(data)
+            resp = MagicMock()
+            resp.json = AsyncMock(
+                return_value={'found': [], 'missing': [], 'deferred': []},
+            )
+            return resp
+
+        key = Key('p', [PathElement('Kind')])
+        with patch.object(AioSession, 'post', _fake_post):
+            async with _WithSentinelField(project='p', api_root='http://dev/'
+                                          ) as ds:
+                # We use lookup as example but most methods do the same
+                await ds.lookup([key])
+
+        assert posted_body.get('sentinel') == 'injected'
 
     @staticmethod
     @pytest.fixture(scope='session')

--- a/datastore/tests/unit/datastore_test.py
+++ b/datastore/tests/unit/datastore_test.py
@@ -1,4 +1,11 @@
+import json
+from typing import Any
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
 import pytest
+from gcloud.aio.auth import AioSession  # pylint: disable=no-name-in-module
 from gcloud.aio.datastore import Consistency
 from gcloud.aio.datastore import Datastore
 from gcloud.aio.datastore import Key
@@ -40,6 +47,33 @@ class TestDatastore:
                 Consistency.STRONG, None, None, None
             )
             assert result == {'readConsistency': 'STRONG'}
+
+    @staticmethod
+    async def test_extra_request_fields_merged_into_payload():
+        class _WithSentinelField(Datastore):
+            def _extra_request_fields(self) -> dict[str, Any]:
+                return {'sentinel': 'injected'}
+
+        posted_body: dict[str, Any] = {}
+
+        async def _fake_post(self_session, url, headers, data=None, **kwargs):
+            del self_session, url, headers, kwargs
+            nonlocal posted_body
+            if data:
+                posted_body = json.loads(data)
+            resp = MagicMock()
+            resp.json = AsyncMock(
+                return_value={'found': [], 'missing': [], 'deferred': []},
+            )
+            return resp
+
+        key = Key('p', [PathElement('Kind')])
+        with patch.object(AioSession, 'post', _fake_post):
+            async with _WithSentinelField(project='p', api_root='http://dev/'
+                                          ) as ds:
+                await ds.lookup([key])
+
+        assert posted_body.get('sentinel') == 'injected'
 
     @staticmethod
     @pytest.fixture(scope='session')


### PR DESCRIPTION
## Description

Adds a protected `_extra_request_fields()` extension method on the `Datastore` class, returning `{}` by default, and merges its result into the top-level request dict of each data-plane payload builder before serialization.

This is a generic subclass extension point for injecting extra top-level fields into Datastore requests without modifying the builders themselves. The default returns an empty dict, so the change is a no-op for all existing consumers — no behavior change unless a subclass overrides the method.

## Summary of changes

- Added `_extra_request_fields(self) -> dict[str, Any]` to `Datastore` with a `{}` default and a docstring describing it as a subclass extension point
- Merged the hook result into the top-level request dict in each of the seven data-plane and session-management builders (`:lookup`, `:runQuery`, `:commit`, `:beginTransaction`, `:allocateIds`, `:reserveIds`, `:rollback`). Not applied to `:export` or `:import`.
- `beginTransaction` now conditionally sends a body only when the merged dict is non-empty, keeping the current no-body behavior for the default case
- Added `datastore/tests/unit/extra_request_fields_test.py` asserting that a non-empty override appears at the top level of each data-plane body and that the default leaves bodies unchanged
