### PR TITLE
feat(datastore): support additional request fields

### DIFF
--- a/bin/build-rest
+++ b/bin/build-rest
@@ -87,6 +87,8 @@ find . -type f -path '*tests/*' \
     | xargs -L1 $SED -Ei 's/@pytest.mark.asyncio/#@pytest.mark.asyncio/g'
 find . -type f -path '*tests/*' \
     | xargs -L1 $SED -Ei 's/Session\(.*\)\sas/Session() as/g'
+find . -type f -path '*tests/*' \
+    | xargs -L1 $SED -Ei 's/AsyncMock/MagicMock/g'
 find . -type f -path '*py' \
     | xargs -L1 $SED -Ei 's/__aenter__/__enter__/g'
 find . -type f -path '*py' \

--- a/datastore/gcloud/aio/datastore/datastore.py
+++ b/datastore/gcloud/aio/datastore/datastore.py
@@ -139,11 +139,13 @@ class Datastore:
         url: str,
         body: dict[str, Any] | None = None,
         *,
-        extra_fields: dict[str, Any] | None = None,
+        additional_request_fields: dict[str, Any] | None = None,
         session: Session | None = None,
         timeout: float = 10.,
     ) -> Any:
-        merged: dict[str, Any] = {**(body or {}), **(extra_fields or {})}
+        merged: dict[str, Any] = {
+            **(body or {}), **(additional_request_fields or {}),
+        }
         headers = await self.headers()
         headers['Content-Type'] = 'application/json'
         s = AioSession(session) if session else self.session
@@ -182,13 +184,14 @@ class Datastore:
         self, keys: list[Key],
         session: Session | None = None,
         timeout: float = 10.,
-        extra_fields: dict[str, Any] | None = None,
+        additional_request_fields: dict[str, Any] | None = None,
     ) -> list[Key]:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:allocateIds'
         resp = await self._post(
             url, {'keys': [k.to_repr() for k in keys]},
-            extra_fields=extra_fields, session=session, timeout=timeout,
+            additional_request_fields=additional_request_fields,
+            session=session, timeout=timeout,
         )
         data = await resp.json()
         return [self.key_kind.from_repr(k) for k in data['keys']]
@@ -198,12 +201,14 @@ class Datastore:
     async def beginTransaction(
         self, session: Session | None = None,
         timeout: float = 10.,
-        extra_fields: dict[str, Any] | None = None,
+        additional_request_fields: dict[str, Any] | None = None,
     ) -> str:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:beginTransaction'
         resp = await self._post(
-            url, extra_fields=extra_fields, session=session, timeout=timeout,
+            url,
+            additional_request_fields=additional_request_fields,
+            session=session, timeout=timeout,
         )
         data = await resp.json()
         transaction: str = data['transaction']
@@ -216,7 +221,7 @@ class Datastore:
         mode: Mode = Mode.TRANSACTIONAL,
         session: Session | None = None,
         timeout: float = 10.,
-        extra_fields: dict[str, Any] | None = None,
+        additional_request_fields: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:commit'
@@ -224,7 +229,8 @@ class Datastore:
             mutations, transaction=transaction, mode=mode)
         resp = await self._post(
             url, body,
-            extra_fields=extra_fields, session=session, timeout=timeout,
+            additional_request_fields=additional_request_fields,
+            session=session, timeout=timeout,
         )
         data: dict[str, Any] = await resp.json()
         return {
@@ -243,7 +249,7 @@ class Datastore:
         labels: dict[str, str] | None = None,
         session: Session | None = None,
         timeout: float = 10.,
-        extra_fields: dict[str, Any] | None = None,
+        additional_request_fields: dict[str, Any] | None = None,
     ) -> DatastoreOperation:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:export'
@@ -257,7 +263,8 @@ class Datastore:
         }
         resp = await self._post(
             url, body,
-            extra_fields=extra_fields, session=session, timeout=timeout,
+            additional_request_fields=additional_request_fields,
+            session=session, timeout=timeout,
         )
         data: dict[str, Any] = await resp.json()
         return self.datastore_operation_kind.from_repr(data)
@@ -289,7 +296,7 @@ class Datastore:
             consistency: Consistency = Consistency.STRONG,
             read_time: str | None = None,
             session: Session | None = None, timeout: float = 10.,
-            extra_fields: dict[str, Any] | None = None,
+            additional_request_fields: dict[str, Any] | None = None,
     ) -> LookUpResult:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:lookup'
@@ -299,7 +306,8 @@ class Datastore:
         resp = await self._post(
             url,
             {'keys': [k.to_repr() for k in keys], 'readOptions': read_options},
-            extra_fields=extra_fields, session=session, timeout=timeout,
+            additional_request_fields=additional_request_fields,
+            session=session, timeout=timeout,
         )
         data: dict[str, Any] = await resp.json()
         return self._build_lookup_result(data)
@@ -350,14 +358,15 @@ class Datastore:
         self, keys: list[Key], database_id: str = '',
         session: Session | None = None,
         timeout: float = 10.,
-        extra_fields: dict[str, Any] | None = None,
+        additional_request_fields: dict[str, Any] | None = None,
     ) -> None:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:reserveIds'
         await self._post(
             url,
             {'databaseId': database_id, 'keys': [k.to_repr() for k in keys]},
-            extra_fields=extra_fields, session=session, timeout=timeout,
+            additional_request_fields=additional_request_fields,
+            session=session, timeout=timeout,
         )
 
     # https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects/rollback
@@ -365,13 +374,14 @@ class Datastore:
         self, transaction: str,
         session: Session | None = None,
         timeout: float = 10.,
-        extra_fields: dict[str, Any] | None = None,
+        additional_request_fields: dict[str, Any] | None = None,
     ) -> None:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:rollback'
         await self._post(
             url, {'transaction': transaction},
-            extra_fields=extra_fields, session=session, timeout=timeout,
+            additional_request_fields=additional_request_fields,
+            session=session, timeout=timeout,
         )
 
     # https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects/runQuery
@@ -384,8 +394,9 @@ class Datastore:
         read_time: str | None = None,
         session: Session | None = None,
         timeout: float = 10.,
-        extra_fields: dict[str, Any] | None = None,
+        additional_request_fields: dict[str, Any] | None = None,
     ) -> QueryResult:
+        # pylint: disable=too-many-locals
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:runQuery'
         read_options = self._build_read_options(
@@ -403,7 +414,8 @@ class Datastore:
             body['explainOptions'] = explain_options.to_repr()
         resp = await self._post(
             url, body,
-            extra_fields=extra_fields, session=session, timeout=timeout,
+            additional_request_fields=additional_request_fields,
+            session=session, timeout=timeout,
         )
         data: dict[str, Any] = await resp.json()
         return self.query_result_kind.from_repr(data)

--- a/datastore/gcloud/aio/datastore/datastore.py
+++ b/datastore/gcloud/aio/datastore/datastore.py
@@ -134,6 +134,28 @@ class Datastore:
             'Authorization': f'Bearer {token}',
         }
 
+    async def _post(
+        self,
+        url: str,
+        body: dict[str, Any] | None = None,
+        *,
+        extra_fields: dict[str, Any] | None = None,
+        session: Session | None = None,
+        timeout: float = 10.,
+    ) -> Any:
+        merged: dict[str, Any] = {**(body or {}), **(extra_fields or {})}
+        headers = await self.headers()
+        headers['Content-Type'] = 'application/json'
+        s = AioSession(session) if session else self.session
+        if merged:
+            payload = json.dumps(merged).encode('utf-8')
+            headers['Content-Length'] = str(len(payload))
+            return await s.post(
+                url, data=payload, headers=headers, timeout=timeout,
+            )
+        headers['Content-Length'] = '0'
+        return await s.post(url, headers=headers, timeout=timeout)
+
     # TODO: support mutations w version specifiers, return new version (commit)
     @classmethod
     def make_mutation(
@@ -164,25 +186,11 @@ class Datastore:
     ) -> list[Key]:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:allocateIds'
-
-        body: dict[str, Any] = {'keys': [k.to_repr() for k in keys]}
-        if extra_fields:
-            body.update(extra_fields)
-        payload = json.dumps(body).encode('utf-8')
-
-        headers = await self.headers()
-        headers.update({
-            'Content-Length': str(len(payload)),
-            'Content-Type': 'application/json',
-        })
-
-        s = AioSession(session) if session else self.session
-        resp = await s.post(
-            url, data=payload, headers=headers,
-            timeout=timeout,
+        resp = await self._post(
+            url, {'keys': [k.to_repr() for k in keys]},
+            extra_fields=extra_fields, session=session, timeout=timeout,
         )
         data = await resp.json()
-
         return [self.key_kind.from_repr(k) for k in data['keys']]
 
     # https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects/beginTransaction
@@ -194,19 +202,10 @@ class Datastore:
     ) -> str:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:beginTransaction'
-        headers = await self.headers()
-        headers['Content-Type'] = 'application/json'
-
-        s = AioSession(session) if session else self.session
-        if extra_fields:
-            payload = json.dumps(extra_fields).encode('utf-8')
-            headers['Content-Length'] = str(len(payload))
-            resp = await s.post(url, data=payload, headers=headers, timeout=timeout)
-        else:
-            headers['Content-Length'] = '0'
-            resp = await s.post(url, headers=headers, timeout=timeout)
+        resp = await self._post(
+            url, extra_fields=extra_fields, session=session, timeout=timeout,
+        )
         data = await resp.json()
-
         transaction: str = data['transaction']
         return transaction
 
@@ -221,28 +220,13 @@ class Datastore:
     ) -> dict[str, Any]:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:commit'
-
         body = self._make_commit_body(
-            mutations, transaction=transaction,
-            mode=mode,
-        )
-        if extra_fields:
-            body.update(extra_fields)
-        payload = json.dumps(body).encode('utf-8')
-
-        headers = await self.headers()
-        headers.update({
-            'Content-Length': str(len(payload)),
-            'Content-Type': 'application/json',
-        })
-
-        s = AioSession(session) if session else self.session
-        resp = await s.post(
-            url, data=payload, headers=headers,
-            timeout=timeout,
+            mutations, transaction=transaction, mode=mode)
+        resp = await self._post(
+            url, body,
+            extra_fields=extra_fields, session=session, timeout=timeout,
         )
         data: dict[str, Any] = await resp.json()
-
         return {
             'mutationResults': [
                 self.mutation_result_kind.from_repr(r)
@@ -263,7 +247,6 @@ class Datastore:
     ) -> DatastoreOperation:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:export'
-
         body: dict[str, Any] = {
             'entityFilter': {
                 'kinds': kinds or [],
@@ -272,23 +255,11 @@ class Datastore:
             'labels': labels or {},
             'outputUrlPrefix': f'gs://{output_bucket_prefix}',
         }
-        if extra_fields:
-            body.update(extra_fields)
-        payload = json.dumps(body).encode('utf-8')
-
-        headers = await self.headers()
-        headers.update({
-            'Content-Length': str(len(payload)),
-            'Content-Type': 'application/json',
-        })
-
-        s = AioSession(session) if session else self.session
-        resp = await s.post(
-            url, data=payload, headers=headers,
-            timeout=timeout,
+        resp = await self._post(
+            url, body,
+            extra_fields=extra_fields, session=session, timeout=timeout,
         )
         data: dict[str, Any] = await resp.json()
-
         return self.datastore_operation_kind.from_repr(data)
 
     # https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects.operations/get
@@ -320,36 +291,17 @@ class Datastore:
             session: Session | None = None, timeout: float = 10.,
             extra_fields: dict[str, Any] | None = None,
     ) -> LookUpResult:
-        # pylint: disable=too-many-locals
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:lookup'
-
         read_options = self._build_read_options(
             consistency, newTransaction, transaction, read_time,
         )
-
-        body: dict[str, Any] = {
-            'keys': [k.to_repr() for k in keys],
-            'readOptions': read_options,
-        }
-        if extra_fields:
-            body.update(extra_fields)
-        payload = json.dumps(body).encode('utf-8')
-
-        headers = await self.headers()
-        headers.update({
-            'Content-Length': str(len(payload)),
-            'Content-Type': 'application/json',
-        })
-
-        s = AioSession(session) if session else self.session
-        resp = await s.post(
-            url, data=payload, headers=headers,
-            timeout=timeout,
+        resp = await self._post(
+            url,
+            {'keys': [k.to_repr() for k in keys], 'readOptions': read_options},
+            extra_fields=extra_fields, session=session, timeout=timeout,
         )
-
         data: dict[str, Any] = await resp.json()
-
         return self._build_lookup_result(data)
 
     def _build_lookup_result(self, data: dict[str, Any]) -> LookUpResult:
@@ -402,23 +354,11 @@ class Datastore:
     ) -> None:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:reserveIds'
-
-        body: dict[str, Any] = {
-            'databaseId': database_id,
-            'keys': [k.to_repr() for k in keys],
-        }
-        if extra_fields:
-            body.update(extra_fields)
-        payload = json.dumps(body).encode('utf-8')
-
-        headers = await self.headers()
-        headers.update({
-            'Content-Length': str(len(payload)),
-            'Content-Type': 'application/json',
-        })
-
-        s = AioSession(session) if session else self.session
-        await s.post(url, data=payload, headers=headers, timeout=timeout)
+        await self._post(
+            url,
+            {'databaseId': database_id, 'keys': [k.to_repr() for k in keys]},
+            extra_fields=extra_fields, session=session, timeout=timeout,
+        )
 
     # https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects/rollback
     async def rollback(
@@ -429,20 +369,10 @@ class Datastore:
     ) -> None:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:rollback'
-
-        body: dict[str, Any] = {'transaction': transaction}
-        if extra_fields:
-            body.update(extra_fields)
-        payload = json.dumps(body).encode('utf-8')
-
-        headers = await self.headers()
-        headers.update({
-            'Content-Length': str(len(payload)),
-            'Content-Type': 'application/json',
-        })
-
-        s = AioSession(session) if session else self.session
-        await s.post(url, data=payload, headers=headers, timeout=timeout)
+        await self._post(
+            url, {'transaction': transaction},
+            extra_fields=extra_fields, session=session, timeout=timeout,
+        )
 
     # https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects/runQuery
     async def runQuery(
@@ -456,15 +386,12 @@ class Datastore:
         timeout: float = 10.,
         extra_fields: dict[str, Any] | None = None,
     ) -> QueryResult:
-        # pylint: disable=too-many-locals
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:runQuery'
-
         read_options = self._build_read_options(
             consistency, newTransaction, transaction, read_time,
         )
-
-        payload_dict: dict[str, Any] = {
+        body: dict[str, Any] = {
             'partitionId': {
                 'projectId': project,
                 'namespaceId': self.namespace,
@@ -473,23 +400,11 @@ class Datastore:
             'readOptions': read_options,
         }
         if explain_options:
-            payload_dict['explainOptions'] = explain_options.to_repr()
-        if extra_fields:
-            payload_dict.update(extra_fields)
-        payload = json.dumps(payload_dict).encode('utf-8')
-
-        headers = await self.headers()
-        headers.update({
-            'Content-Length': str(len(payload)),
-            'Content-Type': 'application/json',
-        })
-
-        s = AioSession(session) if session else self.session
-        resp = await s.post(
-            url, data=payload, headers=headers,
-            timeout=timeout,
+            body['explainOptions'] = explain_options.to_repr()
+        resp = await self._post(
+            url, body,
+            extra_fields=extra_fields, session=session, timeout=timeout,
         )
-
         data: dict[str, Any] = await resp.json()
         return self.query_result_kind.from_repr(data)
 

--- a/datastore/gcloud/aio/datastore/datastore.py
+++ b/datastore/gcloud/aio/datastore/datastore.py
@@ -160,13 +160,15 @@ class Datastore:
         self, keys: list[Key],
         session: Session | None = None,
         timeout: float = 10.,
+        extra_fields: dict[str, Any] | None = None,
     ) -> list[Key]:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:allocateIds'
 
-        payload = json.dumps({
-            'keys': [k.to_repr() for k in keys],
-        }).encode('utf-8')
+        body: dict[str, Any] = {'keys': [k.to_repr() for k in keys]}
+        if extra_fields:
+            body.update(extra_fields)
+        payload = json.dumps(body).encode('utf-8')
 
         headers = await self.headers()
         headers.update({
@@ -188,17 +190,21 @@ class Datastore:
     async def beginTransaction(
         self, session: Session | None = None,
         timeout: float = 10.,
+        extra_fields: dict[str, Any] | None = None,
     ) -> str:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:beginTransaction'
         headers = await self.headers()
-        headers.update({
-            'Content-Length': '0',
-            'Content-Type': 'application/json',
-        })
+        headers['Content-Type'] = 'application/json'
 
         s = AioSession(session) if session else self.session
-        resp = await s.post(url, headers=headers, timeout=timeout)
+        if extra_fields:
+            payload = json.dumps(extra_fields).encode('utf-8')
+            headers['Content-Length'] = str(len(payload))
+            resp = await s.post(url, data=payload, headers=headers, timeout=timeout)
+        else:
+            headers['Content-Length'] = '0'
+            resp = await s.post(url, headers=headers, timeout=timeout)
         data = await resp.json()
 
         transaction: str = data['transaction']
@@ -211,6 +217,7 @@ class Datastore:
         mode: Mode = Mode.TRANSACTIONAL,
         session: Session | None = None,
         timeout: float = 10.,
+        extra_fields: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:commit'
@@ -219,6 +226,8 @@ class Datastore:
             mutations, transaction=transaction,
             mode=mode,
         )
+        if extra_fields:
+            body.update(extra_fields)
         payload = json.dumps(body).encode('utf-8')
 
         headers = await self.headers()
@@ -250,18 +259,22 @@ class Datastore:
         labels: dict[str, str] | None = None,
         session: Session | None = None,
         timeout: float = 10.,
+        extra_fields: dict[str, Any] | None = None,
     ) -> DatastoreOperation:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:export'
 
-        payload = json.dumps({
+        body: dict[str, Any] = {
             'entityFilter': {
                 'kinds': kinds or [],
                 'namespaceIds': namespaces or [],
             },
             'labels': labels or {},
             'outputUrlPrefix': f'gs://{output_bucket_prefix}',
-        }).encode('utf-8')
+        }
+        if extra_fields:
+            body.update(extra_fields)
+        payload = json.dumps(body).encode('utf-8')
 
         headers = await self.headers()
         headers.update({
@@ -305,6 +318,7 @@ class Datastore:
             consistency: Consistency = Consistency.STRONG,
             read_time: str | None = None,
             session: Session | None = None, timeout: float = 10.,
+            extra_fields: dict[str, Any] | None = None,
     ) -> LookUpResult:
         # pylint: disable=too-many-locals
         project = await self.project()
@@ -314,10 +328,13 @@ class Datastore:
             consistency, newTransaction, transaction, read_time,
         )
 
-        payload = json.dumps({
+        body: dict[str, Any] = {
             'keys': [k.to_repr() for k in keys],
             'readOptions': read_options,
-        }).encode('utf-8')
+        }
+        if extra_fields:
+            body.update(extra_fields)
+        payload = json.dumps(body).encode('utf-8')
 
         headers = await self.headers()
         headers.update({
@@ -381,14 +398,18 @@ class Datastore:
         self, keys: list[Key], database_id: str = '',
         session: Session | None = None,
         timeout: float = 10.,
+        extra_fields: dict[str, Any] | None = None,
     ) -> None:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:reserveIds'
 
-        payload = json.dumps({
+        body: dict[str, Any] = {
             'databaseId': database_id,
             'keys': [k.to_repr() for k in keys],
-        }).encode('utf-8')
+        }
+        if extra_fields:
+            body.update(extra_fields)
+        payload = json.dumps(body).encode('utf-8')
 
         headers = await self.headers()
         headers.update({
@@ -404,13 +425,15 @@ class Datastore:
         self, transaction: str,
         session: Session | None = None,
         timeout: float = 10.,
+        extra_fields: dict[str, Any] | None = None,
     ) -> None:
         project = await self.project()
         url = f'{self._api_root}/projects/{project}:rollback'
 
-        payload = json.dumps({
-            'transaction': transaction,
-        }).encode('utf-8')
+        body: dict[str, Any] = {'transaction': transaction}
+        if extra_fields:
+            body.update(extra_fields)
+        payload = json.dumps(body).encode('utf-8')
 
         headers = await self.headers()
         headers.update({
@@ -431,6 +454,7 @@ class Datastore:
         read_time: str | None = None,
         session: Session | None = None,
         timeout: float = 10.,
+        extra_fields: dict[str, Any] | None = None,
     ) -> QueryResult:
         # pylint: disable=too-many-locals
         project = await self.project()
@@ -440,7 +464,7 @@ class Datastore:
             consistency, newTransaction, transaction, read_time,
         )
 
-        payload_dict = {
+        payload_dict: dict[str, Any] = {
             'partitionId': {
                 'projectId': project,
                 'namespaceId': self.namespace,
@@ -450,6 +474,8 @@ class Datastore:
         }
         if explain_options:
             payload_dict['explainOptions'] = explain_options.to_repr()
+        if extra_fields:
+            payload_dict.update(extra_fields)
         payload = json.dumps(payload_dict).encode('utf-8')
 
         headers = await self.headers()

--- a/datastore/tests/unit/post_test.py
+++ b/datastore/tests/unit/post_test.py
@@ -1,0 +1,137 @@
+import json
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from gcloud.aio.datastore import Datastore
+
+
+# pylint: disable=protected-access
+class TestPost:
+    @staticmethod
+    async def test_no_body_no_additional_fields(mocker):
+        ds = Datastore(project='test-project')
+        mocker.patch.object(ds, 'headers', return_value={})
+        mock_resp = AsyncMock()
+        ds.session = MagicMock()
+        ds.session.post = AsyncMock(return_value=mock_resp)
+
+        result = await ds._post('https://example.com')
+
+        ds.session.post.assert_called_once_with(
+            'https://example.com',
+            headers={
+                'Content-Type': 'application/json',
+                'Content-Length': '0'},
+            timeout=10.,
+        )
+        assert result is mock_resp
+
+    @staticmethod
+    async def test_body_only(mocker):
+        ds = Datastore(project='test-project')
+        mocker.patch.object(ds, 'headers', return_value={})
+        mock_resp = AsyncMock()
+        ds.session = MagicMock()
+        ds.session.post = AsyncMock(return_value=mock_resp)
+        body = {'key': 'value'}
+
+        result = await ds._post('https://example.com', body)
+
+        expected_payload = json.dumps(body).encode('utf-8')
+        ds.session.post.assert_called_once_with(
+            'https://example.com',
+            data=expected_payload,
+            headers={
+                'Content-Type': 'application/json',
+                'Content-Length': str(len(expected_payload)),
+            },
+            timeout=10.,
+        )
+        assert result is mock_resp
+
+    @staticmethod
+    async def test_additional_request_fields_only(mocker):
+        ds = Datastore(project='test-project')
+        mocker.patch.object(ds, 'headers', return_value={})
+        mock_resp = AsyncMock()
+        ds.session = MagicMock()
+        ds.session.post = AsyncMock(return_value=mock_resp)
+        extra = {'customField': 'customValue'}
+
+        result = await ds._post(
+            'https://example.com',
+            additional_request_fields=extra,
+        )
+
+        expected_payload = json.dumps(extra).encode('utf-8')
+        ds.session.post.assert_called_once_with(
+            'https://example.com',
+            data=expected_payload,
+            headers={
+                'Content-Type': 'application/json',
+                'Content-Length': str(len(expected_payload)),
+            },
+            timeout=10.,
+        )
+        assert result is mock_resp
+
+    @staticmethod
+    async def test_body_and_additional_fields_merged(mocker):
+        """additional_request_fields wins on key collision."""
+        ds = Datastore(project='test-project')
+        mocker.patch.object(ds, 'headers', return_value={})
+        mock_resp = AsyncMock()
+        ds.session = MagicMock()
+        ds.session.post = AsyncMock(return_value=mock_resp)
+        body = {'a': 1, 'b': 2}
+        extra = {'b': 99, 'c': 3}
+
+        await ds._post(
+            'https://example.com', body,
+            additional_request_fields=extra,
+        )
+
+        expected_payload = json.dumps(
+            {'a': 1, 'b': 99, 'c': 3}).encode('utf-8')
+        ds.session.post.assert_called_once_with(
+            'https://example.com',
+            data=expected_payload,
+            headers={
+                'Content-Type': 'application/json',
+                'Content-Length': str(len(expected_payload)),
+            },
+            timeout=10.,
+        )
+
+    @staticmethod
+    async def test_no_session_uses_self_session(mocker):
+        ds = Datastore(project='test-project')
+        mocker.patch.object(ds, 'headers', return_value={})
+        mock_session = MagicMock()
+        mock_session.post = AsyncMock()
+        ds.session = mock_session
+
+        await ds._post('https://example.com', {'x': 1})
+
+        mock_session.post.assert_called_once()
+
+    @staticmethod
+    async def test_provided_session_is_wrapped_in_aio_session(mocker):
+        ds = Datastore(project='test-project')
+        mocker.patch.object(ds, 'headers', return_value={})
+        raw_session = MagicMock()
+        mock_wrapped = MagicMock()
+        mock_wrapped.post = AsyncMock()
+
+        with patch(
+            'gcloud.aio.datastore.datastore.AioSession',
+            return_value=mock_wrapped,
+        ) as mock_aio_cls:
+            await ds._post(
+                'https://example.com', {'x': 1},
+                session=raw_session,
+            )
+
+        mock_aio_cls.assert_called_once_with(raw_session)
+        mock_wrapped.post.assert_called_once()


### PR DESCRIPTION
## Summary

Allow additional request fields to be passed through each supported method of the `Datastore` class to the underlying API call. This should enable support for current fields we do not currently explicitly support (e.g., `propertyMask` of the [runQuery](https://docs.cloud.google.com/datastore/docs/reference/data/rest/v1/projects/runQuery?rep_location=global) endpoint method) as well as new fields introduced or not exposed in the public API.

Supersedes #1074.
