### PR TITLE
chore(release): bump datastore minor

### DIFF
--- a/datastore/pyproject.rest.toml
+++ b/datastore/pyproject.rest.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcloud-rest-datastore"
-version = "9.1.0"
+version = "9.2.0"
 description = "Python Client for Google Cloud Datastore"
 readme = "README.rst"
 

--- a/datastore/pyproject.toml
+++ b/datastore/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcloud-aio-datastore"
-version = "9.1.0"
+version = "9.2.0"
 description = "Python Client for Google Cloud Datastore"
 readme = "README.rst"
 


### PR DESCRIPTION
## gcloud-{aio|rest}-datastore 9.2.0

- **New:** All request methods (`lookup`, `runQuery`, `allocateIds`,
  `reserveIds`, `beginTransaction`, `commit`, `rollback`) now accept an
  `additional_request_fields` keyword argument. Pass a dict of extra
  fields to merge into the request body — useful for accessing API
  features not yet natively supported by the library.

- **New:** `Datastore` accepts a new `api_is_dev` keyword
  argument (`bool | None`, default `None`). Use this to explicitly
  control emulator/dev mode when providing a custom `api_root`, rather
  than relying solely on the `DATASTORE_EMULATOR_HOST` environment
  variable.

- **Dropped:** Python 3.9 is no longer supported. Minimum supported
  version is Python 3.10.
