### PR TITLE
fix: keep api_is_dev optional

### DIFF
--- a/bigquery/gcloud/aio/bigquery/bigquery.py
+++ b/bigquery/gcloud/aio/bigquery/bigquery.py
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 
 
 def init_api_root(
-        api_root: str | None, api_is_dev: bool | None,
+        api_root: str | None, api_is_dev: bool | None = None,
 ) -> tuple[bool, str]:
     if api_root:
         return api_is_dev is None or api_is_dev, api_root

--- a/datastore/gcloud/aio/datastore/datastore.py
+++ b/datastore/gcloud/aio/datastore/datastore.py
@@ -42,7 +42,7 @@ LookUpResult = dict[str, str | list[EntityResult | Key]]
 
 
 def init_api_root(
-        api_root: str | None, api_is_dev: bool | None,
+        api_root: str | None, api_is_dev: bool | None = None,
 ) -> tuple[bool, str]:
     if api_root:
         return api_is_dev is None or api_is_dev, api_root

--- a/kms/gcloud/aio/kms/kms.py
+++ b/kms/gcloud/aio/kms/kms.py
@@ -24,7 +24,7 @@ SCOPES = [
 
 
 def init_api_root(
-        api_root: str | None, api_is_dev: bool | None,
+        api_root: str | None, api_is_dev: bool | None = None,
 ) -> tuple[bool, str]:
     if api_root:
         return api_is_dev is None or api_is_dev, api_root

--- a/pubsub/gcloud/aio/pubsub/publisher_client.py
+++ b/pubsub/gcloud/aio/pubsub/publisher_client.py
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 
 
 def init_api_root(
-        api_root: str | None, api_is_dev: bool | None,
+        api_root: str | None, api_is_dev: bool | None = None,
 ) -> tuple[bool, str]:
     if api_root:
         return api_is_dev is None or api_is_dev, api_root

--- a/pubsub/gcloud/aio/pubsub/subscriber_client.py
+++ b/pubsub/gcloud/aio/pubsub/subscriber_client.py
@@ -22,7 +22,7 @@ SCOPES = [
 
 
 def init_api_root(
-        api_root: str | None, api_is_dev: bool | None,
+        api_root: str | None, api_is_dev: bool | None = None,
 ) -> tuple[bool, str]:
     if api_root:
         return api_is_dev is None or api_is_dev, api_root

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -43,7 +43,7 @@ log = logging.getLogger(__name__)
 
 
 def init_api_root(
-        api_root: str | None, api_is_dev: bool | None,
+        api_root: str | None, api_is_dev: bool | None = None,
 ) -> tuple[bool, str]:
     if api_root:
         return api_is_dev is None or api_is_dev, api_root

--- a/taskqueue/gcloud/aio/taskqueue/queue.py
+++ b/taskqueue/gcloud/aio/taskqueue/queue.py
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 
 
 def init_api_root(
-        api_root: str | None, api_is_dev: bool | None,
+        api_root: str | None, api_is_dev: bool | None = None,
 ) -> tuple[bool, str]:
     if api_root:
         return api_is_dev is None or api_is_dev, api_root


### PR DESCRIPTION
## Summary

Some users currently make use of `init_api_root`, so extend #811 to
maintain backwards compatibility.
