### PR TITLE
chore(release): bump datastore patch

### DIFF
--- a/datastore/pyproject.rest.toml
+++ b/datastore/pyproject.rest.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcloud-rest-datastore"
-version = "9.2.0"
+version = "9.2.1"
 description = "Python Client for Google Cloud Datastore"
 readme = "README.rst"
 

--- a/datastore/pyproject.toml
+++ b/datastore/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcloud-aio-datastore"
-version = "9.2.0"
+version = "9.2.1"
 description = "Python Client for Google Cloud Datastore"
 readme = "README.rst"
 


### PR DESCRIPTION
## Summary

Pulls in #1080 which patches a breaking change to `init_api_root` introduced in
gcloud-rest-datastore==9.2.0 and gcloud-aio-datastore==9.2.0, where a new
mandatory argument was added in #811.

Only users explicitly calling `init_api_root` were affected and would have seen
the following error:

```
TypeError: init_api_root() missing 1 required positional argument: 'api_is_dev'
```

This argument is now optional to maintain backwards compatibility.
