### PR TITLE
fix(auth): two external_account scope-handling bugs

### DIFF
--- a/auth/gcloud/aio/auth/token.py
+++ b/auth/gcloud/aio/auth/token.py
@@ -418,7 +418,7 @@ class Token(BaseToken):
             data['client_secret'] = self.service_data['client_secret']
         # add scopes if configured
         if self.scopes:
-            data['scope'] = ' '.join(self.scopes)
+            data['scope'] = self.scopes
 
         resp = await self.session.post(
             self.service_data['token_url'],

--- a/auth/gcloud/aio/auth/token.py
+++ b/auth/gcloud/aio/auth/token.py
@@ -406,18 +406,19 @@ class Token(BaseToken):
             'subject_token': subject_token,
             'subject_token_type': self.service_data['subject_token_type'],
         }
-        # add optional service account impersonation if configured
-        if self.service_data.get('service_account_impersonation_url'):
-            data['service_account_impersonation_url'] = self.service_data[
-                'service_account_impersonation_url'
-            ]
         # add optional client ID and secret if configured
         if self.service_data.get('client_id'):
             data['client_id'] = self.service_data['client_id']
         if self.service_data.get('client_secret'):
             data['client_secret'] = self.service_data['client_secret']
         # add scopes if configured
-        if self.scopes:
+        if self.impersonation_uri:
+            # The STS token becomes the bearer for the downstream
+            # generateAccessToken call, which requires an IAM scope, not the
+            # caller's app scope. _impersonate applies the caller's scopes to
+            # the final token.
+            data['scope'] = 'https://www.googleapis.com/auth/iam'
+        elif self.scopes:
             data['scope'] = self.scopes
 
         resp = await self.session.post(


### PR DESCRIPTION
Fixes #1090.

Two bugs in `Token._refresh_external_account` (external_account / Workload Identity Federation support), each in its own commit.

## Bug 1 — scope re-joined character-by-character
`Token.__init__` stores `self.scopes` as a space-joined string, but `_refresh_external_account` did `' '.join(self.scopes)`, which iterates the string character-by-character and produces an invalid scope. STS rejects it with 400 `invalid_scope`. Fixed by sending `self.scopes` as-is, matching every other `_refresh_*` method.

## Bug 2 — wrong scope at the STS step when impersonating
When impersonation is configured, the STS token becomes the bearer for the downstream `iamcredentials.googleapis.com:generateAccessToken` call (done by `_impersonate`), which requires an IAM scope rather than the caller's app scope — otherwise `403 ACCESS_TOKEN_SCOPE_INSUFFICIENT`. Now requests `https://www.googleapis.com/auth/iam` at the STS step when `self.impersonation_uri` is set; `_impersonate` still applies the caller's app scopes to the final token. This matches google-auth's `impersonated_credentials` behaviour (`iam._IAM_SCOPE`).

Also drops the `service_account_impersonation_url` field from the STS request body: verified against google-auth's `oauth2/sts.py` that the STS endpoint does not read this parameter (impersonation is handled separately by `_impersonate`).

## Testing
- `pre-commit run -a` passes (mypy `--strict`, pylint, flake8, etc.).
- `tests/unit/token_test.py` passes.