### PR TITLE
fix(auth): fall back to metadata service when CLOUDSDK_CONFIG points at a directory without the well-known ADC file

### DIFF
--- a/auth/gcloud/aio/auth/token.py
+++ b/auth/gcloud/aio/auth/token.py
@@ -124,7 +124,13 @@ def get_service_data(
                 )
 
         service = os.path.join(sdkpath, 'application_default_credentials.json')
-        set_explicitly = bool(cloudsdk_config)
+        # CLOUDSDK_CONFIG only relocates gcloud CLI's config directory; it is
+        # not an ADC directive. Match google-auth's
+        # _get_gcloud_sdk_credentials(), which silently returns None when the
+        # well-known file is absent so ADC falls through to the GCE metadata
+        # service. Only GOOGLE_APPLICATION_CREDENTIALS (handled above) counts
+        # as explicit user intent.
+        set_explicitly = False
     else:
         set_explicitly = True
 

--- a/auth/tests/unit/token_test.py
+++ b/auth/tests/unit/token_test.py
@@ -2,6 +2,7 @@
 import asyncio
 import io
 import json
+import os
 from unittest import mock
 
 import pytest
@@ -220,3 +221,33 @@ else:
                 ValueError, match='unsupported credential_source type',
         ):
             await t._get_subject_token(invalid_source, timeout=10)
+
+
+def test_get_service_data_cloudsdk_config_missing_wellknown_returns_empty(
+        tmp_path, monkeypatch,
+):
+    """CLOUDSDK_CONFIG only relocates gcloud CLI's config directory; a missing
+    well-known ADC file at that path must not hard-fail. get_service_data must
+    silently return {} so Token can fall back to the GCE metadata service —
+    matching google-auth's _get_gcloud_sdk_credentials() behaviour.
+    """
+    monkeypatch.delenv('GOOGLE_APPLICATION_CREDENTIALS', raising=False)
+    monkeypatch.setenv('CLOUDSDK_CONFIG', str(tmp_path))
+    assert not os.path.exists(
+        os.path.join(str(tmp_path), 'application_default_credentials.json'),
+    )
+    assert token.get_service_data(None) == {}
+
+
+def test_get_service_data_google_application_credentials_missing_raises(
+        tmp_path, monkeypatch,
+):
+    """GOOGLE_APPLICATION_CREDENTIALS is an explicit user directive to use a
+    specific credentials file. A missing file at that path must still raise —
+    this is the "explicit intent" branch and its behaviour is unchanged.
+    """
+    missing = str(tmp_path / 'does-not-exist.json')
+    monkeypatch.delenv('CLOUDSDK_CONFIG', raising=False)
+    monkeypatch.setenv('GOOGLE_APPLICATION_CREDENTIALS', missing)
+    with pytest.raises(FileNotFoundError):
+        token.get_service_data(None)


### PR DESCRIPTION
Fixes #936.

## Problem

When `CLOUDSDK_CONFIG` is set in the environment (a common workaround for `readOnlyRootFilesystem` containers that need a writable `gcloud` CLI config directory), and the file at `$CLOUDSDK_CONFIG/application_default_credentials.json` does not exist, `get_service_data()` raises `FileNotFoundError` instead of returning `{}`. That prevents `Token` from falling back to the GCE metadata service, which breaks Workload Identity–only authentication for any async workload whose base image happens to export `CLOUDSDK_CONFIG`.

The docstring on `get_service_data()` states the function is meant to match `google.auth.default()`. In google-auth, `_get_gcloud_sdk_credentials()` guards the well-known file with `os.path.isfile()` and silently returns `None` when it is missing, regardless of `CLOUDSDK_CONFIG`. Only `GOOGLE_APPLICATION_CREDENTIALS` is treated as explicit user intent.

## Fix

In the well-known-file branch, `set_explicitly` is now always `False` (previously `bool(cloudsdk_config)`). The `GOOGLE_APPLICATION_CREDENTIALS` branch is unchanged; a missing file at that path still raises.

## Testing

- Reproduced the failure end-to-end with a deferrable `GCSObjects*` sensor on a Kubernetes environment where the triggerer pod exported `CLOUDSDK_CONFIG=/tmp/gcloud` with no file at that path — trigger yielded `FileNotFoundError` instead of falling back to WI. With this patch applied the trigger polls cleanly through the metadata service and the sensor completes normally.
- Two new unit tests in ` auth/tests/unit/token_test.py`. All existing and new tests pass locally.