### PR TITLE
fix(storage): calculate UTF-8 upload length in bytes

### DIFF
--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -431,9 +431,9 @@ class Storage:
             # load the whole file into memory at once.
             stream = self._compress_file_in_chunks(input_stream=stream)
 
-        if BUILD_GCLOUD_REST and isinstance(stream, io.StringIO):
-            # HACK: `requests` library does not accept `str` as `data` in `put`
-            # HTTP request.
+        if isinstance(stream, io.StringIO):
+            # HTTP requests send encoded bytes, so normalize in-memory text
+            # streams before calculating Content-Length.
             stream = io.BytesIO(stream.getvalue().encode('utf-8'))
 
         content_length = self._get_stream_len(stream)

--- a/storage/gcloud/aio/storage/storage.py
+++ b/storage/gcloud/aio/storage/storage.py
@@ -434,7 +434,7 @@ class Storage:
         if isinstance(stream, io.StringIO):
             # HTTP requests send encoded bytes, so normalize in-memory text
             # streams before calculating Content-Length.
-            stream = io.BytesIO(stream.getvalue().encode('utf-8'))
+            stream = io.BytesIO(stream.read().encode('utf-8'))
 
         content_length = self._get_stream_len(stream)
 

--- a/storage/tests/unit/upload_retry_test.py
+++ b/storage/tests/unit/upload_retry_test.py
@@ -29,7 +29,12 @@ class FakeHttpServerHandler(BaseHTTPRequestHandler):
     def _read_and_write_data(self):
         content_len = int(self.headers.get('Content-Length'))
         data = self.rfile.read(content_len)
-        payload = {'data': data.decode('utf-8')}
+        payload = {
+            'data': data.decode('utf-8'),
+            'upload_type': (
+                'resumable' if 'Content-Range' in self.headers else 'simple'
+            ),
+        }
         json_payload = json.dumps(payload).encode('utf-8')
         self.wfile.write(json_payload)
 
@@ -99,6 +104,10 @@ async def test_upload_retry(fake_server):  # pylint: disable=redefined-outer-nam
             {'force_resumable_upload': True},
             id='resumable',
         ),
+        pytest.param(
+            {'force_resumable_upload': None},
+            id='automatic',
+        ),
     ],
 )
 @pytest.mark.parametrize('as_stream', [False, True])
@@ -106,8 +115,14 @@ async def test_upload_utf8_content_length(
     fake_server,  # pylint: disable=redefined-outer-name
     upload_options,
     as_stream,
+    monkeypatch,
 ):
     text = '中文abcdefgh'
+    # Keep the test payload small while exercising byte-based type selection.
+    monkeypatch.setattr(
+        aio_storage,
+        'MAX_CONTENT_LENGTH_SIMPLE_UPLOAD',
+        len(text))
     file_data = io.StringIO(text) if as_stream else text
 
     async with Session() as session:
@@ -121,3 +136,28 @@ async def test_upload_utf8_content_length(
         )
 
     assert response['data'] == text
+    if upload_options['force_resumable_upload'] is None:
+        assert response['upload_type'] == 'resumable'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('read_chars', [1, 10])
+async def test_upload_utf8_stream_position(
+    fake_server,  # pylint: disable=redefined-outer-name
+    read_chars,
+):
+    text = '中文abcdefgh'
+    file_data = io.StringIO(text)
+    file_data.read(read_chars)
+
+    async with Session() as session:
+        storage = aio_storage.Storage(session=session, api_root=fake_server)
+
+        response = await storage.upload(
+            'bucket',
+            'object',
+            file_data=file_data,
+            force_resumable_upload=False,
+        )
+
+    assert response['data'] == text[read_chars:]

--- a/storage/tests/unit/upload_retry_test.py
+++ b/storage/tests/unit/upload_retry_test.py
@@ -85,3 +85,39 @@ async def test_upload_retry(fake_server):  # pylint: disable=redefined-outer-nam
         )
 
     assert response.get('data') == 'test data'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'upload_options',
+    [
+        pytest.param(
+            {'force_resumable_upload': False},
+            id='simple',
+        ),
+        pytest.param(
+            {'force_resumable_upload': True},
+            id='resumable',
+        ),
+    ],
+)
+@pytest.mark.parametrize('as_stream', [False, True])
+async def test_upload_utf8_content_length(
+    fake_server,  # pylint: disable=redefined-outer-name
+    upload_options,
+    as_stream,
+):
+    text = '中文abcdefgh'
+    file_data = io.StringIO(text) if as_stream else text
+
+    async with Session() as session:
+        storage = aio_storage.Storage(session=session, api_root=fake_server)
+
+        response = await storage.upload(
+            'bucket',
+            'object',
+            file_data=file_data,
+            **upload_options,
+        )
+
+    assert response['data'] == text


### PR DESCRIPTION
## What does this PR do?

Normalize `io.StringIO` upload data to UTF-8 encoded bytes before calculating
`Content-Length`.

This keeps the declared length, transmitted body, and upload method selection
consistent for text uploads.

## Why?

When `Storage.upload()` receives a `str` or `io.StringIO` containing non-ASCII
text, `_get_stream_len()` counts characters while the HTTP client sends UTF-8
bytes. Simple and resumable uploads can therefore send a shorter body and
silently truncate data.

The same mismatch can also cause UTF-8 content larger than 5 MiB in bytes to
be incorrectly selected for simple upload.

Fixes #469.

## How was this tested?

- AIO storage unit tests
- Generated REST storage unit tests
- Regression coverage for `str` and `io.StringIO` through simple and resumable uploads
- Project pre-commit hooks, including pylint, mypy, and flake8
